### PR TITLE
Separate Ingress rules from Scanner SG in cloudformation

### DIFF
--- a/installation/aws/VmClarity.cfn
+++ b/installation/aws/VmClarity.cfn
@@ -403,11 +403,17 @@ Resources:
     Properties:
       VpcId: !Ref VmClarityVPC
       GroupDescription: Allow only required network traffic for VMClarity scanners
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          SourceSecurityGroupId: !Ref VmClarityServerSecurityGroup
+  # Allow the VMClarity Server in the VmClarityScannerSecurityGroup to access
+  # the Scanner VMs through SSH by adding an ingress rule to the
+  # VmClarityScannerSecurityGroup.
+  VmClarityScannerSecurityGroupServerIngressToSSH:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      GroupId: !Ref VmClarityScannerSecurityGroup
+      IpProtocol: tcp
+      FromPort: 22
+      ToPort: 22
+      SourceSecurityGroupId: !Ref VmClarityServerSecurityGroup
   # Allow the Scanner VMs in the VmClarityScannerSecurityGroup to access the
   # VMClarity server API on 8888 by adding an ingress rule to the
   # VmClarityServerSecurityGroup.


### PR DESCRIPTION
## Description

This PR removes the SSH ingress rule from the ScannerSecurityGroup to prevent circular dependencies between the created resources in AWS. Without this change its not possible to delete the SecurityGroups because they have rules which reference each other.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
