### PR TITLE
Make CLI write reports to file for scanner jobs

### DIFF
--- a/runtime_scan/pkg/cloudinit/cloudinit_template.go
+++ b/runtime_scan/pkg/cloudinit/cloudinit_template.go
@@ -35,16 +35,19 @@ write_files:
       [Service]
       Type=oneshot
       WorkingDirectory=/opt/vmclarity
+      ExecStartPre=mkdir -p /var/opt/vmclarity
       ExecStartPre=docker pull {{ .ScannerImage }}
       ExecStart=docker run --rm --name %n --privileged \
           -v /opt/vmclarity:/opt/vmclarity \
           -v /run:/run \
+          -v /var/opt/vmclarity:/var/opt/vmclarity \
           {{ .ScannerImage }} \
           --config /opt/vmclarity/scanconfig.yaml \
           --server {{ .ServerAddress }} \
           --wait-for-server-attached \
           --mount-attached-volume \
-          --scan-result-id {{ .ScanResultID }}
+          --scan-result-id {{ .ScanResultID }} \
+          --output /var/opt/vmclarity
 
       [Install]
       WantedBy=multi-user.target


### PR DESCRIPTION
## Description

Currently the CLI writes reports to the console by default which might make sense when the CLI is used locally. However it makes hard to spot issues/errors at runtime for scanner jobs as it pollutes the logs with the reports of the scanners.
This change makes the the scanner job to write the scanner reports to files at path provided via `--output` command line parameter.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
