### PR TITLE
save times in the db in a unified format

### DIFF
--- a/backend/pkg/rest/convert/resttodb/convert.go
+++ b/backend/pkg/rest/convert/resttodb/convert.go
@@ -18,6 +18,7 @@ package resttodb
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	uuid "github.com/satori/go.uuid"
 
@@ -187,9 +188,9 @@ func ConvertScan(scan *models.Scan, id string) (*database.Scan, error) {
 
 	ret.ScanConfigID = scan.ScanConfigId
 
-	ret.ScanEndTime = scan.EndTime
-
-	ret.ScanStartTime = scan.StartTime
+	// convert times to rfc3339 format in order to keep a unified format in the db
+	ret.ScanEndTime = convertTimeToRFC3339(scan.EndTime)
+	ret.ScanStartTime = convertTimeToRFC3339(scan.StartTime)
 
 	if scan.ScanFamiliesConfig != nil {
 		ret.ScanFamiliesConfig, err = json.Marshal(scan.ScanFamiliesConfig)
@@ -208,4 +209,16 @@ func ConvertScan(scan *models.Scan, id string) (*database.Scan, error) {
 	ret.Base = database.Base{ID: scanUUID}
 
 	return &ret, nil
+}
+
+func convertTimeToRFC3339(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+
+	str := t.Format(time.RFC3339)
+	// ignore the error since str is converted from a valid time.
+	converted, _ := time.Parse(time.RFC3339, str)
+
+	return &converted
 }

--- a/runtime_scan/pkg/orchestrator/configwatcher/scan_runner.go
+++ b/runtime_scan/pkg/orchestrator/configwatcher/scan_runner.go
@@ -65,7 +65,7 @@ func (scw *ScanConfigWatcher) initNewScan(ctx context.Context, scanConfig *model
 		return nil, "", fmt.Errorf("failed to get or create targets: %v", err)
 	}
 
-	now := time.Now().UTC()
+	now := time.Now()
 	scan := &models.Scan{
 		ScanConfigId:       scanConfig.Id,
 		ScanFamiliesConfig: scanConfig.ScanFamiliesConfig,


### PR DESCRIPTION
For visibility purposes, we need to save times in a unified format (RFC3339), so the times will always be presented in a similar format across the system.