### PR TITLE
Fix odata startswith and endswith filters

### DIFF
--- a/backend/pkg/database/odatasql/query.go
+++ b/backend/pkg/database/odatasql/query.go
@@ -493,7 +493,7 @@ func buildWhereFromFilter(source string, node *godata.ParseNode) (string, error)
 		default:
 			return query, fmt.Errorf("unsupported token type")
 		}
-		query = fmt.Sprintf("%s -> '$.%s' LIKE '%s'", source, queryPath, value)
+		query = fmt.Sprintf("%s ->> '%s' LIKE '%s'", source, queryPath, value)
 	}
 
 	return query, nil

--- a/backend/pkg/database/odatasql/query_test.go
+++ b/backend/pkg/database/odatasql/query_test.go
@@ -562,6 +562,20 @@ func TestBuildSQLQuery(t *testing.T) {
 			want: []Car{car1},
 		},
 		{
+			name: "'startswith' filter",
+			args: args{
+				filterString: PointerTo(fmt.Sprintf("startswith(Manufacturer/Id, '%s')", manu1.ID[0:3])),
+			},
+			want: []Car{car1, car2},
+		},
+		{
+			name: "'endswith' filter",
+			args: args{
+				filterString: PointerTo("endswith(ModelName, '3')"),
+			},
+			want: []Car{car3},
+		},
+		{
 			name: "filter on nested field",
 			args: args{
 				filterString: PointerTo(fmt.Sprintf("Engine/Manufacturer/Id eq '%s'", manu1.ID)),


### PR DESCRIPTION
## Description

This fixes startswith and endswith filters by ensuring that we're getting the SQL representation of the string field and not the JSON representation of the string with builtin quotes. To prevent regressions this commit also adds missing unit tests for these filters.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
