### PR TITLE
Add support for stopping Scans to Orchestrator

### DIFF
--- a/api/models/helpers.go
+++ b/api/models/helpers.go
@@ -21,6 +21,7 @@ func (s *TargetScanState) GetState() (TargetScanStateState, bool) {
 
 	if s.State != nil {
 		state = *s.State
+		ok = true
 	}
 	return state, ok
 }
@@ -42,6 +43,18 @@ func (r *TargetScanResult) GetGeneralState() (TargetScanStateState, bool) {
 
 	if r.Status != nil {
 		state, ok = r.Status.GetGeneralState()
+	}
+
+	return state, ok
+}
+
+func (s *Scan) GetState() (ScanState, bool) {
+	var state ScanState
+	var ok bool
+
+	if s.State != nil {
+		state = *s.State
+		ok = true
 	}
 
 	return state, ok

--- a/api/models/helpers.go
+++ b/api/models/helpers.go
@@ -1,0 +1,48 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+func (s *TargetScanState) GetState() (TargetScanStateState, bool) {
+	var state TargetScanStateState
+	var ok bool
+
+	if s.State != nil {
+		state = *s.State
+	}
+	return state, ok
+}
+
+func (s *TargetScanStatus) GetGeneralState() (TargetScanStateState, bool) {
+	var state TargetScanStateState
+	var ok bool
+
+	if s.General != nil {
+		state, ok = s.General.GetState()
+	}
+
+	return state, ok
+}
+
+func (r *TargetScanResult) GetGeneralState() (TargetScanStateState, bool) {
+	var state TargetScanStateState
+	var ok bool
+
+	if r.Status != nil {
+		state, ok = r.Status.GetGeneralState()
+	}
+
+	return state, ok
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -96,7 +96,6 @@ var rootCmd = &cobra.Command{
 			mountPoints, err := cli.MountVolumes(abortCtx)
 			if err != nil {
 				err = fmt.Errorf("failed to mount attached volume: %w", err)
-				logger.Error(err)
 				if e := cli.MarkDone(ctx, []error{err}); e != nil {
 					logger.Error(fmt.Errorf("failed to update scan result stat to completed with errors: %w", e))
 				}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -81,7 +81,6 @@ var rootCmd = &cobra.Command{
 		if waitForServerAttached {
 			if err := cli.WaitForVolumeAttachment(ctx); err != nil {
 				err = fmt.Errorf("failed to wait for block device being attached: %w", err)
-				logger.Error(err)
 				if e := cli.MarkDone(ctx, []error{err}); e != nil {
 					logger.Error(fmt.Errorf("failed to update scan result stat to completed with errors: %w", e))
 				}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -86,7 +86,7 @@ var rootCmd = &cobra.Command{
 			if err := cli.WaitForVolumeAttachment(abortCtx); err != nil {
 				err = fmt.Errorf("failed to wait for block device being attached: %w", err)
 				if e := cli.MarkDone(ctx, []error{err}); e != nil {
-					logger.Error(fmt.Errorf("failed to update scan result stat to completed with errors: %w", e))
+					logger.Errorf("Failed to update scan result stat to completed with errors: %v", e)
 				}
 				return err
 			}
@@ -97,7 +97,7 @@ var rootCmd = &cobra.Command{
 			if err != nil {
 				err = fmt.Errorf("failed to mount attached volume: %w", err)
 				if e := cli.MarkDone(ctx, []error{err}); e != nil {
-					logger.Error(fmt.Errorf("failed to update scan result stat to completed with errors: %w", e))
+					logger.Errorf("Failed to update scan result stat to completed with errors: %v", e)
 				}
 				return err
 			}

--- a/cli/pkg/cli/cli.go
+++ b/cli/pkg/cli/cli.go
@@ -130,7 +130,7 @@ func (c *CLI) ExportResults(ctx context.Context, res *results.Results, errs fami
 
 func (c *CLI) WatchForAbort(ctx context.Context, cancel context.CancelFunc, interval time.Duration) {
 	go func() {
-		timer := time.NewTimer(interval)
+		timer := time.NewTicker(interval)
 		defer timer.Stop()
 
 		for {
@@ -144,11 +144,7 @@ func (c *CLI) WatchForAbort(ctx context.Context, cancel context.CancelFunc, inte
 					cancel()
 					return
 				}
-				timer.Reset(interval)
 			case <-ctx.Done():
-				if !timer.Stop() {
-					<-timer.C
-				}
 				log.Debugf("Stop watching for abort event as context is cancelled")
 				return
 			}

--- a/cli/pkg/cli/cli.go
+++ b/cli/pkg/cli/cli.go
@@ -59,7 +59,7 @@ func (c *CLI) MountVolumes(ctx context.Context) ([]string, error) {
 			if err := device.Mount(mountDir); err != nil {
 				return nil, fmt.Errorf("failed to mount device: %v", err)
 			}
-			log.Infof("device %v on %v is mounted", device.DeviceName, mountDir)
+			log.Infof("Device %v on %v is mounted", device.DeviceName, mountDir)
 			mountPoints = append(mountPoints, mountDir)
 		}
 		if ctx.Err() != nil {
@@ -138,7 +138,7 @@ func (c *CLI) WatchForAbort(ctx context.Context, cancel context.CancelFunc, inte
 			case <-timer.C:
 				aborted, err := c.IsAborted(ctx)
 				if err != nil {
-					log.Errorf("failed to retrieve scan result state: %v", err)
+					log.Errorf("Failed to retrieve scan result state: %v", err)
 				}
 				if aborted {
 					cancel()
@@ -149,7 +149,7 @@ func (c *CLI) WatchForAbort(ctx context.Context, cancel context.CancelFunc, inte
 				if !timer.Stop() {
 					<-timer.C
 				}
-				log.Debugf("stop watching for abort evetn as context is cancelled")
+				log.Debugf("Stop watching for abort event as context is cancelled")
 				return
 			}
 		}

--- a/cli/pkg/state/local.go
+++ b/cli/pkg/state/local.go
@@ -35,6 +35,7 @@ func (l *LocalState) MarkInProgress(context.Context) error {
 func (l *LocalState) MarkDone(_ context.Context, errs []error) error {
 	if len(errs) > 0 {
 		log.Errorf("scan has been completed with errors: %v", errs)
+		return nil
 	}
 	log.Info("scan has been completed")
 	return nil

--- a/cli/pkg/state/local.go
+++ b/cli/pkg/state/local.go
@@ -32,8 +32,11 @@ func (l *LocalState) MarkInProgress(context.Context) error {
 	return nil
 }
 
-func (l *LocalState) MarkDone(context.Context, []error) error {
-	log.Info("scanning is finished")
+func (l *LocalState) MarkDone(_ context.Context, errs []error) error {
+	if len(errs) > 0 {
+		log.Errorf("scan has been completed with errors: %v", errs)
+	}
+	log.Info("scan has been completed")
 	return nil
 }
 

--- a/cli/pkg/state/local.go
+++ b/cli/pkg/state/local.go
@@ -37,6 +37,10 @@ func (l *LocalState) MarkDone(context.Context, []error) error {
 	return nil
 }
 
+func (l *LocalState) IsAborted(context.Context) (bool, error) {
+	return false, nil
+}
+
 func NewLocalState() (*LocalState, error) {
 	return &LocalState{}, nil
 }

--- a/cli/pkg/state/local.go
+++ b/cli/pkg/state/local.go
@@ -28,7 +28,7 @@ func (l *LocalState) WaitForVolumeAttachment(context.Context) error {
 }
 
 func (l *LocalState) MarkInProgress(context.Context) error {
-	log.Info("scanning is in progress")
+	log.Info("Scanning is in progress")
 	return nil
 }
 
@@ -37,7 +37,7 @@ func (l *LocalState) MarkDone(_ context.Context, errs []error) error {
 		log.Errorf("scan has been completed with errors: %v", errs)
 		return nil
 	}
-	log.Info("scan has been completed")
+	log.Info("Scan has been completed")
 	return nil
 }
 

--- a/cli/pkg/state/manager.go
+++ b/cli/pkg/state/manager.go
@@ -23,4 +23,5 @@ type Manager interface {
 	WaitForVolumeAttachment(context.Context) error
 	MarkInProgress(context.Context) error
 	MarkDone(context.Context, []error) error
+	IsAborted(ctx context.Context) (bool, error)
 }

--- a/cli/pkg/state/vmclarity.go
+++ b/cli/pkg/state/vmclarity.go
@@ -137,6 +137,26 @@ func (v *VMClarityState) MarkDone(ctx context.Context, errors []error) error {
 	return nil
 }
 
+func (v VMClarityState) IsAborted(ctx context.Context) (bool, error) {
+	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{
+		Select: utils.PointerTo("id,status"),
+	})
+	if err != nil {
+		return false, fmt.Errorf("failed to get scan result: %w", err)
+	}
+
+	state, ok := scanResult.GetGeneralState()
+	if !ok {
+		return false, errors.New("failed to get general state of scan result")
+	}
+
+	if state == models.ABORTED {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 func NewVMClarityState(client *backendclient.BackendClient, id ScanResultID) (*VMClarityState, error) {
 	if client == nil {
 		return nil, errors.New("backend client must not be nil")

--- a/docs/testplans/abort-scan.md
+++ b/docs/testplans/abort-scan.md
@@ -1,0 +1,92 @@
+# Test Plan
+
+## Scan configuration
+
+Create Scan Configuration file
+
+```shell
+cat <<EOF > scanconfig.json
+{
+  "name": "test",
+  "scanFamiliesConfig": {
+     "sbom": {
+       "enabled": true
+     },
+     "vulnerabilities": {
+       "enabled": true
+     },
+     "exploits": {
+       "enabled": true
+     }
+  },
+  "scheduled": {
+    "cronLine": "0 */4 * * *",
+    "operationTime": "2023-01-20T15:46:18+00:00"
+  },
+  "scope": {
+    "allRegions": true,
+    "objectType": "AwsScanScope",
+    "instanceTagSelector": [
+      {
+        "key": "ScanConfig",
+        "value": "test"
+      }
+    ]
+  }
+}
+EOF
+```
+
+Apply Scan Configuration to API
+
+```shell
+curl -sSf -X POST 'http://localhost:8888/api/scanConfigs' -H 'Content-Type: application/json' \
+  -d @scanconfig.json \
+| jq -r -e '.id' > scanconfig.id
+```
+
+Get Scan Configuration object from API
+
+```shell
+curl -sSf -X GET 'http://localhost:8888/api/scanConfigs/'"$(cat scanconfig.id)"'' \
+| jq -r -e '.' > scanconfig.api.json
+```
+
+## Start Scan
+
+Start Scan using Scan Config
+
+```shell
+jq -r -e '{maxParallelScanners, name, scanFamiliesConfig, scheduled, scope} | .scheduled.operationTime = (now|todate)' \
+  scanconfig.api.json \
+| curl -sSf -X PUT -H 'Content-Type: application/json' 'http://localhost:8888/api/scanConfigs/'"$(cat scanconfig.id)"'' \
+  -d @-
+```
+
+**Wait until the Scan object is created on the backend/API side**
+
+Get ongoing Scan from API using ScanConfig id
+
+```shell
+curl -sSf -G 'http://localhost:8888/api/scans' \
+  --data-urlencode "\$filter=scanConfig/id eq '$(cat scanconfig.id)' and state ne 'Done' and state ne 'Failed'" \
+| jq -r -e '.items | first' > scan.api.json
+```
+
+## Abort Scan in progress
+
+```shell
+cat <<EOF > scan-aborted.json
+{
+  "state": "Aborted"
+}
+EOF
+```
+
+```shell
+jq -r -e '.id' scan.api.json > scan.id \
+&& curl -sSf -X PATCH -H 'Content-Type: application/json' \
+  "http://localhost:8888/api/scans/$(cat scan.id)" \
+  -d @scan-aborted.json \
+| jq -r -e '.' > scan-aborted.api.json
+```

--- a/runtime_scan/pkg/orchestrator/orchestrator.go
+++ b/runtime_scan/pkg/orchestrator/orchestrator.go
@@ -18,13 +18,13 @@ package orchestrator
 import (
 	"context"
 
-	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/scanwatcher"
 	log "github.com/sirupsen/logrus"
 
 	_config "github.com/openclarity/vmclarity/runtime_scan/pkg/config"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/configwatcher"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/discovery"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/scanresultprocessor"
+	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/scanwatcher"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/provider"
 	"github.com/openclarity/vmclarity/shared/pkg/backendclient"
 )

--- a/runtime_scan/pkg/orchestrator/orchestrator.go
+++ b/runtime_scan/pkg/orchestrator/orchestrator.go
@@ -18,6 +18,7 @@ package orchestrator
 import (
 	"context"
 
+	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/scanwatcher"
 	log "github.com/sirupsen/logrus"
 
 	_config "github.com/openclarity/vmclarity/runtime_scan/pkg/config"
@@ -38,6 +39,7 @@ type orchestrator struct {
 	scanConfigWatcher   *configwatcher.ScanConfigWatcher
 	scopeDiscoverer     *discovery.ScopeDiscoverer
 	scanResultProcessor *scanresultprocessor.ScanResultProcessor
+	scanWatcher         *scanwatcher.Watcher
 	cancelFunc          context.CancelFunc
 }
 
@@ -47,6 +49,11 @@ func Create(config *_config.OrchestratorConfig, providerClient provider.Client, 
 		scanConfigWatcher:   configwatcher.CreateScanConfigWatcher(backendClient, providerClient, config.ScannerConfig),
 		scopeDiscoverer:     discovery.CreateScopeDiscoverer(backendClient, providerClient),
 		scanResultProcessor: scanresultprocessor.NewScanResultProcessor(backendClient),
+		scanWatcher: scanwatcher.New(scanwatcher.Config{
+			Backend:          backendClient,
+			PollPeriod:       scanwatcher.DefaultPollInterval,
+			ReconcileTimeout: scanwatcher.DefaultReconcileTimeout,
+		}),
 	}
 
 	return orc, nil
@@ -59,6 +66,7 @@ func (o *orchestrator) Start(ctx context.Context) {
 	o.scanConfigWatcher.Start(ctx)
 	o.scopeDiscoverer.Start(ctx)
 	o.scanResultProcessor.Start(ctx)
+	o.scanWatcher.Start(ctx)
 }
 
 func (o *orchestrator) Stop(cancel context.CancelFunc) {

--- a/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
+++ b/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
@@ -105,7 +105,7 @@ func (w *Watcher) GetAbortedScans(ctx context.Context) ([]ScanReconcileEvent, er
 }
 
 func (w *Watcher) Reconcile(ctx context.Context, event ScanReconcileEvent) error {
-	w.logger.Infof("reconciling scan event: %v", event)
+	w.logger.Infof("Reconciling scan event: %v", event)
 
 	selector := "id,state,stateReason"
 	params := models.GetScansScanIDParams{
@@ -124,7 +124,7 @@ func (w *Watcher) Reconcile(ctx context.Context, event ScanReconcileEvent) error
 
 	switch state {
 	case models.ScanStateDone, models.ScanStateFailed:
-		w.logger.Infof("reconciling scan event is skipped as Scan is already finished: %v", event)
+		w.logger.Debugf("Reconciling scan event is skipped as Scan is already finished: %v", event)
 	case models.ScanStateAborted:
 		return w.reconcileAborted(ctx, event)
 	case models.ScanStatePending, models.ScanStateDiscovered, models.ScanStateInProgress:
@@ -190,7 +190,7 @@ func (w *Watcher) reconcileAborted(ctx context.Context, event ScanReconcileEvent
 
 				err := w.client.PatchScanResult(ctx, sr, id)
 				if err != nil {
-					w.logger.Errorf("failed to patch ScanResult with id: %s", id)
+					w.logger.Errorf("Failed to patch ScanResult with id: %s", id)
 					retryIsNeeded = true
 					return
 				}

--- a/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
+++ b/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
@@ -1,0 +1,194 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scanwatcher
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/openclarity/vmclarity/api/models"
+	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/common"
+	runtimeScanUtils "github.com/openclarity/vmclarity/runtime_scan/pkg/utils"
+	"github.com/openclarity/vmclarity/shared/pkg/backendclient"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	DefaultPollInterval     = time.Minute
+	DefaultReconcileTimeout = time.Minute
+)
+
+type ScanQueue = common.Queue[ScanReconcileEvent]
+type ScanPoller = common.Poller[ScanReconcileEvent]
+type ScanReconciler = common.Reconciler[ScanReconcileEvent]
+
+type ScanEventKind int8
+
+const (
+	Aborted ScanEventKind = iota
+)
+
+type ScanReconcileEvent struct {
+	Kind ScanEventKind
+	Id   string
+}
+
+type Config struct {
+	Backend          *backendclient.BackendClient
+	PollPeriod       time.Duration
+	ReconcileTimeout time.Duration
+}
+
+func New(c Config) *Watcher {
+	logger := log.WithFields(log.Fields{"controller": "ScanWatcher"})
+	return &Watcher{
+		logger,
+		c.Backend,
+		c.PollPeriod,
+		c.ReconcileTimeout,
+	}
+}
+
+type Watcher struct {
+	logger           *log.Entry
+	client           *backendclient.BackendClient
+	pollPeriod       time.Duration
+	reconcileTimeout time.Duration
+}
+
+func (w *Watcher) Start(ctx context.Context) {
+	queue := common.NewQueue[ScanReconcileEvent]()
+
+	poller := &ScanPoller{
+		Logger:     w.logger,
+		PollPeriod: w.pollPeriod,
+		Queue:      queue,
+		GetItems:   w.GetItems,
+	}
+	poller.Start(ctx)
+
+	reconciler := &ScanReconciler{
+		ReconcileTimeout:  w.reconcileTimeout,
+		Queue:             queue,
+		ReconcileFunction: w.Reconcile,
+	}
+	reconciler.Start(ctx)
+}
+
+func (w *Watcher) GetItems(ctx context.Context) ([]ScanReconcileEvent, error) {
+	scans, err := w.getScansByState(ctx, models.ScanStateAborted)
+	if err != nil || scans.Items == nil || len(*scans.Items) <= 0 {
+		return nil, err
+	}
+
+	count := len(*scans.Items)
+	r := make([]ScanReconcileEvent, count)
+	for i, scan := range *scans.Items {
+		r[i] = ScanReconcileEvent{
+			Kind: Aborted,
+			Id:   *scan.Id,
+		}
+	}
+
+	return r, nil
+}
+
+func (w *Watcher) Reconcile(ctx context.Context, s ScanReconcileEvent) error {
+	w.logger.Infof("reconciling scan event: %v", s)
+	switch {
+	case s.Kind == Aborted:
+		return w.reconcileAborted(ctx, s)
+	}
+
+	return nil
+}
+
+func (w *Watcher) getScansByState(ctx context.Context, s models.ScanState) (models.Scans, error) {
+	filter := fmt.Sprintf("state eq '%s'", s)
+	selector := "id,state,stateReason,targetIDs"
+	params := models.GetScansParams{
+		Filter: &filter,
+		Select: &selector,
+	}
+	scans, err := w.client.GetScans(ctx, params)
+	if err != nil {
+		err = fmt.Errorf("getting Scan(s) by their state failed: %v", err)
+	}
+	if scans == nil {
+		scans = &models.Scans{}
+	}
+
+	return *scans, err
+}
+
+func (w *Watcher) getScanResultsByScanID(ctx context.Context, id string) (models.TargetScanResults, error) {
+	filter := fmt.Sprintf("scan/id eq '%s'", id)
+	selector := "id,scan,status,target"
+	params := models.GetScanResultsParams{
+		Filter: &filter,
+		Select: &selector,
+	}
+
+	scanResutls, err := w.client.GetScanResults(ctx, params)
+	if err != nil {
+		err = fmt.Errorf("getting ScanResult(s) by Scan ID failed: %v", err)
+	}
+
+	return scanResutls, err
+}
+
+func (w *Watcher) reconcileAborted(ctx context.Context, s ScanReconcileEvent) error {
+	scanResults, err := w.getScanResultsByScanID(ctx, s.Id)
+	if err != nil {
+		return err
+	}
+
+	if scanResults.Items == nil || len(*scanResults.Items) <= 0 {
+		w.logger.Debug("nothing to reconcile")
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	for _, scanResult := range *scanResults.Items {
+		if scanResult.Id == nil {
+			continue
+		}
+		id := *scanResult.Id
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sr := models.TargetScanResult{
+				Status: &models.TargetScanStatus{
+					General: &models.TargetScanState{
+						State: runtimeScanUtils.PointerTo(models.ABORTED),
+					},
+				},
+			}
+
+			err := w.client.PatchScanResult(ctx, sr, id)
+			if err != nil {
+				w.logger.Errorf("failed to patch ScanResult with id: %s", id)
+				return
+			}
+		}()
+	}
+	wg.Wait()
+
+	return nil
+}

--- a/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
+++ b/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
@@ -137,7 +137,7 @@ func (w *Watcher) Reconcile(ctx context.Context, event ScanReconcileEvent) error
 
 func (w *Watcher) getScansByState(ctx context.Context, s models.ScanState) (models.Scans, error) {
 	filter := fmt.Sprintf("state eq '%s'", s)
-	selector := "id,state,stateReason,targetIDs"
+	selector := "id"
 	params := models.GetScansParams{
 		Filter: &filter,
 		Select: &selector,
@@ -156,7 +156,7 @@ func (w *Watcher) getScansByState(ctx context.Context, s models.ScanState) (mode
 func (w *Watcher) reconcileAborted(ctx context.Context, event ScanReconcileEvent) error {
 	filter := fmt.Sprintf("scan/id eq '%s' and status/general/state ne '%s' and status/general/state ne '%s'",
 		event.ScanID, models.ABORTED, models.DONE)
-	selector := "id,scan,status,target"
+	selector := "id,status"
 	params := models.GetScanResultsParams{
 		Filter: &filter,
 		Select: &selector,

--- a/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
+++ b/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
@@ -22,11 +22,12 @@ import (
 	"sync"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/common"
 	runtimeScanUtils "github.com/openclarity/vmclarity/runtime_scan/pkg/utils"
 	"github.com/openclarity/vmclarity/shared/pkg/backendclient"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
+++ b/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
@@ -39,9 +39,11 @@ type ScanReconcileEvent struct {
 	ScanID models.ScanID
 }
 
-type ScanQueue = common.Queue[ScanReconcileEvent]
-type ScanPoller = common.Poller[ScanReconcileEvent]
-type ScanReconciler = common.Reconciler[ScanReconcileEvent]
+type (
+	ScanQueue      = common.Queue[ScanReconcileEvent]
+	ScanPoller     = common.Poller[ScanReconcileEvent]
+	ScanReconciler = common.Reconciler[ScanReconcileEvent]
+)
 
 type Config struct {
 	Backend          *backendclient.BackendClient

--- a/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
+++ b/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
@@ -203,16 +203,18 @@ func (w *Watcher) reconcileAborted(ctx context.Context, event ScanReconcileEvent
 		}
 	}
 
-	scan := &models.Scan{
-		EndTime:     runtimeScanUtils.PointerTo(time.Now().UTC()),
-		State:       runtimeScanUtils.PointerTo(models.ScanStateFailed),
-		StateReason: runtimeScanUtils.PointerTo(models.ScanStateReasonAborted),
-	}
-
-	err = w.client.PatchScan(ctx, event.ScanID, scan)
-	if err != nil {
-		return fmt.Errorf("failed to patch Scan with id: %s: %v", event.ScanID, err)
-	}
+	// FIXME(chrisgacsal): updating the Scan state here collides the Scan logic in Scanner.job_management
+	//                     therefore it is disabled until Scan lifecycle management is moved to ScanWatcher.
+	// scan := &models.Scan{
+	// 	EndTime:     runtimeScanUtils.PointerTo(time.Now().UTC()),
+	// 	State:       runtimeScanUtils.PointerTo(models.ScanStateFailed),
+	// 	StateReason: runtimeScanUtils.PointerTo(models.ScanStateReasonAborted),
+	// }
+	//
+	// err = w.client.PatchScan(ctx, event.ScanID, scan)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to patch Scan with id: %s: %v", event.ScanID, err)
+	// }
 
 	return nil
 }

--- a/runtime_scan/pkg/scanner/job_managment.go
+++ b/runtime_scan/pkg/scanner/job_managment.go
@@ -248,13 +248,13 @@ func (s *Scanner) handleScanData(ctx context.Context, data *scanData, ks chan bo
 			data.success = false
 			data.completed = true
 			s.Unlock()
-			return nil, fmt.Errorf("failed to run scan job for target %s: %v", data.targetInstance, err)
+			return nil, fmt.Errorf("failed to run scan job for target %s: %v", data.targetInstance.TargetID, err)
 		}
 		fallthrough
 	case models.ATTACHED, models.INPROGRESS, models.ABORTED:
 		s.waitForResult(ctx, data, ks)
 		if data.timeout {
-			return nil, fmt.Errorf("scan job for target %s timed out: %v", data.targetInstance, err)
+			return nil, fmt.Errorf("scan job for target %s timed out: %v", data.targetInstance.TargetID, err)
 		}
 	case models.DONE, models.NOTSCANNED:
 	}

--- a/runtime_scan/pkg/scanner/job_managment.go
+++ b/runtime_scan/pkg/scanner/job_managment.go
@@ -265,7 +265,7 @@ func (s *Scanner) handleScanData(ctx context.Context, data *scanData, ks chan bo
 // nolint:cyclop
 func (s *Scanner) waitForResult(ctx context.Context, data *scanData, ks chan bool) {
 	log.WithFields(s.logFields).Infof("Waiting for result. targetID=%+v", data.targetInstance.TargetID)
-	timer := time.NewTimer(s.config.JobResultsPollingInterval)
+	timer := time.NewTicker(s.config.JobResultsPollingInterval)
 	defer timer.Stop()
 
 	ctx, cancel := context.WithTimeout(ctx, s.config.JobResultTimeout)
@@ -303,11 +303,7 @@ func (s *Scanner) waitForResult(ctx context.Context, data *scanData, ks chan boo
 				s.Unlock()
 				return
 			}
-			timer.Reset(s.config.JobResultsPollingInterval)
 		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
 			log.WithFields(s.logFields).Infof("Job has timed out. targetID=%v", data.targetInstance.TargetID)
 			s.Lock()
 			data.success = false

--- a/runtime_scan/pkg/scanner/job_managment.go
+++ b/runtime_scan/pkg/scanner/job_managment.go
@@ -125,12 +125,7 @@ func (s *Scanner) jobBatchManagement(ctx context.Context) {
 					break
 				}
 
-				var isAborted bool
 				if scanState == models.ScanStateAborted {
-					isAborted = true
-				}
-
-				if isAborted {
 					log.Warning("Scan is aborted")
 					scan.State = utils.PointerTo(models.ScanStateFailed)
 					scan.StateMessage = utils.PointerTo("User initiated")

--- a/runtime_scan/pkg/scanner/job_managment.go
+++ b/runtime_scan/pkg/scanner/job_managment.go
@@ -62,7 +62,7 @@ const (
 )
 
 // run jobs.
-// nolint:cyclop
+// nolint:cyclop,gocognit
 func (s *Scanner) jobBatchManagement(ctx context.Context) {
 	s.Lock()
 	targetIDToScanData := s.targetIDToScanData

--- a/shared/pkg/families/manager.go
+++ b/shared/pkg/families/manager.go
@@ -16,6 +16,7 @@
 package families
 
 import (
+	"context"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -77,17 +78,43 @@ func New(logger *log.Entry, config *Config) *Manager {
 
 type RunErrors map[types.FamilyType]error
 
-func (m *Manager) Run() (*results.Results, RunErrors) {
-	familyErrors := make(map[types.FamilyType]error)
+type familyResult struct {
+	result interfaces.IsResults
+	err    error
+}
 
+func (m *Manager) Run(ctx context.Context) (*results.Results, RunErrors) {
+	familyErrors := make(RunErrors)
 	familyResults := results.New()
+	result := make(chan familyResult, len(m.families))
 
+outer:
 	for _, family := range m.families {
-		ret, err := family.Run(familyResults)
-		if err != nil {
-			familyErrors[family.GetType()] = fmt.Errorf("failed to run family %v: %w", family.GetType(), err)
-		} else {
-			familyResults.SetResults(ret)
+		go func() {
+			ret, err := family.Run(familyResults)
+			result <- familyResult{
+				ret,
+				err,
+			}
+		}()
+
+	inner:
+		for {
+			select {
+			case <-ctx.Done():
+				log.Warningf("received context cancelled while family %q is still running. Aborting...", family)
+				break outer
+			case r := <-result:
+				log.Debugf("received result from family %q: %v", family, r)
+				if r.err != nil {
+					familyErrors[family.GetType()] = fmt.Errorf("failed to run family %v: %w", family.GetType(), r.err)
+				} else {
+					familyResults.SetResults(r.result)
+				}
+				break inner
+			default:
+				continue
+			}
 		}
 	}
 

--- a/shared/pkg/families/manager.go
+++ b/shared/pkg/families/manager.go
@@ -102,7 +102,7 @@ outer:
 		for {
 			select {
 			case <-ctx.Done():
-				log.Warningf("received context cancelled while family %q is still running. Aborting...", family)
+				familyErrors[family.GetType()] = fmt.Errorf("failed to run family %v: aborted", family.GetType())
 				break outer
 			case r := <-result:
 				log.Debugf("received result from family %q: %v", family, r)


### PR DESCRIPTION
## Description

* Add `ScanWatcher` to look up for Scans which status has changed to `Aborted` and updated all the corresponding `ScanResult` status to `ABORTED` so the Scanner Worker and the CLI could detect cancellation events.
* Update Scanner Worker to detect if the `ScanResult `state is changed to `Aborted`.

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Test Plan

Manual steps to test aborting ongoing scans in live environment.

<details>
  <summary>Expand</summary>

### Scan configuration

Create Scan Configuration file

```shell
cat <<EOF > scanconfig.json
{
  "name": "test",
  "scanFamiliesConfig": {
     "sbom": {
       "enabled": true
     },
     "vulnerabilities": {
       "enabled": true
     },
     "exploits": {
       "enabled": true
     }
  },
  "scheduled": {
    "cronLine": "0 */4 * * *",
    "operationTime": "2023-01-20T15:46:18+00:00"
  },
  "scope": {
    "allRegions": true,
    "objectType": "AwsScanScope",
    "instanceTagSelector": [
      {
        "key": "ScanConfig",
        "value": "test"
      }
    ]
  }
}
EOF
```

Apply Scan Configuration to API

```shell
curl -sSf -X POST 'http://localhost:8888/api/scanConfigs' -H 'Content-Type: application/json' \
  -d @scanconfig.json \
| jq -r -e '.id' > scanconfig.id
```

Get Scan Configuration object from API

```shell
curl -sSf -X GET 'http://localhost:8888/api/scanConfigs/'"$(cat scanconfig.id)"'' \
| jq -r -e '.' > scanconfig.api.json
```

### Start Scan

Start Scan using Scan Config

```shell
jq -r -e '{maxParallelScanners, name, scanFamiliesConfig, scheduled, scope} | .scheduled.operationTime = (now|todate)' \
  scanconfig.api.json \
| curl -sSf -X PUT -H 'Content-Type: application/json' 'http://localhost:8888/api/scanConfigs/'"$(cat scanconfig.id)"'' \
  -d @-
```

Get ongoing Scan from API using ScanConfig id 

```shell
curl -sSf -G 'http://localhost:8888/api/scans' \
  --data-urlencode "\$filter=scanConfig/id eq '$(cat scanconfig.id)' and state ne 'Done' and state ne 'Failed'" \
| jq -r -e '.items[] | first' > scan.api.json
```

### Abort Scan in progress

```shell
cat <<EOF > scan-aborted.json
{
  "state": "Aborted"
}
EOF
```

```shell
jq -r -e '.id' scan.api.json > scan.id \
&& curl -sSf -X PATCH -H 'Content-Type: application/json' \
  "http://localhost:8888/api/scans/$(cat scan.id)" \
  -d @scan-aborted.json \
| jq -r -e '.' > scan-aborted.api.json
```

</details>
