### PR TITLE
fix an issue with verifying families errors map

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -117,7 +117,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		if famerr != nil {
+		if len(famerr) > 0 {
 			return fmt.Errorf("failed to run families: %+v", famerr)
 		}
 


### PR DESCRIPTION
## Description

`famerr` is a map of familiyType --> error, the `nil` check was wrong causing a successful run to print the following error 
```
Error: failed to run families: map[]
```
The PR fixes it by checking the length of the map.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  
