### PR TITLE
Make AWS Scanner VM InstanceType configurable

### DIFF
--- a/installation/aws/VmClarity.cfn
+++ b/installation/aws/VmClarity.cfn
@@ -157,6 +157,7 @@ Resources:
                     SCANNER_AWS_REGION=${AWS::Region}
                     AWS_SUBNET_ID=${VmClarityScannerSubnet}
                     AWS_SECURITY_GROUP_ID=${VmClarityScannerSecurityGroup}
+                    AWS_INSTANCE_TYPE=${ScannerInstanceType}
                     SCANNER_KEY_PAIR_NAME=${KeyName}
                     AWS_JOB_IMAGE_ID=${JobImageID}
                     DATABASE_DRIVER=LOCAL
@@ -745,6 +746,15 @@ Parameters:
       - t2.large
       - t3.large
     ConstraintDescription: must be a valid EC2 instance type.
+  ScannerInstanceType:
+    Description: VmClarity Scanner Instance Type
+    Type: String
+    Default: t2.large
+    AllowedValues:
+      - m6i.large
+      - t2.large
+      - t3.large
+    ConstraintDescription: must be a valid EC2 instance type.
   KeyName:
     Description: Name of an EC2 KeyPair to enable SSH access to the instance.
     Type: "AWS::EC2::KeyPair::KeyName"
@@ -792,6 +802,7 @@ Metadata:
           default: EC2 Configuration
         Parameters:
           - InstanceType
+          - ScannerInstanceType
           - KeyName
       - Label:
           default: Network Configuration
@@ -804,8 +815,13 @@ Metadata:
           - ScannerContainerImage
           - TrivyServerContainerImage
           - GrypeServerContainerImage
+          - FreshclamMirrorContainerImage
           - AssetScanDeletePolicy
     ParameterLabels:
+      InstanceType:
+        default: VMClarity Server Instance Type
+      ScannerInstanceType:
+        default: Scanner Job Instance Type
       BackendContainerImage:
         default: Backend Container Image
       ScannerContainerImage:
@@ -814,6 +830,8 @@ Metadata:
         default: Trivy Server Container Image
       GrypeServerContainerImage:
         default: Grype Server Container Image
+      FreshclamMirrorContainerImage:
+        default: freshclam-mirror Container Image
       AssetScanDeletePolicy:
         default: Asset Scan Delete Policy
 Mappings:

--- a/runtime_scan/pkg/config/aws/config.go
+++ b/runtime_scan/pkg/config/aws/config.go
@@ -18,20 +18,24 @@ package aws
 import "github.com/spf13/viper"
 
 const (
-	AWSSubnetID          = "AWS_SUBNET_ID"
-	AWSJobImageID        = "AWS_JOB_IMAGE_ID"
-	AWSSecurityGroupID   = "AWS_SECURITY_GROUP_ID"
-	defaultAWSJobImageID = "ami-0568773882d492fc8" // ubuntu server 22.04 LTS (HVM), SSD volume type
+	AWSSubnetID            = "AWS_SUBNET_ID"
+	AWSJobImageID          = "AWS_JOB_IMAGE_ID"
+	AWSSecurityGroupID     = "AWS_SECURITY_GROUP_ID"
+	AWSInstanceType        = "AWS_INSTANCE_TYPE"
+	defaultAWSJobImageID   = "ami-0568773882d492fc8" // ubuntu server 22.04 LTS (HVM), SSD volume type
+	defaultAWSInstanceType = "t2.large"
 )
 
 type Config struct {
 	AmiID           string // image id of a scanner job
 	SubnetID        string // the scanner's subnet ID
 	SecurityGroupID string // the scanner's security group
+	InstanceType    string // the scanner's instance type
 }
 
 func setConfigDefaults() {
 	viper.SetDefault(AWSJobImageID, defaultAWSJobImageID)
+	viper.SetDefault(AWSInstanceType, defaultAWSInstanceType)
 
 	viper.AutomaticEnv()
 }
@@ -43,6 +47,7 @@ func LoadConfig() *Config {
 		AmiID:           viper.GetString(AWSJobImageID),
 		SubnetID:        viper.GetString(AWSSubnetID),
 		SecurityGroupID: viper.GetString(AWSSecurityGroupID),
+		InstanceType:    viper.GetString(AWSInstanceType),
 	}
 
 	return config

--- a/runtime_scan/pkg/provider/aws/client.go
+++ b/runtime_scan/pkg/provider/aws/client.go
@@ -262,7 +262,7 @@ func (c *Client) RunScanningJob(ctx context.Context, region, id string, config p
 		MaxCount:     utils.Int32Ptr(1),
 		MinCount:     utils.Int32Ptr(1),
 		ImageId:      &c.awsConfig.AmiID,
-		InstanceType: ec2types.InstanceTypeT2Large, // TODO need to decide instance type
+		InstanceType: ec2types.InstanceType(c.awsConfig.InstanceType),
 		TagSpecifications: []ec2types.TagSpecification{
 			{
 				ResourceType: ec2types.ResourceTypeInstance,


### PR DESCRIPTION
## Description

This exposes a new environment variable configuration AWS_INSTANCE_TYPE for the orchestrator which configures the instance type to use for the scanner VMs. It defaults to t2.large.

A new parameter has been added to the cloud formation to allow user's to choose which instance type they wish to use at install time.

## Type of Change

[ ] Bug Fix  
[X] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
