### PR TITLE
fix: add volume to job after creation, in order for the volume to be deleted with job

### DIFF
--- a/runtime_scan/pkg/scanner/job_managment.go
+++ b/runtime_scan/pkg/scanner/job_managment.go
@@ -355,6 +355,7 @@ func (s *Scanner) runJob(ctx context.Context, data *scanData) (types.Job, error)
 	if err != nil {
 		return types.Job{}, fmt.Errorf("failed to create volume: %v", err)
 	}
+	job.Volume = newVolume
 
 	// wait for instance to be in a running state.
 	if err := job.Instance.WaitForReady(ctx); err != nil {


### PR DESCRIPTION
## Description

when snapshotting a volume, a new volume is created. This adds the new volume to the job object, in order for the volume to be cleaned with the job


## Type of Change

[* ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

