### PR TITLE
Update VMClarity init so stack upgrades apply correctly

### DIFF
--- a/installation/aws/VmClarity.cfn
+++ b/installation/aws/VmClarity.cfn
@@ -109,6 +109,7 @@ Resources:
                   [main]
                   stack=${AWS::StackId}
                   region=${AWS::Region}
+                  interval=5
               mode: "000400"
               owner: root
               group: root
@@ -133,10 +134,12 @@ Resources:
                 [Install]
                 WantedBy=multi-user.target
           commands:
-            01enable_cfn_hup:
+            01reload_systemctl:
+              command: systemctl daemon-reload
+            02enable_cfn_hup:
               command: systemctl enable cfn-hup.service
-            02start_cfn_hup:
-              command: systemctl start cfn-hup.service
+            03start_restart_cfn_hup:
+              command: systemctl restart cfn-hup.service
         install_vmclarity:
           packages:
             apt:
@@ -366,18 +369,39 @@ Resources:
           commands:
             01subsitute_rest_address:
               command: /etc/vmclarity/render_config.sh
+            02reload_systemctl:
+              command: systemctl daemon-reload
+
             02enable_exploit_db_fetcher_timer:
-              command: systemctl enable --now exploit_fetcher.timer
+              command: systemctl enable exploit_fetcher.timer
+            03start_restart_exploit_db_fetcher_timer:
+              command: systemctl restart exploit_fetcher.timer
+
             03enable_exploit_server:
-              command: systemctl enable --now exploit_server.service
-            04start_trivy_server:
-              command: systemctl enable --now trivy_server.service
-            05start_grype_server:
-              command: systemctl enable --now grype_server.service
-            06enable_vmclarity:
-              command: systemctl enable --now vmclarity.service
-            07enable_vmclarity_freshclam_mirror:
-              command: systemctl enable --now vmclarity_freshclam_mirror.service
+              command: systemctl enable exploit_server.service
+            04start_restart_exploit_server:
+              command: systemctl restart exploit_server.service
+
+            05enable_trivy_server:
+              command: systemctl enable trivy_server.service
+            06start_restart_trivy_server:
+              command: systemctl restart trivy_server.service
+
+            07enable_grype_server:
+              command: systemctl enable grype_server.service
+            08start_restart_grype_server:
+              command: systemctl restart grype_server.service
+
+            09enable_vmclarity_freshclam_mirror:
+              command: systemctl enable vmclarity_freshclam_mirror.service
+            10start_restart_vmclarity_freshclam_mirror:
+              command: systemctl restart vmclarity_freshclam_mirror.service
+
+            11enable_vmclarity:
+              command: systemctl enable vmclarity.service
+            12start_restart_vmclarity:
+              command: systemctl restart vmclarity.service
+
     DependsOn:
       - VmClarityServerPublicRoute
   # Create a Security Group for the VMClarity server. Allow on the public


### PR DESCRIPTION
## Description

This change tweaks the init configs for VMClarity server so that cfn-hup and cfn-init hooks restart the services correctly when the cloud formation stack updates the VMClarity server configuration.

Without this change the cfn-hup and cfn-init notice the change and update the systemd unit files, but the services don't get restarted so they continue to run the old version.

This change also lowers the cfn-hup polling time from 15 minutes to 5 minutes, so that the VMClarityServer notices that the cloudformation has been updated sooner.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
