### PR TITLE
fix crush during patch

### DIFF
--- a/backend/pkg/rest/convert/resttodb/convert.go
+++ b/backend/pkg/rest/convert/resttodb/convert.go
@@ -185,7 +185,9 @@ func ConvertScan(scan *models.Scan, id string) (*database.Scan, error) {
 		}
 	}
 
-	ret.ScanConfigID = &scan.ScanConfig.Id
+	if scan.ScanConfig != nil {
+		ret.ScanConfigID = &scan.ScanConfig.Id
+	}
 
 	ret.ScanEndTime = scan.EndTime
 


### PR DESCRIPTION
Following PR https://github.com/openclarity/vmclarity/pull/92, a regression was introduced:
When calling patch scan with no scanConfig data, we crash.

This PR fixes this.