### PR TITLE
set disabled to true for a non periodic scan once started

### DIFF
--- a/runtime_scan/pkg/orchestrator/configwatcher/scanconfig_watcher.go
+++ b/runtime_scan/pkg/orchestrator/configwatcher/scanconfig_watcher.go
@@ -106,7 +106,7 @@ func (scw *ScanConfigWatcher) reconcileScanConfigs(ctx context.Context) error {
 					log.Debugf("Patching ScanConfig %s with a new operation time (%s)", scanConfigID, nextOperationTime.String())
 				} else {
 					// not a periodic scan, we should disable the scan config, so it will not be fetched again.
-					scanConfig.Disabled = utils.PointerTo(false)
+					scanConfig.Disabled = utils.PointerTo(true)
 					log.Debugf("Patching ScanConfig %s with disabled (%v)", scanConfigID, *scanConfig.Disabled)
 				}
 				if err = scw.backendClient.PatchScanConfig(ctx, scanConfigID, &scanConfig); err != nil {


### PR DESCRIPTION
## Description

Fix a bug where disabled was set to `false` and not `true` once a non periodic scan started.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
