### PR TITLE
Make filter and orderby work for fields that need to be expanded

### DIFF
--- a/backend/pkg/database/odatasql/schema.go
+++ b/backend/pkg/database/odatasql/schema.go
@@ -18,11 +18,10 @@ package odatasql
 type FieldType string
 
 const (
-	PrimitiveFieldType              FieldType = "primitive"
-	CollectionFieldType             FieldType = "collection"
-	ComplexFieldType                FieldType = "complex"
-	RelationshipFieldType           FieldType = "relationship"
-	RelationshipCollectionFieldType FieldType = "relationshipCollection"
+	PrimitiveFieldType    FieldType = "primitive"
+	CollectionFieldType   FieldType = "collection"
+	ComplexFieldType      FieldType = "complex"
+	RelationshipFieldType FieldType = "relationship"
 )
 
 type FieldMeta struct {


### PR DESCRIPTION
## Description

With this change if you put a field in $filter or $orderby which requires expansion, the underlying query will expand it. This works regardless of whether the field is $expand in the returned data.

## Type of Change

[ ] Bug Fix  
[X] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
