### PR TITLE
Add WaitFor to utils package

### DIFF
--- a/shared/pkg/utils/waitfor.go
+++ b/shared/pkg/utils/waitfor.go
@@ -1,0 +1,97 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+var ErrWaitForInValidParameters = errors.New("condition will never get evaluated as timeout < interval")
+
+// ConditionFunc is a function which returns ok indicating whether the condition is met or not.
+// It also returns a non-nil error if the error occurs during evaluating the condition.
+type ConditionFunc func(ctx context.Context) (bool, error)
+
+// WaitFor takes f function and periodically runs with interval until:
+//   - f returns true or error
+//   - parent ctx is cancelled
+//   - timeout is reached
+//
+// Setting timeout to <= 0 means that f condition will be continuously evaluated until f returns true or an error.
+// Providing timeout and interval parameters returns ErrWaitForInValidParameters error if timeout > 0 and interval > timeout.
+//
+// Wait for condition with timeout:
+//
+//	f := func(ctx context.Context) (bool, error) {
+//		expected := 5
+//		actual := rand.Intn(10)
+//		if actual == expected {
+//			return true, nil
+//		}
+//		return false, nil
+//	}
+//	err := utils.WaitFor(ctx, f, time.Minute, 10 * time.Second)
+//	if err != nil {
+//		panic(err)
+//	}
+//
+// Wait for condition without timeout:
+//
+//	err := utils.WaitFor(ctx, f, 0, 10 * time.Second)
+//	if err != nil {
+//		panic(err)
+//	}
+func WaitFor(ctx context.Context, f ConditionFunc, timeout time.Duration, interval time.Duration) error {
+	var cancelFn context.CancelFunc
+
+	if timeout > 0 && timeout < interval {
+		return ErrWaitForInValidParameters
+	}
+
+	if timeout <= 0 {
+		ctx, cancelFn = context.WithCancel(ctx)
+	} else {
+		ctx, cancelFn = context.WithTimeout(ctx, timeout)
+	}
+	defer cancelFn()
+
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-timer.C:
+			{
+				cond, err := f(ctx)
+				if err != nil {
+					return fmt.Errorf("condition failed: %w", err)
+				}
+				if cond {
+					return nil
+				}
+				timer.Reset(interval)
+			}
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return fmt.Errorf("waiting for condition was cancelled: %w", ctx.Err())
+		}
+	}
+}

--- a/shared/pkg/utils/waitfor_test.go
+++ b/shared/pkg/utils/waitfor_test.go
@@ -1,0 +1,129 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+type State struct {
+	iterations int
+}
+
+func conditionFailing() ConditionFunc {
+	return func(_ context.Context) (bool, error) {
+		return false, errors.New("condition failed")
+	}
+}
+
+func conditionNeverMet() ConditionFunc {
+	return func(_ context.Context) (bool, error) {
+		return false, nil
+	}
+}
+
+func conditionMetAfter(s *State, iteration int) ConditionFunc {
+	return func(_ context.Context) (bool, error) {
+		if s.iterations == iteration {
+			return true, nil
+		}
+		s.iterations++
+		return false, nil
+	}
+}
+
+func TestWaitFor(t *testing.T) {
+	t.Run("returns an error when context deadline is exceeded", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := WaitFor(ctx, conditionNeverMet(), 10*time.Second, 2*time.Second)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("returns an error when parent context deadline is exceeded", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		err := WaitFor(ctx, conditionNeverMet(), 10*time.Second, 2*time.Second)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+
+	t.Run("returns an error when parent context is cancelled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(5 * time.Second)
+			defer cancel()
+		}()
+
+		err := WaitFor(ctx, conditionNeverMet(), 10*time.Second, 2*time.Second)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("succeeds with timeout set", func(t *testing.T) {
+		s := &State{0}
+		expectedIteration := 2
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := WaitFor(ctx, conditionMetAfter(s, expectedIteration), 10*time.Second, 2*time.Second)
+		assert.NilError(t, err)
+		assert.Assert(t, s.iterations == expectedIteration)
+	})
+
+	t.Run("succeeds without timeout set", func(t *testing.T) {
+		s := &State{0}
+		expectedIteration := 2
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := WaitFor(ctx, conditionMetAfter(s, expectedIteration), 0, 2*time.Second)
+		assert.NilError(t, err)
+		assert.Assert(t, s.iterations == expectedIteration)
+	})
+
+	t.Run("succeeds with timeout set in parent context", func(t *testing.T) {
+		s := &State{0}
+		expectedIteration := 2
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+
+		err := WaitFor(ctx, conditionMetAfter(s, expectedIteration), 10*time.Second, 2*time.Second)
+		assert.NilError(t, err)
+		assert.Assert(t, s.iterations == expectedIteration)
+	})
+
+	t.Run("returns error if evaluating condition returns error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := WaitFor(ctx, conditionFailing(), 10*time.Second, 2*time.Second)
+		assert.ErrorContains(t, err, "condition failed")
+	})
+
+	t.Run("returns validation error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := WaitFor(ctx, conditionNeverMet(), 2*time.Second, 10*time.Second)
+		assert.ErrorIs(t, err, ErrWaitForInValidParameters)
+	})
+}


### PR DESCRIPTION
## Description

Add `WaitFor` helper function which allows to wait until the provided condition is met or timeout expires.

It does not rely on `time.After` due to memory leak described [here](https://www.arangodb.com/2020/09/a-story-of-a-memory-leak-in-go-how-to-properly-use-time-after/).

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
