### PR TITLE
Add revision number to VMClarity objects and support for If-Match header

### DIFF
--- a/api/client/client.gen.go
+++ b/api/client/client.gen.go
@@ -137,14 +137,14 @@ type ClientInterface interface {
 	GetScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, params *GetScanConfigsScanConfigIDParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PatchScanConfigsScanConfigID request with any body
-	PatchScanConfigsScanConfigIDWithBody(ctx context.Context, scanConfigID ScanConfigID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchScanConfigsScanConfigIDWithBody(ctx context.Context, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PatchScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, body PatchScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, body PatchScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PutScanConfigsScanConfigID request with any body
-	PutScanConfigsScanConfigIDWithBody(ctx context.Context, scanConfigID ScanConfigID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PutScanConfigsScanConfigIDWithBody(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PutScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PutScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetScanResults request
 	GetScanResults(ctx context.Context, params *GetScanResultsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -158,14 +158,14 @@ type ClientInterface interface {
 	GetScanResultsScanResultID(ctx context.Context, scanResultID ScanResultID, params *GetScanResultsScanResultIDParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PatchScanResultsScanResultID request with any body
-	PatchScanResultsScanResultIDWithBody(ctx context.Context, scanResultID ScanResultID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchScanResultsScanResultIDWithBody(ctx context.Context, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PatchScanResultsScanResultID(ctx context.Context, scanResultID ScanResultID, body PatchScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchScanResultsScanResultID(ctx context.Context, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, body PatchScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PutScanResultsScanResultID request with any body
-	PutScanResultsScanResultIDWithBody(ctx context.Context, scanResultID ScanResultID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PutScanResultsScanResultIDWithBody(ctx context.Context, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PutScanResultsScanResultID(ctx context.Context, scanResultID ScanResultID, body PutScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PutScanResultsScanResultID(ctx context.Context, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, body PutScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetScans request
 	GetScans(ctx context.Context, params *GetScansParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -182,14 +182,14 @@ type ClientInterface interface {
 	GetScansScanID(ctx context.Context, scanID ScanID, params *GetScansScanIDParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PatchScansScanID request with any body
-	PatchScansScanIDWithBody(ctx context.Context, scanID ScanID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchScansScanIDWithBody(ctx context.Context, scanID ScanID, params *PatchScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PatchScansScanID(ctx context.Context, scanID ScanID, body PatchScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchScansScanID(ctx context.Context, scanID ScanID, params *PatchScansScanIDParams, body PatchScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PutScansScanID request with any body
-	PutScansScanIDWithBody(ctx context.Context, scanID ScanID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PutScansScanIDWithBody(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PutScansScanID(ctx context.Context, scanID ScanID, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PutScansScanID(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetTargets request
 	GetTargets(ctx context.Context, params *GetTargetsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -206,14 +206,14 @@ type ClientInterface interface {
 	GetTargetsTargetID(ctx context.Context, targetID TargetID, params *GetTargetsTargetIDParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PatchTargetsTargetID request with any body
-	PatchTargetsTargetIDWithBody(ctx context.Context, targetID TargetID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchTargetsTargetIDWithBody(ctx context.Context, targetID TargetID, params *PatchTargetsTargetIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PatchTargetsTargetID(ctx context.Context, targetID TargetID, body PatchTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PatchTargetsTargetID(ctx context.Context, targetID TargetID, params *PatchTargetsTargetIDParams, body PatchTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PutTargetsTargetID request with any body
-	PutTargetsTargetIDWithBody(ctx context.Context, targetID TargetID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PutTargetsTargetIDWithBody(ctx context.Context, targetID TargetID, params *PutTargetsTargetIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	PutTargetsTargetID(ctx context.Context, targetID TargetID, body PutTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	PutTargetsTargetID(ctx context.Context, targetID TargetID, params *PutTargetsTargetIDParams, body PutTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
 func (c *Client) GetDiscoveryScopes(ctx context.Context, params *GetDiscoveryScopesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -420,8 +420,8 @@ func (c *Client) GetScanConfigsScanConfigID(ctx context.Context, scanConfigID Sc
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchScanConfigsScanConfigIDWithBody(ctx context.Context, scanConfigID ScanConfigID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchScanConfigsScanConfigIDRequestWithBody(c.Server, scanConfigID, contentType, body)
+func (c *Client) PatchScanConfigsScanConfigIDWithBody(ctx context.Context, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchScanConfigsScanConfigIDRequestWithBody(c.Server, scanConfigID, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -432,8 +432,8 @@ func (c *Client) PatchScanConfigsScanConfigIDWithBody(ctx context.Context, scanC
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, body PatchScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchScanConfigsScanConfigIDRequest(c.Server, scanConfigID, body)
+func (c *Client) PatchScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, body PatchScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchScanConfigsScanConfigIDRequest(c.Server, scanConfigID, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -444,8 +444,8 @@ func (c *Client) PatchScanConfigsScanConfigID(ctx context.Context, scanConfigID 
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutScanConfigsScanConfigIDWithBody(ctx context.Context, scanConfigID ScanConfigID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutScanConfigsScanConfigIDRequestWithBody(c.Server, scanConfigID, contentType, body)
+func (c *Client) PutScanConfigsScanConfigIDWithBody(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutScanConfigsScanConfigIDRequestWithBody(c.Server, scanConfigID, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -456,8 +456,8 @@ func (c *Client) PutScanConfigsScanConfigIDWithBody(ctx context.Context, scanCon
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutScanConfigsScanConfigIDRequest(c.Server, scanConfigID, body)
+func (c *Client) PutScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutScanConfigsScanConfigIDRequest(c.Server, scanConfigID, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -516,8 +516,8 @@ func (c *Client) GetScanResultsScanResultID(ctx context.Context, scanResultID Sc
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchScanResultsScanResultIDWithBody(ctx context.Context, scanResultID ScanResultID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchScanResultsScanResultIDRequestWithBody(c.Server, scanResultID, contentType, body)
+func (c *Client) PatchScanResultsScanResultIDWithBody(ctx context.Context, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchScanResultsScanResultIDRequestWithBody(c.Server, scanResultID, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -528,8 +528,8 @@ func (c *Client) PatchScanResultsScanResultIDWithBody(ctx context.Context, scanR
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchScanResultsScanResultID(ctx context.Context, scanResultID ScanResultID, body PatchScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchScanResultsScanResultIDRequest(c.Server, scanResultID, body)
+func (c *Client) PatchScanResultsScanResultID(ctx context.Context, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, body PatchScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchScanResultsScanResultIDRequest(c.Server, scanResultID, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -540,8 +540,8 @@ func (c *Client) PatchScanResultsScanResultID(ctx context.Context, scanResultID 
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutScanResultsScanResultIDWithBody(ctx context.Context, scanResultID ScanResultID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutScanResultsScanResultIDRequestWithBody(c.Server, scanResultID, contentType, body)
+func (c *Client) PutScanResultsScanResultIDWithBody(ctx context.Context, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutScanResultsScanResultIDRequestWithBody(c.Server, scanResultID, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -552,8 +552,8 @@ func (c *Client) PutScanResultsScanResultIDWithBody(ctx context.Context, scanRes
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutScanResultsScanResultID(ctx context.Context, scanResultID ScanResultID, body PutScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutScanResultsScanResultIDRequest(c.Server, scanResultID, body)
+func (c *Client) PutScanResultsScanResultID(ctx context.Context, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, body PutScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutScanResultsScanResultIDRequest(c.Server, scanResultID, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -624,8 +624,8 @@ func (c *Client) GetScansScanID(ctx context.Context, scanID ScanID, params *GetS
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchScansScanIDWithBody(ctx context.Context, scanID ScanID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchScansScanIDRequestWithBody(c.Server, scanID, contentType, body)
+func (c *Client) PatchScansScanIDWithBody(ctx context.Context, scanID ScanID, params *PatchScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchScansScanIDRequestWithBody(c.Server, scanID, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -636,8 +636,8 @@ func (c *Client) PatchScansScanIDWithBody(ctx context.Context, scanID ScanID, co
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchScansScanID(ctx context.Context, scanID ScanID, body PatchScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchScansScanIDRequest(c.Server, scanID, body)
+func (c *Client) PatchScansScanID(ctx context.Context, scanID ScanID, params *PatchScansScanIDParams, body PatchScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchScansScanIDRequest(c.Server, scanID, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -648,8 +648,8 @@ func (c *Client) PatchScansScanID(ctx context.Context, scanID ScanID, body Patch
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutScansScanIDWithBody(ctx context.Context, scanID ScanID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutScansScanIDRequestWithBody(c.Server, scanID, contentType, body)
+func (c *Client) PutScansScanIDWithBody(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutScansScanIDRequestWithBody(c.Server, scanID, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -660,8 +660,8 @@ func (c *Client) PutScansScanIDWithBody(ctx context.Context, scanID ScanID, cont
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutScansScanID(ctx context.Context, scanID ScanID, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutScansScanIDRequest(c.Server, scanID, body)
+func (c *Client) PutScansScanID(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutScansScanIDRequest(c.Server, scanID, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -732,8 +732,8 @@ func (c *Client) GetTargetsTargetID(ctx context.Context, targetID TargetID, para
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchTargetsTargetIDWithBody(ctx context.Context, targetID TargetID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchTargetsTargetIDRequestWithBody(c.Server, targetID, contentType, body)
+func (c *Client) PatchTargetsTargetIDWithBody(ctx context.Context, targetID TargetID, params *PatchTargetsTargetIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchTargetsTargetIDRequestWithBody(c.Server, targetID, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -744,8 +744,8 @@ func (c *Client) PatchTargetsTargetIDWithBody(ctx context.Context, targetID Targ
 	return c.Client.Do(req)
 }
 
-func (c *Client) PatchTargetsTargetID(ctx context.Context, targetID TargetID, body PatchTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPatchTargetsTargetIDRequest(c.Server, targetID, body)
+func (c *Client) PatchTargetsTargetID(ctx context.Context, targetID TargetID, params *PatchTargetsTargetIDParams, body PatchTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchTargetsTargetIDRequest(c.Server, targetID, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -756,8 +756,8 @@ func (c *Client) PatchTargetsTargetID(ctx context.Context, targetID TargetID, bo
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutTargetsTargetIDWithBody(ctx context.Context, targetID TargetID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutTargetsTargetIDRequestWithBody(c.Server, targetID, contentType, body)
+func (c *Client) PutTargetsTargetIDWithBody(ctx context.Context, targetID TargetID, params *PutTargetsTargetIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutTargetsTargetIDRequestWithBody(c.Server, targetID, params, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -768,8 +768,8 @@ func (c *Client) PutTargetsTargetIDWithBody(ctx context.Context, targetID Target
 	return c.Client.Do(req)
 }
 
-func (c *Client) PutTargetsTargetID(ctx context.Context, targetID TargetID, body PutTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewPutTargetsTargetIDRequest(c.Server, targetID, body)
+func (c *Client) PutTargetsTargetID(ctx context.Context, targetID TargetID, params *PutTargetsTargetIDParams, body PutTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutTargetsTargetIDRequest(c.Server, targetID, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1568,18 +1568,18 @@ func NewGetScanConfigsScanConfigIDRequest(server string, scanConfigID ScanConfig
 }
 
 // NewPatchScanConfigsScanConfigIDRequest calls the generic PatchScanConfigsScanConfigID builder with application/json body
-func NewPatchScanConfigsScanConfigIDRequest(server string, scanConfigID ScanConfigID, body PatchScanConfigsScanConfigIDJSONRequestBody) (*http.Request, error) {
+func NewPatchScanConfigsScanConfigIDRequest(server string, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, body PatchScanConfigsScanConfigIDJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPatchScanConfigsScanConfigIDRequestWithBody(server, scanConfigID, "application/json", bodyReader)
+	return NewPatchScanConfigsScanConfigIDRequestWithBody(server, scanConfigID, params, "application/json", bodyReader)
 }
 
 // NewPatchScanConfigsScanConfigIDRequestWithBody generates requests for PatchScanConfigsScanConfigID with any type of body
-func NewPatchScanConfigsScanConfigIDRequestWithBody(server string, scanConfigID ScanConfigID, contentType string, body io.Reader) (*http.Request, error) {
+func NewPatchScanConfigsScanConfigIDRequestWithBody(server string, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1611,22 +1611,33 @@ func NewPatchScanConfigsScanConfigIDRequestWithBody(server string, scanConfigID 
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
+
 	return req, nil
 }
 
 // NewPutScanConfigsScanConfigIDRequest calls the generic PutScanConfigsScanConfigID builder with application/json body
-func NewPutScanConfigsScanConfigIDRequest(server string, scanConfigID ScanConfigID, body PutScanConfigsScanConfigIDJSONRequestBody) (*http.Request, error) {
+func NewPutScanConfigsScanConfigIDRequest(server string, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, body PutScanConfigsScanConfigIDJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPutScanConfigsScanConfigIDRequestWithBody(server, scanConfigID, "application/json", bodyReader)
+	return NewPutScanConfigsScanConfigIDRequestWithBody(server, scanConfigID, params, "application/json", bodyReader)
 }
 
 // NewPutScanConfigsScanConfigIDRequestWithBody generates requests for PutScanConfigsScanConfigID with any type of body
-func NewPutScanConfigsScanConfigIDRequestWithBody(server string, scanConfigID ScanConfigID, contentType string, body io.Reader) (*http.Request, error) {
+func NewPutScanConfigsScanConfigIDRequestWithBody(server string, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1657,6 +1668,17 @@ func NewPutScanConfigsScanConfigIDRequestWithBody(server string, scanConfigID Sc
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
 
 	return req, nil
 }
@@ -1915,18 +1937,18 @@ func NewGetScanResultsScanResultIDRequest(server string, scanResultID ScanResult
 }
 
 // NewPatchScanResultsScanResultIDRequest calls the generic PatchScanResultsScanResultID builder with application/json body
-func NewPatchScanResultsScanResultIDRequest(server string, scanResultID ScanResultID, body PatchScanResultsScanResultIDJSONRequestBody) (*http.Request, error) {
+func NewPatchScanResultsScanResultIDRequest(server string, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, body PatchScanResultsScanResultIDJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPatchScanResultsScanResultIDRequestWithBody(server, scanResultID, "application/json", bodyReader)
+	return NewPatchScanResultsScanResultIDRequestWithBody(server, scanResultID, params, "application/json", bodyReader)
 }
 
 // NewPatchScanResultsScanResultIDRequestWithBody generates requests for PatchScanResultsScanResultID with any type of body
-func NewPatchScanResultsScanResultIDRequestWithBody(server string, scanResultID ScanResultID, contentType string, body io.Reader) (*http.Request, error) {
+func NewPatchScanResultsScanResultIDRequestWithBody(server string, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1958,22 +1980,33 @@ func NewPatchScanResultsScanResultIDRequestWithBody(server string, scanResultID 
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
+
 	return req, nil
 }
 
 // NewPutScanResultsScanResultIDRequest calls the generic PutScanResultsScanResultID builder with application/json body
-func NewPutScanResultsScanResultIDRequest(server string, scanResultID ScanResultID, body PutScanResultsScanResultIDJSONRequestBody) (*http.Request, error) {
+func NewPutScanResultsScanResultIDRequest(server string, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, body PutScanResultsScanResultIDJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPutScanResultsScanResultIDRequestWithBody(server, scanResultID, "application/json", bodyReader)
+	return NewPutScanResultsScanResultIDRequestWithBody(server, scanResultID, params, "application/json", bodyReader)
 }
 
 // NewPutScanResultsScanResultIDRequestWithBody generates requests for PutScanResultsScanResultID with any type of body
-func NewPutScanResultsScanResultIDRequestWithBody(server string, scanResultID ScanResultID, contentType string, body io.Reader) (*http.Request, error) {
+func NewPutScanResultsScanResultIDRequestWithBody(server string, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -2004,6 +2037,17 @@ func NewPutScanResultsScanResultIDRequestWithBody(server string, scanResultID Sc
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
 
 	return req, nil
 }
@@ -2296,18 +2340,18 @@ func NewGetScansScanIDRequest(server string, scanID ScanID, params *GetScansScan
 }
 
 // NewPatchScansScanIDRequest calls the generic PatchScansScanID builder with application/json body
-func NewPatchScansScanIDRequest(server string, scanID ScanID, body PatchScansScanIDJSONRequestBody) (*http.Request, error) {
+func NewPatchScansScanIDRequest(server string, scanID ScanID, params *PatchScansScanIDParams, body PatchScansScanIDJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPatchScansScanIDRequestWithBody(server, scanID, "application/json", bodyReader)
+	return NewPatchScansScanIDRequestWithBody(server, scanID, params, "application/json", bodyReader)
 }
 
 // NewPatchScansScanIDRequestWithBody generates requests for PatchScansScanID with any type of body
-func NewPatchScansScanIDRequestWithBody(server string, scanID ScanID, contentType string, body io.Reader) (*http.Request, error) {
+func NewPatchScansScanIDRequestWithBody(server string, scanID ScanID, params *PatchScansScanIDParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -2339,22 +2383,33 @@ func NewPatchScansScanIDRequestWithBody(server string, scanID ScanID, contentTyp
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
+
 	return req, nil
 }
 
 // NewPutScansScanIDRequest calls the generic PutScansScanID builder with application/json body
-func NewPutScansScanIDRequest(server string, scanID ScanID, body PutScansScanIDJSONRequestBody) (*http.Request, error) {
+func NewPutScansScanIDRequest(server string, scanID ScanID, params *PutScansScanIDParams, body PutScansScanIDJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPutScansScanIDRequestWithBody(server, scanID, "application/json", bodyReader)
+	return NewPutScansScanIDRequestWithBody(server, scanID, params, "application/json", bodyReader)
 }
 
 // NewPutScansScanIDRequestWithBody generates requests for PutScansScanID with any type of body
-func NewPutScansScanIDRequestWithBody(server string, scanID ScanID, contentType string, body io.Reader) (*http.Request, error) {
+func NewPutScansScanIDRequestWithBody(server string, scanID ScanID, params *PutScansScanIDParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -2385,6 +2440,17 @@ func NewPutScansScanIDRequestWithBody(server string, scanID ScanID, contentType 
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
 
 	return req, nil
 }
@@ -2677,18 +2743,18 @@ func NewGetTargetsTargetIDRequest(server string, targetID TargetID, params *GetT
 }
 
 // NewPatchTargetsTargetIDRequest calls the generic PatchTargetsTargetID builder with application/json body
-func NewPatchTargetsTargetIDRequest(server string, targetID TargetID, body PatchTargetsTargetIDJSONRequestBody) (*http.Request, error) {
+func NewPatchTargetsTargetIDRequest(server string, targetID TargetID, params *PatchTargetsTargetIDParams, body PatchTargetsTargetIDJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPatchTargetsTargetIDRequestWithBody(server, targetID, "application/json", bodyReader)
+	return NewPatchTargetsTargetIDRequestWithBody(server, targetID, params, "application/json", bodyReader)
 }
 
 // NewPatchTargetsTargetIDRequestWithBody generates requests for PatchTargetsTargetID with any type of body
-func NewPatchTargetsTargetIDRequestWithBody(server string, targetID TargetID, contentType string, body io.Reader) (*http.Request, error) {
+func NewPatchTargetsTargetIDRequestWithBody(server string, targetID TargetID, params *PatchTargetsTargetIDParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -2720,22 +2786,33 @@ func NewPatchTargetsTargetIDRequestWithBody(server string, targetID TargetID, co
 
 	req.Header.Add("Content-Type", contentType)
 
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
+
 	return req, nil
 }
 
 // NewPutTargetsTargetIDRequest calls the generic PutTargetsTargetID builder with application/json body
-func NewPutTargetsTargetIDRequest(server string, targetID TargetID, body PutTargetsTargetIDJSONRequestBody) (*http.Request, error) {
+func NewPutTargetsTargetIDRequest(server string, targetID TargetID, params *PutTargetsTargetIDParams, body PutTargetsTargetIDJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewPutTargetsTargetIDRequestWithBody(server, targetID, "application/json", bodyReader)
+	return NewPutTargetsTargetIDRequestWithBody(server, targetID, params, "application/json", bodyReader)
 }
 
 // NewPutTargetsTargetIDRequestWithBody generates requests for PutTargetsTargetID with any type of body
-func NewPutTargetsTargetIDRequestWithBody(server string, targetID TargetID, contentType string, body io.Reader) (*http.Request, error) {
+func NewPutTargetsTargetIDRequestWithBody(server string, targetID TargetID, params *PutTargetsTargetIDParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -2766,6 +2843,17 @@ func NewPutTargetsTargetIDRequestWithBody(server string, targetID TargetID, cont
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
 
 	return req, nil
 }
@@ -2860,14 +2948,14 @@ type ClientWithResponsesInterface interface {
 	GetScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *GetScanConfigsScanConfigIDParams, reqEditors ...RequestEditorFn) (*GetScanConfigsScanConfigIDResponse, error)
 
 	// PatchScanConfigsScanConfigID request with any body
-	PatchScanConfigsScanConfigIDWithBodyWithResponse(ctx context.Context, scanConfigID ScanConfigID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanConfigsScanConfigIDResponse, error)
+	PatchScanConfigsScanConfigIDWithBodyWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanConfigsScanConfigIDResponse, error)
 
-	PatchScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, body PatchScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanConfigsScanConfigIDResponse, error)
+	PatchScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, body PatchScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanConfigsScanConfigIDResponse, error)
 
 	// PutScanConfigsScanConfigID request with any body
-	PutScanConfigsScanConfigIDWithBodyWithResponse(ctx context.Context, scanConfigID ScanConfigID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanConfigsScanConfigIDResponse, error)
+	PutScanConfigsScanConfigIDWithBodyWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanConfigsScanConfigIDResponse, error)
 
-	PutScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanConfigsScanConfigIDResponse, error)
+	PutScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanConfigsScanConfigIDResponse, error)
 
 	// GetScanResults request
 	GetScanResultsWithResponse(ctx context.Context, params *GetScanResultsParams, reqEditors ...RequestEditorFn) (*GetScanResultsResponse, error)
@@ -2881,14 +2969,14 @@ type ClientWithResponsesInterface interface {
 	GetScanResultsScanResultIDWithResponse(ctx context.Context, scanResultID ScanResultID, params *GetScanResultsScanResultIDParams, reqEditors ...RequestEditorFn) (*GetScanResultsScanResultIDResponse, error)
 
 	// PatchScanResultsScanResultID request with any body
-	PatchScanResultsScanResultIDWithBodyWithResponse(ctx context.Context, scanResultID ScanResultID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanResultsScanResultIDResponse, error)
+	PatchScanResultsScanResultIDWithBodyWithResponse(ctx context.Context, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanResultsScanResultIDResponse, error)
 
-	PatchScanResultsScanResultIDWithResponse(ctx context.Context, scanResultID ScanResultID, body PatchScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanResultsScanResultIDResponse, error)
+	PatchScanResultsScanResultIDWithResponse(ctx context.Context, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, body PatchScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanResultsScanResultIDResponse, error)
 
 	// PutScanResultsScanResultID request with any body
-	PutScanResultsScanResultIDWithBodyWithResponse(ctx context.Context, scanResultID ScanResultID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanResultsScanResultIDResponse, error)
+	PutScanResultsScanResultIDWithBodyWithResponse(ctx context.Context, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanResultsScanResultIDResponse, error)
 
-	PutScanResultsScanResultIDWithResponse(ctx context.Context, scanResultID ScanResultID, body PutScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanResultsScanResultIDResponse, error)
+	PutScanResultsScanResultIDWithResponse(ctx context.Context, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, body PutScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanResultsScanResultIDResponse, error)
 
 	// GetScans request
 	GetScansWithResponse(ctx context.Context, params *GetScansParams, reqEditors ...RequestEditorFn) (*GetScansResponse, error)
@@ -2905,14 +2993,14 @@ type ClientWithResponsesInterface interface {
 	GetScansScanIDWithResponse(ctx context.Context, scanID ScanID, params *GetScansScanIDParams, reqEditors ...RequestEditorFn) (*GetScansScanIDResponse, error)
 
 	// PatchScansScanID request with any body
-	PatchScansScanIDWithBodyWithResponse(ctx context.Context, scanID ScanID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScansScanIDResponse, error)
+	PatchScansScanIDWithBodyWithResponse(ctx context.Context, scanID ScanID, params *PatchScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScansScanIDResponse, error)
 
-	PatchScansScanIDWithResponse(ctx context.Context, scanID ScanID, body PatchScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScansScanIDResponse, error)
+	PatchScansScanIDWithResponse(ctx context.Context, scanID ScanID, params *PatchScansScanIDParams, body PatchScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScansScanIDResponse, error)
 
 	// PutScansScanID request with any body
-	PutScansScanIDWithBodyWithResponse(ctx context.Context, scanID ScanID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error)
+	PutScansScanIDWithBodyWithResponse(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error)
 
-	PutScansScanIDWithResponse(ctx context.Context, scanID ScanID, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error)
+	PutScansScanIDWithResponse(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error)
 
 	// GetTargets request
 	GetTargetsWithResponse(ctx context.Context, params *GetTargetsParams, reqEditors ...RequestEditorFn) (*GetTargetsResponse, error)
@@ -2929,14 +3017,14 @@ type ClientWithResponsesInterface interface {
 	GetTargetsTargetIDWithResponse(ctx context.Context, targetID TargetID, params *GetTargetsTargetIDParams, reqEditors ...RequestEditorFn) (*GetTargetsTargetIDResponse, error)
 
 	// PatchTargetsTargetID request with any body
-	PatchTargetsTargetIDWithBodyWithResponse(ctx context.Context, targetID TargetID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchTargetsTargetIDResponse, error)
+	PatchTargetsTargetIDWithBodyWithResponse(ctx context.Context, targetID TargetID, params *PatchTargetsTargetIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchTargetsTargetIDResponse, error)
 
-	PatchTargetsTargetIDWithResponse(ctx context.Context, targetID TargetID, body PatchTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchTargetsTargetIDResponse, error)
+	PatchTargetsTargetIDWithResponse(ctx context.Context, targetID TargetID, params *PatchTargetsTargetIDParams, body PatchTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchTargetsTargetIDResponse, error)
 
 	// PutTargetsTargetID request with any body
-	PutTargetsTargetIDWithBodyWithResponse(ctx context.Context, targetID TargetID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutTargetsTargetIDResponse, error)
+	PutTargetsTargetIDWithBodyWithResponse(ctx context.Context, targetID TargetID, params *PutTargetsTargetIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutTargetsTargetIDResponse, error)
 
-	PutTargetsTargetIDWithResponse(ctx context.Context, targetID TargetID, body PutTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutTargetsTargetIDResponse, error)
+	PutTargetsTargetIDWithResponse(ctx context.Context, targetID TargetID, params *PutTargetsTargetIDParams, body PutTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutTargetsTargetIDResponse, error)
 }
 
 type GetDiscoveryScopesResponse struct {
@@ -3234,6 +3322,7 @@ type PatchScanConfigsScanConfigIDResponse struct {
 	JSON400      *ApiResponse
 	JSON404      *ApiResponse
 	JSON409      *ScanConfigExists
+	JSON412      *ApiResponse
 	JSONDefault  *ApiResponse
 }
 
@@ -3260,6 +3349,7 @@ type PutScanConfigsScanConfigIDResponse struct {
 	JSON400      *ApiResponse
 	JSON404      *ApiResponse
 	JSON409      *ScanConfigExists
+	JSON412      *ApiResponse
 	JSONDefault  *ApiResponse
 }
 
@@ -3358,6 +3448,7 @@ type PatchScanResultsScanResultIDResponse struct {
 	JSON400      *ApiResponse
 	JSON404      *ApiResponse
 	JSON409      *TargetScanResultExists
+	JSON412      *ApiResponse
 	JSONDefault  *ApiResponse
 }
 
@@ -3384,6 +3475,7 @@ type PutScanResultsScanResultIDResponse struct {
 	JSON400      *ApiResponse
 	JSON404      *ApiResponse
 	JSON409      *TargetScanResultExists
+	JSON412      *ApiResponse
 	JSONDefault  *ApiResponse
 }
 
@@ -3506,6 +3598,7 @@ type PatchScansScanIDResponse struct {
 	JSON400      *ApiResponse
 	JSON404      *ApiResponse
 	JSON409      *ScanExists
+	JSON412      *ApiResponse
 	JSONDefault  *ApiResponse
 }
 
@@ -3532,6 +3625,7 @@ type PutScansScanIDResponse struct {
 	JSON400      *ApiResponse
 	JSON404      *ApiResponse
 	JSON409      *ScanExists
+	JSON412      *ApiResponse
 	JSONDefault  *ApiResponse
 }
 
@@ -3654,6 +3748,7 @@ type PatchTargetsTargetIDResponse struct {
 	JSON200      *Target
 	JSON404      *ApiResponse
 	JSON409      *TargetExists
+	JSON412      *ApiResponse
 	JSONDefault  *ApiResponse
 }
 
@@ -3680,6 +3775,7 @@ type PutTargetsTargetIDResponse struct {
 	JSON400      *ApiResponse
 	JSON404      *ApiResponse
 	JSON409      *TargetExists
+	JSON412      *ApiResponse
 	JSONDefault  *ApiResponse
 }
 
@@ -3848,16 +3944,16 @@ func (c *ClientWithResponses) GetScanConfigsScanConfigIDWithResponse(ctx context
 }
 
 // PatchScanConfigsScanConfigIDWithBodyWithResponse request with arbitrary body returning *PatchScanConfigsScanConfigIDResponse
-func (c *ClientWithResponses) PatchScanConfigsScanConfigIDWithBodyWithResponse(ctx context.Context, scanConfigID ScanConfigID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanConfigsScanConfigIDResponse, error) {
-	rsp, err := c.PatchScanConfigsScanConfigIDWithBody(ctx, scanConfigID, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PatchScanConfigsScanConfigIDWithBodyWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanConfigsScanConfigIDResponse, error) {
+	rsp, err := c.PatchScanConfigsScanConfigIDWithBody(ctx, scanConfigID, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePatchScanConfigsScanConfigIDResponse(rsp)
 }
 
-func (c *ClientWithResponses) PatchScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, body PatchScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanConfigsScanConfigIDResponse, error) {
-	rsp, err := c.PatchScanConfigsScanConfigID(ctx, scanConfigID, body, reqEditors...)
+func (c *ClientWithResponses) PatchScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *PatchScanConfigsScanConfigIDParams, body PatchScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanConfigsScanConfigIDResponse, error) {
+	rsp, err := c.PatchScanConfigsScanConfigID(ctx, scanConfigID, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -3865,16 +3961,16 @@ func (c *ClientWithResponses) PatchScanConfigsScanConfigIDWithResponse(ctx conte
 }
 
 // PutScanConfigsScanConfigIDWithBodyWithResponse request with arbitrary body returning *PutScanConfigsScanConfigIDResponse
-func (c *ClientWithResponses) PutScanConfigsScanConfigIDWithBodyWithResponse(ctx context.Context, scanConfigID ScanConfigID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanConfigsScanConfigIDResponse, error) {
-	rsp, err := c.PutScanConfigsScanConfigIDWithBody(ctx, scanConfigID, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PutScanConfigsScanConfigIDWithBodyWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanConfigsScanConfigIDResponse, error) {
+	rsp, err := c.PutScanConfigsScanConfigIDWithBody(ctx, scanConfigID, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePutScanConfigsScanConfigIDResponse(rsp)
 }
 
-func (c *ClientWithResponses) PutScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanConfigsScanConfigIDResponse, error) {
-	rsp, err := c.PutScanConfigsScanConfigID(ctx, scanConfigID, body, reqEditors...)
+func (c *ClientWithResponses) PutScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanConfigsScanConfigIDResponse, error) {
+	rsp, err := c.PutScanConfigsScanConfigID(ctx, scanConfigID, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -3917,16 +4013,16 @@ func (c *ClientWithResponses) GetScanResultsScanResultIDWithResponse(ctx context
 }
 
 // PatchScanResultsScanResultIDWithBodyWithResponse request with arbitrary body returning *PatchScanResultsScanResultIDResponse
-func (c *ClientWithResponses) PatchScanResultsScanResultIDWithBodyWithResponse(ctx context.Context, scanResultID ScanResultID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanResultsScanResultIDResponse, error) {
-	rsp, err := c.PatchScanResultsScanResultIDWithBody(ctx, scanResultID, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PatchScanResultsScanResultIDWithBodyWithResponse(ctx context.Context, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanResultsScanResultIDResponse, error) {
+	rsp, err := c.PatchScanResultsScanResultIDWithBody(ctx, scanResultID, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePatchScanResultsScanResultIDResponse(rsp)
 }
 
-func (c *ClientWithResponses) PatchScanResultsScanResultIDWithResponse(ctx context.Context, scanResultID ScanResultID, body PatchScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanResultsScanResultIDResponse, error) {
-	rsp, err := c.PatchScanResultsScanResultID(ctx, scanResultID, body, reqEditors...)
+func (c *ClientWithResponses) PatchScanResultsScanResultIDWithResponse(ctx context.Context, scanResultID ScanResultID, params *PatchScanResultsScanResultIDParams, body PatchScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanResultsScanResultIDResponse, error) {
+	rsp, err := c.PatchScanResultsScanResultID(ctx, scanResultID, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -3934,16 +4030,16 @@ func (c *ClientWithResponses) PatchScanResultsScanResultIDWithResponse(ctx conte
 }
 
 // PutScanResultsScanResultIDWithBodyWithResponse request with arbitrary body returning *PutScanResultsScanResultIDResponse
-func (c *ClientWithResponses) PutScanResultsScanResultIDWithBodyWithResponse(ctx context.Context, scanResultID ScanResultID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanResultsScanResultIDResponse, error) {
-	rsp, err := c.PutScanResultsScanResultIDWithBody(ctx, scanResultID, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PutScanResultsScanResultIDWithBodyWithResponse(ctx context.Context, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanResultsScanResultIDResponse, error) {
+	rsp, err := c.PutScanResultsScanResultIDWithBody(ctx, scanResultID, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePutScanResultsScanResultIDResponse(rsp)
 }
 
-func (c *ClientWithResponses) PutScanResultsScanResultIDWithResponse(ctx context.Context, scanResultID ScanResultID, body PutScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanResultsScanResultIDResponse, error) {
-	rsp, err := c.PutScanResultsScanResultID(ctx, scanResultID, body, reqEditors...)
+func (c *ClientWithResponses) PutScanResultsScanResultIDWithResponse(ctx context.Context, scanResultID ScanResultID, params *PutScanResultsScanResultIDParams, body PutScanResultsScanResultIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanResultsScanResultIDResponse, error) {
+	rsp, err := c.PutScanResultsScanResultID(ctx, scanResultID, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -3995,16 +4091,16 @@ func (c *ClientWithResponses) GetScansScanIDWithResponse(ctx context.Context, sc
 }
 
 // PatchScansScanIDWithBodyWithResponse request with arbitrary body returning *PatchScansScanIDResponse
-func (c *ClientWithResponses) PatchScansScanIDWithBodyWithResponse(ctx context.Context, scanID ScanID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScansScanIDResponse, error) {
-	rsp, err := c.PatchScansScanIDWithBody(ctx, scanID, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PatchScansScanIDWithBodyWithResponse(ctx context.Context, scanID ScanID, params *PatchScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScansScanIDResponse, error) {
+	rsp, err := c.PatchScansScanIDWithBody(ctx, scanID, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePatchScansScanIDResponse(rsp)
 }
 
-func (c *ClientWithResponses) PatchScansScanIDWithResponse(ctx context.Context, scanID ScanID, body PatchScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScansScanIDResponse, error) {
-	rsp, err := c.PatchScansScanID(ctx, scanID, body, reqEditors...)
+func (c *ClientWithResponses) PatchScansScanIDWithResponse(ctx context.Context, scanID ScanID, params *PatchScansScanIDParams, body PatchScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScansScanIDResponse, error) {
+	rsp, err := c.PatchScansScanID(ctx, scanID, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -4012,16 +4108,16 @@ func (c *ClientWithResponses) PatchScansScanIDWithResponse(ctx context.Context, 
 }
 
 // PutScansScanIDWithBodyWithResponse request with arbitrary body returning *PutScansScanIDResponse
-func (c *ClientWithResponses) PutScansScanIDWithBodyWithResponse(ctx context.Context, scanID ScanID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error) {
-	rsp, err := c.PutScansScanIDWithBody(ctx, scanID, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PutScansScanIDWithBodyWithResponse(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error) {
+	rsp, err := c.PutScansScanIDWithBody(ctx, scanID, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePutScansScanIDResponse(rsp)
 }
 
-func (c *ClientWithResponses) PutScansScanIDWithResponse(ctx context.Context, scanID ScanID, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error) {
-	rsp, err := c.PutScansScanID(ctx, scanID, body, reqEditors...)
+func (c *ClientWithResponses) PutScansScanIDWithResponse(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error) {
+	rsp, err := c.PutScansScanID(ctx, scanID, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -4073,16 +4169,16 @@ func (c *ClientWithResponses) GetTargetsTargetIDWithResponse(ctx context.Context
 }
 
 // PatchTargetsTargetIDWithBodyWithResponse request with arbitrary body returning *PatchTargetsTargetIDResponse
-func (c *ClientWithResponses) PatchTargetsTargetIDWithBodyWithResponse(ctx context.Context, targetID TargetID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchTargetsTargetIDResponse, error) {
-	rsp, err := c.PatchTargetsTargetIDWithBody(ctx, targetID, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PatchTargetsTargetIDWithBodyWithResponse(ctx context.Context, targetID TargetID, params *PatchTargetsTargetIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchTargetsTargetIDResponse, error) {
+	rsp, err := c.PatchTargetsTargetIDWithBody(ctx, targetID, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePatchTargetsTargetIDResponse(rsp)
 }
 
-func (c *ClientWithResponses) PatchTargetsTargetIDWithResponse(ctx context.Context, targetID TargetID, body PatchTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchTargetsTargetIDResponse, error) {
-	rsp, err := c.PatchTargetsTargetID(ctx, targetID, body, reqEditors...)
+func (c *ClientWithResponses) PatchTargetsTargetIDWithResponse(ctx context.Context, targetID TargetID, params *PatchTargetsTargetIDParams, body PatchTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchTargetsTargetIDResponse, error) {
+	rsp, err := c.PatchTargetsTargetID(ctx, targetID, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -4090,16 +4186,16 @@ func (c *ClientWithResponses) PatchTargetsTargetIDWithResponse(ctx context.Conte
 }
 
 // PutTargetsTargetIDWithBodyWithResponse request with arbitrary body returning *PutTargetsTargetIDResponse
-func (c *ClientWithResponses) PutTargetsTargetIDWithBodyWithResponse(ctx context.Context, targetID TargetID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutTargetsTargetIDResponse, error) {
-	rsp, err := c.PutTargetsTargetIDWithBody(ctx, targetID, contentType, body, reqEditors...)
+func (c *ClientWithResponses) PutTargetsTargetIDWithBodyWithResponse(ctx context.Context, targetID TargetID, params *PutTargetsTargetIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutTargetsTargetIDResponse, error) {
+	rsp, err := c.PutTargetsTargetIDWithBody(ctx, targetID, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParsePutTargetsTargetIDResponse(rsp)
 }
 
-func (c *ClientWithResponses) PutTargetsTargetIDWithResponse(ctx context.Context, targetID TargetID, body PutTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutTargetsTargetIDResponse, error) {
-	rsp, err := c.PutTargetsTargetID(ctx, targetID, body, reqEditors...)
+func (c *ClientWithResponses) PutTargetsTargetIDWithResponse(ctx context.Context, targetID TargetID, params *PutTargetsTargetIDParams, body PutTargetsTargetIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutTargetsTargetIDResponse, error) {
+	rsp, err := c.PutTargetsTargetID(ctx, targetID, params, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -4628,6 +4724,13 @@ func ParsePatchScanConfigsScanConfigIDResponse(rsp *http.Response) (*PatchScanCo
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ApiResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -4681,6 +4784,13 @@ func ParsePutScanConfigsScanConfigIDResponse(rsp *http.Response) (*PutScanConfig
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ApiResponse
@@ -4856,6 +4966,13 @@ func ParsePatchScanResultsScanResultIDResponse(rsp *http.Response) (*PatchScanRe
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ApiResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -4909,6 +5026,13 @@ func ParsePutScanResultsScanResultIDResponse(rsp *http.Response) (*PutScanResult
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ApiResponse
@@ -5124,6 +5248,13 @@ func ParsePatchScansScanIDResponse(rsp *http.Response) (*PatchScansScanIDRespons
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ApiResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -5177,6 +5308,13 @@ func ParsePutScansScanIDResponse(rsp *http.Response) (*PutScansScanIDResponse, e
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ApiResponse
@@ -5392,6 +5530,13 @@ func ParsePatchTargetsTargetIDResponse(rsp *http.Response) (*PatchTargetsTargetI
 		}
 		response.JSON409 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ApiResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -5445,6 +5590,13 @@ func ParsePutTargetsTargetIDResponse(rsp *http.Response) (*PutTargetsTargetIDRes
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
 		var dest ApiResponse

--- a/api/models/models.gen.go
+++ b/api/models/models.gen.go
@@ -378,8 +378,9 @@ type SbomScan struct {
 
 // Scan Describes a multi-target scheduled scan.
 type Scan struct {
-	EndTime *time.Time `json:"endTime,omitempty"`
-	Id      *string    `json:"id,omitempty"`
+	EndTime  *time.Time `json:"endTime,omitempty"`
+	Id       *string    `json:"id,omitempty"`
+	Revision *int       `json:"revision,omitempty"`
 
 	// ScanConfig Describes a relationship to a scan config which can be expanded.
 	ScanConfig *ScanConfigRelationship `json:"scanConfig,omitempty"`
@@ -421,6 +422,7 @@ type ScanConfig struct {
 	// MaxParallelScanners The maximum number of scanners that can run in parallel for each scan
 	MaxParallelScanners *int    `json:"maxParallelScanners,omitempty"`
 	Name                *string `json:"name,omitempty"`
+	Revision            *int    `json:"revision,omitempty"`
 
 	// ScanFamiliesConfig The configuration of the scanner families within a scan config
 	ScanFamiliesConfig *ScanFamiliesConfig `json:"scanFamiliesConfig,omitempty"`
@@ -451,6 +453,7 @@ type ScanConfigRelationship struct {
 	// MaxParallelScanners The maximum number of scanners that can run in parallel for each scan
 	MaxParallelScanners *int    `json:"maxParallelScanners,omitempty"`
 	Name                *string `json:"name,omitempty"`
+	Revision            *int    `json:"revision,omitempty"`
 
 	// ScanFamiliesConfig The configuration of the scanner families within a scan config
 	ScanFamiliesConfig *ScanFamiliesConfig `json:"scanFamiliesConfig,omitempty"`
@@ -529,8 +532,9 @@ type ScanFindingsSummary struct {
 
 // ScanRelationship Describes an expandable relationship to Scan object
 type ScanRelationship struct {
-	EndTime *time.Time `json:"endTime,omitempty"`
-	Id      string     `json:"id"`
+	EndTime  *time.Time `json:"endTime,omitempty"`
+	Id       string     `json:"id"`
+	Revision *int       `json:"revision,omitempty"`
 
 	// ScanConfig Describes a relationship to a scan config which can be expanded.
 	ScanConfig *ScanConfigRelationship `json:"scanConfig,omitempty"`
@@ -690,7 +694,8 @@ type Tag struct {
 
 // Target Describes a target object.
 type Target struct {
-	Id *string `json:"id,omitempty"`
+	Id       *string `json:"id,omitempty"`
+	Revision *int    `json:"revision,omitempty"`
 
 	// ScansCount Total number of scans that have ever run for this target
 	ScansCount *int `json:"scansCount,omitempty"`
@@ -714,7 +719,8 @@ type TargetExists struct {
 
 // TargetRelationship Describes a relationship to a target which can be expanded.
 type TargetRelationship struct {
-	Id string `json:"id"`
+	Id       string `json:"id"`
+	Revision *int   `json:"revision,omitempty"`
 
 	// ScansCount Total number of scans that have ever run for this target
 	ScansCount *int `json:"scansCount,omitempty"`
@@ -731,6 +737,7 @@ type TargetScanResult struct {
 	Id                *string               `json:"id,omitempty"`
 	Malware           *MalwareScan          `json:"malware,omitempty"`
 	Misconfigurations *MisconfigurationScan `json:"misconfigurations,omitempty"`
+	Revision          *int                  `json:"revision,omitempty"`
 	Rootkits          *RootkitScan          `json:"rootkits,omitempty"`
 	Sboms             *SbomScan             `json:"sboms,omitempty"`
 
@@ -903,6 +910,9 @@ type VulnerabilitySeverity string
 // FindingID defines model for findingID.
 type FindingID = string
 
+// Ifmatch defines model for ifmatch.
+type Ifmatch = int
+
 // OdataCount defines model for odataCount.
 type OdataCount = bool
 
@@ -983,6 +993,16 @@ type GetScanConfigsScanConfigIDParams struct {
 	Expand *OdataExpand `form:"$expand,omitempty" json:"$expand,omitempty"`
 }
 
+// PatchScanConfigsScanConfigIDParams defines parameters for PatchScanConfigsScanConfigID.
+type PatchScanConfigsScanConfigIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
+
+// PutScanConfigsScanConfigIDParams defines parameters for PutScanConfigsScanConfigID.
+type PutScanConfigsScanConfigIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
+
 // GetScanResultsParams defines parameters for GetScanResults.
 type GetScanResultsParams struct {
 	Filter  *OdataFilter `form:"$filter,omitempty" json:"$filter,omitempty"`
@@ -998,6 +1018,16 @@ type GetScanResultsParams struct {
 type GetScanResultsScanResultIDParams struct {
 	Select *OdataSelect `form:"$select,omitempty" json:"$select,omitempty"`
 	Expand *OdataExpand `form:"$expand,omitempty" json:"$expand,omitempty"`
+}
+
+// PatchScanResultsScanResultIDParams defines parameters for PatchScanResultsScanResultID.
+type PatchScanResultsScanResultIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
+
+// PutScanResultsScanResultIDParams defines parameters for PutScanResultsScanResultID.
+type PutScanResultsScanResultIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
 }
 
 // GetScansParams defines parameters for GetScans.
@@ -1017,6 +1047,16 @@ type GetScansScanIDParams struct {
 	Expand *OdataExpand `form:"$expand,omitempty" json:"$expand,omitempty"`
 }
 
+// PatchScansScanIDParams defines parameters for PatchScansScanID.
+type PatchScansScanIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
+
+// PutScansScanIDParams defines parameters for PutScansScanID.
+type PutScansScanIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
+
 // GetTargetsParams defines parameters for GetTargets.
 type GetTargetsParams struct {
 	Filter  *OdataFilter `form:"$filter,omitempty" json:"$filter,omitempty"`
@@ -1032,6 +1072,16 @@ type GetTargetsParams struct {
 type GetTargetsTargetIDParams struct {
 	Select *OdataSelect `form:"$select,omitempty" json:"$select,omitempty"`
 	Expand *OdataExpand `form:"$expand,omitempty" json:"$expand,omitempty"`
+}
+
+// PatchTargetsTargetIDParams defines parameters for PatchTargetsTargetID.
+type PatchTargetsTargetIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
+
+// PutTargetsTargetIDParams defines parameters for PutTargetsTargetID.
+type PutTargetsTargetIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
 }
 
 // PutDiscoveryScopesJSONRequestBody defines body for PutDiscoveryScopes for application/json ContentType.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -89,6 +89,7 @@ paths:
       operationId: PutTargetsTargetID
       parameters:
         - $ref: '#/components/parameters/targetID'
+        - $ref: '#/components/parameters/ifmatch'
       requestBody:
         content:
           application/json:
@@ -120,6 +121,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TargetExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         default:
           $ref: '#/components/responses/UnknownError'
       x-codegen-request-body-name: body
@@ -128,6 +135,7 @@ paths:
       operationId: PatchTargetsTargetID
       parameters:
         - $ref: '#/components/parameters/targetID'
+        - $ref: '#/components/parameters/ifmatch'
       requestBody:
         content:
           application/json:
@@ -153,6 +161,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TargetExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         default:
           $ref: '#/components/responses/UnknownError'
       x-codegen-request-body-name: body
@@ -261,6 +275,7 @@ paths:
       operationId: PutScanResultsScanResultID
       parameters:
         - $ref: '#/components/parameters/scanResultID'
+        - $ref: '#/components/parameters/ifmatch'
       requestBody:
         content:
           application/json:
@@ -292,6 +307,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TargetScanResultExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         default:
           $ref: '#/components/responses/UnknownError'
       x-codegen-request-body-name: body
@@ -300,6 +321,7 @@ paths:
       operationId: PatchScanResultsScanResultID
       parameters:
         - $ref: '#/components/parameters/scanResultID'
+        - $ref: '#/components/parameters/ifmatch'
       requestBody:
         content:
           application/json:
@@ -331,6 +353,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TargetScanResultExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         default:
           $ref: '#/components/responses/UnknownError'
       x-codegen-request-body-name: body
@@ -416,6 +444,7 @@ paths:
       operationId: PutScansScanID
       parameters:
         - $ref: '#/components/parameters/scanID'
+        - $ref: '#/components/parameters/ifmatch'
       requestBody:
         content:
           application/json:
@@ -447,6 +476,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScanExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         default:
           $ref: '#/components/responses/UnknownError'
       x-codegen-request-body-name: body
@@ -455,6 +490,7 @@ paths:
       operationId: PatchScansScanID
       parameters:
         - $ref: '#/components/parameters/scanID'
+        - $ref: '#/components/parameters/ifmatch'
       requestBody:
         content:
           application/json:
@@ -486,6 +522,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScanExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         default:
           $ref: '#/components/responses/UnknownError'
       x-codegen-request-body-name: body
@@ -588,6 +630,7 @@ paths:
       operationId: PutScanConfigsScanConfigID
       parameters:
         - $ref: '#/components/parameters/scanConfigID'
+        - $ref: '#/components/parameters/ifmatch'
       requestBody:
         content:
           application/json:
@@ -619,6 +662,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScanConfigExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         default:
           $ref: '#/components/responses/UnknownError'
       x-codegen-request-body-name: body
@@ -627,6 +676,7 @@ paths:
       operationId: PatchScanConfigsScanConfigID
       parameters:
         - $ref: '#/components/parameters/scanConfigID'
+        - $ref: '#/components/parameters/ifmatch'
       requestBody:
         content:
           application/json:
@@ -658,6 +708,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ScanConfigExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
         default:
           $ref: '#/components/responses/UnknownError'
       x-codegen-request-body-name: body
@@ -918,6 +974,9 @@ components:
       properties:
         id:
           type: string
+        revision:
+          type: integer
+          readOnly: true
         startTime:
           type: string
           format: date-time
@@ -989,6 +1048,8 @@ components:
           # on the client side.
           #
           # readOnly: true
+        revision:
+          type: integer
         startTime:
           type: string
           format: date-time
@@ -1208,6 +1269,9 @@ components:
       properties:
         id:
           type: string
+        revision:
+          type: integer
+          readOnly: true
         name:
           type: string
           readOnly: true
@@ -1243,6 +1307,8 @@ components:
       properties:
         id:
           type: string
+        revision:
+          type: integer
         name:
           type: string
         scanFamiliesConfig:
@@ -1466,6 +1532,17 @@ components:
           # on the client side.
           #
           # readOnly: true
+        revision:
+          type: integer
+          # TODO(sambetts) Decide if we want the validation here by having
+          # separate schemas for GET, POST and PATCH.
+          #
+          # We can't make anything readOnly or required here if we want to
+          # use the same schema for PATCH otherwise it will require you
+          # always send the required fields and remove the readOnly fields
+          # on the client side.
+          #
+          # readOnly: true
         targetInfo:
           $ref: '#/components/schemas/TargetType'
         scansCount:
@@ -1480,6 +1557,9 @@ components:
       properties:
         id:
           type: string
+        revision:
+          type: integer
+          readOnly: true
         targetInfo:
           $ref: '#/components/schemas/TargetType'
           readOnly: true
@@ -1607,6 +1687,8 @@ components:
           # on the client side.
           #
           # readOnly: true
+        revision:
+          type: integer
         target:
           $ref: '#/components/schemas/TargetRelationship'
         scan:
@@ -2250,3 +2332,8 @@ components:
       schema:
         type: string
         
+    ifmatch:
+      name: If-Match
+      in: header
+      schema:
+        type: integer

--- a/api/server/server.gen.go
+++ b/api/server/server.gen.go
@@ -59,10 +59,10 @@ type ServerInterface interface {
 	GetScanConfigsScanConfigID(ctx echo.Context, scanConfigID ScanConfigID, params GetScanConfigsScanConfigIDParams) error
 	// Patch a scan config.
 	// (PATCH /scanConfigs/{scanConfigID})
-	PatchScanConfigsScanConfigID(ctx echo.Context, scanConfigID ScanConfigID) error
+	PatchScanConfigsScanConfigID(ctx echo.Context, scanConfigID ScanConfigID, params PatchScanConfigsScanConfigIDParams) error
 	// Update a scan config.
 	// (PUT /scanConfigs/{scanConfigID})
-	PutScanConfigsScanConfigID(ctx echo.Context, scanConfigID ScanConfigID) error
+	PutScanConfigsScanConfigID(ctx echo.Context, scanConfigID ScanConfigID, params PutScanConfigsScanConfigIDParams) error
 	// Get scan results according to the given filters
 	// (GET /scanResults)
 	GetScanResults(ctx echo.Context, params GetScanResultsParams) error
@@ -74,10 +74,10 @@ type ServerInterface interface {
 	GetScanResultsScanResultID(ctx echo.Context, scanResultID ScanResultID, params GetScanResultsScanResultIDParams) error
 	// Patch a scan result
 	// (PATCH /scanResults/{scanResultID})
-	PatchScanResultsScanResultID(ctx echo.Context, scanResultID ScanResultID) error
+	PatchScanResultsScanResultID(ctx echo.Context, scanResultID ScanResultID, params PatchScanResultsScanResultIDParams) error
 	// Update a scan result.
 	// (PUT /scanResults/{scanResultID})
-	PutScanResultsScanResultID(ctx echo.Context, scanResultID ScanResultID) error
+	PutScanResultsScanResultID(ctx echo.Context, scanResultID ScanResultID, params PutScanResultsScanResultIDParams) error
 	// Get all scans. Each scan contains details about a multi-target scheduled scan.
 	// (GET /scans)
 	GetScans(ctx echo.Context, params GetScansParams) error
@@ -92,10 +92,10 @@ type ServerInterface interface {
 	GetScansScanID(ctx echo.Context, scanID ScanID, params GetScansScanIDParams) error
 	// Patch a scan.
 	// (PATCH /scans/{scanID})
-	PatchScansScanID(ctx echo.Context, scanID ScanID) error
+	PatchScansScanID(ctx echo.Context, scanID ScanID, params PatchScansScanIDParams) error
 	// Update a scan.
 	// (PUT /scans/{scanID})
-	PutScansScanID(ctx echo.Context, scanID ScanID) error
+	PutScansScanID(ctx echo.Context, scanID ScanID, params PutScansScanIDParams) error
 	// Get targets
 	// (GET /targets)
 	GetTargets(ctx echo.Context, params GetTargetsParams) error
@@ -110,10 +110,10 @@ type ServerInterface interface {
 	GetTargetsTargetID(ctx echo.Context, targetID TargetID, params GetTargetsTargetIDParams) error
 	// Update target.
 	// (PATCH /targets/{targetID})
-	PatchTargetsTargetID(ctx echo.Context, targetID TargetID) error
+	PatchTargetsTargetID(ctx echo.Context, targetID TargetID, params PatchTargetsTargetIDParams) error
 	// Update target.
 	// (PUT /targets/{targetID})
-	PutTargetsTargetID(ctx echo.Context, targetID TargetID) error
+	PutTargetsTargetID(ctx echo.Context, targetID TargetID, params PutTargetsTargetIDParams) error
 }
 
 // ServerInterfaceWrapper converts echo contexts to parameters.
@@ -439,8 +439,28 @@ func (w *ServerInterfaceWrapper) PatchScanConfigsScanConfigID(ctx echo.Context) 
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanConfigID: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PatchScanConfigsScanConfigIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PatchScanConfigsScanConfigID(ctx, scanConfigID)
+	err = w.Handler.PatchScanConfigsScanConfigID(ctx, scanConfigID, params)
 	return err
 }
 
@@ -455,8 +475,28 @@ func (w *ServerInterfaceWrapper) PutScanConfigsScanConfigID(ctx echo.Context) er
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanConfigID: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PutScanConfigsScanConfigIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PutScanConfigsScanConfigID(ctx, scanConfigID)
+	err = w.Handler.PutScanConfigsScanConfigID(ctx, scanConfigID, params)
 	return err
 }
 
@@ -572,8 +612,28 @@ func (w *ServerInterfaceWrapper) PatchScanResultsScanResultID(ctx echo.Context) 
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanResultID: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PatchScanResultsScanResultIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PatchScanResultsScanResultID(ctx, scanResultID)
+	err = w.Handler.PatchScanResultsScanResultID(ctx, scanResultID, params)
 	return err
 }
 
@@ -588,8 +648,28 @@ func (w *ServerInterfaceWrapper) PutScanResultsScanResultID(ctx echo.Context) er
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanResultID: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PutScanResultsScanResultIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PutScanResultsScanResultID(ctx, scanResultID)
+	err = w.Handler.PutScanResultsScanResultID(ctx, scanResultID, params)
 	return err
 }
 
@@ -721,8 +801,28 @@ func (w *ServerInterfaceWrapper) PatchScansScanID(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanID: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PatchScansScanIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PatchScansScanID(ctx, scanID)
+	err = w.Handler.PatchScansScanID(ctx, scanID, params)
 	return err
 }
 
@@ -737,8 +837,28 @@ func (w *ServerInterfaceWrapper) PutScansScanID(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanID: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PutScansScanIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PutScansScanID(ctx, scanID)
+	err = w.Handler.PutScansScanID(ctx, scanID, params)
 	return err
 }
 
@@ -870,8 +990,28 @@ func (w *ServerInterfaceWrapper) PatchTargetsTargetID(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter targetID: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PatchTargetsTargetIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PatchTargetsTargetID(ctx, targetID)
+	err = w.Handler.PatchTargetsTargetID(ctx, targetID, params)
 	return err
 }
 
@@ -886,8 +1026,28 @@ func (w *ServerInterfaceWrapper) PutTargetsTargetID(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter targetID: %s", err))
 	}
 
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PutTargetsTargetIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
 	// Invoke the callback with all the unmarshalled arguments
-	err = w.Handler.PutTargetsTargetID(ctx, targetID)
+	err = w.Handler.PutTargetsTargetID(ctx, targetID, params)
 	return err
 }
 
@@ -956,99 +1116,101 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+w9a2/buJZ/hdBeYO+9UJN2dvbD5lvquK0xecF22724MxjQEm1zKpEakkriLfrfF3zp",
-	"SVqSYztpJ98Skzwkz/scHlJfg4imGSWICB6cfQ0yyGCKBGLqvyUmMSaryYX8B5PgLMigWAdhQGCKgrNK",
-	"exgw9GeOGYqDM8FyFAY8WqMUyoFik8nOXDBMVsG3b2FAYyjgiOZEFID/zBHblJD/FqlWB5gFpQmCpIQz",
-	"fsggib2AkG7usaB3OBGIeQEtdXMPQDcsRuztxguJyvbFZhuoMHh4taKvzAgL0E4wQwmK/LjjurnHSmdf",
-	"cOYHIxsdQDARaIVYCWVO/UAE7YTBI0hGlCyxn9FqXYbxmhy6Fe5OEKeI54nYCrfoMgy6gGyF/JCL5iFQ",
-	"v8nOPKOEIyXXszyKEFd/RpQIpOUQZlmCIygwJad/cErkbyXMvzG0DM6C/zgtFcapbuWnBt7UzKFnjBGP",
-	"GM4kuODMTglSxDlcIcnKH8kXQu/JmDHK9raU8wxvW4aZEyA1qaamGijhVseefW2MPCeALv5AkQBiDQXA",
-	"HDAkckZQDDABMElABDnigC7BEuIkZ4ifBGGQMZohJrBGvN392deAIRjfkGRjqefgBP2LnlUi7Pyen0dK",
-	"Mc4imrnW+HkGooTmMYC6H+CqY3MZGuR8o2G0VA9DK0yJ6okFSnknzu/5VA2Rg0meJHCRoMa+IGNwE2hO",
-	"tGz77+pCfnNv2ACWPBHHWO4TJreVzSxhwlHowIPeRGvrWoy+Bikml4isxDo4exO2UXCXRYP2/+l2NHjz",
-	"aimebc8iSAoiD9j5fI00zSUfQhApnZkzFAOpktoMCZNkWlK7IbIR1Ixt+CEEeAk4EuAeJwmgd4gxHCMA",
-	"yUasMVmpJkxsbzlX02SHASZcQBKhOVyNH6Ik54a49Zk/XQHbkevZCBVggdQmlMQtgVijjdyfgEb8qPqN",
-	"IyDgioO/oztEin4pFNEaVCbXFpSyf5yAyRKgNBObUE0i4Bc5jghqZUhupBcbzOGqmwdqKLCr6IOBIbs/",
-	"/qaeTqOEAV/TPImVxAiaZSieWMx53MZhGmiGopxhsXnPaJ7toIi4GQ9WCkBTAnHcqY4aS8axb6lSCw1f",
-	"oBy1w6rCgFcxM4i4dZwOVZweBIyk5btl9A7H2o1HJE9l//PPs8qAcv0XmE3Ikqq4p7b7GLNrYydagxKq",
-	"/RJn41YxGMZ544csoVi0FxfdIe0dtmavkdbRTnx74jRnEbp462wUWCTuYTlL6lRvz9hFVt+235nI0pAH",
-	"JsnNMjj793bGsij7Fn4d4vAMocsWSkkF1KYW0o39paPcxO7Y4zpWcqyGSHixRy+2wBkqtOFAzpHoNh0y",
-	"VJmiRMkLX2Ml6csGZcmmB2VvYfQFrlCVKySRtw35lCcEMbjACRabIQOvYHIP2aC5ZihiSAyaBHPrmyns",
-	"DBk7pVR8wYOmc0iVZOUYS4WRYgKNE5LCLDMEL/RPb4hhYFA3ALNh0MTELhgLA8MgA/gnDAweB6A5DDSl",
-	"+/NBGNT4cAdmtZK30Rapqp6kzC5pTuIbhw/9eY0IEGvMgZE4cA85kBSXnjuKwWIDoHIpAwmFpVBuK4YC",
-	"vRI4RYHDXuLYqeQxuYMJliMHLKQySK+EoHvEhq2HG427VTRVJqaqgrYouvED5iYPWlN3y1IPbpvLqstv",
-	"YTXQr2PjQv23kF79GkdrkBP8Z46kK88Fg5gIENF0ISUSUwIimHPEpWevQrkER8pz3yF3YNbm2Fxk87CN",
-	"SJIKmFiScaDTCTJ6YIqGgqpVrbAMs3RqlJc0KtJ7lSijDv4Sc6FyJXaCTtC9rGeFBN3WslBXTZSkusHr",
-	"A5p260/0sCZaXkOdzGsh4xaKtYng5IaRTjGZ8I4DM13Qi9Bmwj15AA6V3dsds+g9sjtmpnW7Y2lJ8l78",
-	"VO6hMwxNkYAxFLA37JkK59mVHbeTx3dVZ8UWq7bN61d/TtIRt6coxv54x2Qkbg1Xe9r9wRRHd4gpuzjM",
-	"XZrZcRIliIsRFGhF2cYdwCAuLjpCI9nHGVU5cb7FFekvHU3CHFtMmih1y0ujV/84xrG/7kyOZpe9B5Ve",
-	"9qkkCZp9PuDVuujXBnGFYpynWzpc0vui1ZV8aPbfV8xWeMItO5+hRyE2DBJIVrlPVSQ4QvZ8afcpvCmK",
-	"LGeJW3J9mu8OMe4W9y1o20mULcqPLMG3NHanr3ZPUYVBRmOPth6WviqCq0HmRg/ymgvT3sfvmla6Ognu",
-	"CO96E9xu7sgEN9O6NbXBTX8FXW5iB406rVOiUKLjq5vpv4Iw+GU8vR5fBmFwfnt7ORmdzyc310EYvJtM",
-	"rz6fT8dBGHy8/uX65vO1Uzca6PtSidOcyBByFq1RnCfKMywhD0iWGziAG0AqWgU1La5OXihJNkDCUj/N",
-	"5RDMAUciBFgUpzkQcExWFoqFGYMlZSoQqAEo4UaMkktMSpAqOMwZQ0QAtTw7gWz4NVgymqrffw1kZMUF",
-	"ZEI1mRllxNWKvewkatoFldFJbTuQxOVCIEPlSpaYcaG3pNbBcgKgcAxvbbG2bg1GbUfFQtVFFR3Rcoki",
-	"ge8QkJuUgXGKSZWKb5rHGhZEOwQbMVoSAaCHjCHO7TkmeoBpJsUj+G/wM/gn+Cd448pH1LbjiKjXCBD0",
-	"UGwLc1CyItCnWEAwvFohZlIzJz1zIS6un729udqTAM0WNHVrnUybvv5ap7SVO2gduwZfSgWCNE8EfqWL",
-	"ZCoy5T78RiS2lHpUAozXFEpXyKd7NtPiJYwZgRlfU9EfVjFCwpHyPWxXXEDhYdcEL1G0iaSSkp10jkIq",
-	"HoNPq/dvkU67hMFFkWAMwmAipXElJUlaggVlQv38DuJE/XFBCXIaADXblS+H9iFPIXnFEIwl+9iSIiAt",
-	"uXR8yArESECccAAXNNfKI4FSLalNCAYJVzr/xIuOKYLcVZlwBaM1JqiYPAQfswyxEUxRMoIcASEFvLIS",
-	"OTdTwArFHlGiTc5/cr2s+oKKU8sCX5Kc8U0ugjC4IeiGXVGG9OGKxuScznTa1CJ/U2D4I0EPGYo0nGuq",
-	"CjWK7rYMzEmBPE0h2/RhwpnpWile25LwM7I5ueBas0vroX8ztk8FgcoqcZBJY1VlumoecA+BYd0V2Emt",
-	"GPvf1i4x5oWSrUPGS6AWaMxwAUOadDtK2UhCjXOgbYO0pcqcY+Eurok92cqHW8hgkqBkVgmwY7SEeSKC",
-	"s59cRUQpfMBpngKSpwvEJA1scG6Sk5Co9WAiiaSAK+ohGK0tpQyM4Oyn18o063/euLLE/qPpCJJ3MMUJ",
-	"Rry/jm2MKFMLtjRkxJBSv/1B+gebIkLFEp1Ot9cVVVBod2BTVIb5Q5sSqu9A40mPJ3YzmF1brRnUrcLM",
-	"Kj2lwwtrMqj3LX9YKD8QkhjFx5duDw4fIe1HlXDP8h0S34tZXjTAVg3Qozhq5vQvGwWfpsUeRdUiW82b",
-	"8udK0GKERWIDqZDuVyLRHAJODROtIVkhLpmoMTSmqjQRqhhONSKprDBZ/apy0Se/kmdgUp+HNL3YyyPZ",
-	"y6HH41VO63lC3q0ZO07MK3N2nZorjs/gCp0ANTpRxZwgzbmqpk7ovWRVBtCfOUwkBNl3hv8P9S4PrhPE",
-	"s7cOB/wZOyl9tu/fWFsO23qjrmON4jXCB5YGALjHMnKreyrtdEal1LBHMVhF2Cun4j0OwyvjXKeDQw4F",
-	"K2uo5q97pK2rqmpB005ClckwXbjMUPdUupyrMtNdpUzLIL1vCWJFuXrZxZTCzMrQu1GsDUxUXuWTooKm",
-	"7aMKqaPGFa5o6xrVpVIH4+vhIrSn720lJejpMq3Q2tNlVpLI0+PT7sTY1NIWPnr0jiiIiRNUNqoZXahb",
-	"NAbw0ARkp476IRKS3Zr4yROU/ZZ4nIRlv7X81RKY3Vj5ARKanf5Vz0Cw9Id7V+DX7iR21Y7XLzD2Abi1",
-	"zNm3i5Ki/Y7tXUa2fYT/B13wEU2zRBLQbX9kl0u0FHM6zYnnVnv7PL/DmGdGE+mbm9q0UwYw0UpTHVGD",
-	"LGcZ5YifWCQ0T+CloxOEwaePl9fj6fnbyeVk/q8gDK7OL825+2w8mo7n8qfJbHRz/W7y/uPUHs9Pb27m",
-	"v0xk4/h/by9vJnPn0cCsKzRsnKw2PVzr3doLju1b0vDhluHIV5Io2OYKPpwLgdLM5yHkHM0yKobcBGwN",
-	"8UlPtWazFbR0Vjzq9ll/bVTp7XVV6hDrK7qAAk4RdHsKslEDcLePyQoT9MlbSiVN6FKp53c48fl8vxB6",
-	"Tz5hlnNfD7OEC8zUfVjc0W/LXLOcZ13rkeZoDr+gvrVhctZdMgP8qDmB55EM2DUNsItBqj2G0MMm1R9P",
-	"6Al2uGWiptCyeZte/l5cwNm0tJ7KZtk6tO1o3p7NMleUWpdaO0qgEYlHNMlT4hYaRGJbOdNuXOIE3Tqv",
-	"Nkik1a42mFsN1rXUobjrHH6JyQqxjGGXkF1Tgc60F4W5SiTrJJDnQJ+JbVtTHXyb86N4p9JBQ50jVw7q",
-	"Wd0lPJVkSD8ptzvY5by9llF5dFnSI27mrxBBDCbmuZRj3dFvPpQz8JWZ4oUZbl7TUZ10DyUFMjra96sz",
-	"c7ja4VEBAdsJyi/IfUHjDiZ5D66Xw23n35wLlUHX9rNfE6zpQSceQjudNj7aZu7rxz6GMGt4hwC6Q0wf",
-	"M6noGXOzBudluQFBajuQscFqDxOiUeW3Ibp9RNO0ZiyaHZ5p5l4UjNCNg237f0xJgWG0ntUEx+W7bnfz",
-	"ifiwhwbVI2bF+2rbX1zocQxinVabRr9lVKpWtxXaUnUx5ATFzvno85PC4x52eGKH8QXtYe9t8e/ON64H",
-	"HrgUkwkoct6PhfTrP6r/nth3t9ct7h55KLFNHZVM/6z1bl02+5HO9O+1+Z3O6JkeetxDejvpU8flbTzv",
-	"EqPXBc1xwVC9qfjoK4ZczIvThB3r2G0u9Ppm/vtsdH59Pb4IwmByrTKb5/P5+eiD+eX32+nN++l4NpMN",
-	"b2+mc/X7xc312JH57EZKznc3R030fgttjLLDyJ7myDVyqElywOhrjRxD+5zlu4b1sy+OkQMVdguCnymG",
-	"pbM+XfV6yMfe+ezqZ58268qKFU+gbQdTuWy6fV1hYDbStc2BWTWN0qGqXxskh9Y/hMq3k5lSxyfR8btp",
-	"dkuyJm5x6ruoa49uPA/R2ebqY3zbFl9/ua/6RqbvmnICcxKth9mHR12LTqCQs3hesdjpHcSBjyBK/2rV",
-	"H3qvhzv9ecUajSu4a9AmNExSwVCNOK4Qzl0W9dhkYOOdrfaribw/7mqwRnJkD+p05ddjzAWjg6a+0ENU",
-	"dPowaOQ7/KDFZIPYJPY82EC+PNJby8q3Jnre+cy8L8X0fAmmHjFVnoGpGvKN/wmD7XwzMlzSDKsEw9Fw",
-	"rrky49RjFPad30e+U+GdpLXqBeRoFtFaXZ9OF6njHO2WFqGnrx9OMxgJX3vnCi8Kpm8EpOp3kGmdz6tV",
-	"DqYGCoIYCXWSCy4xyR+Akh+8yG2ZUX23k4tL/MUR+UpTPLn4/XLyyxgsMUpioF7MsxW1svkUieiU8lcM",
-	"JQhyfUz1iHuGZXG+/ySsvSOXwapwRuN1aN3ghwb+nsI/qHIp1B8nKSaUAQPwH/0ukHsfJex92FXXyUc+",
-	"82rpw/bJlw0YfZjf+0NE7XxPa1GOgGS4zdrT6vpVIpc56MbajahliAGr3j1FyiOGBY6cNb2e6t8PeLXu",
-	"3/uS3vfvrJ926t//Gq0SvMKLBPUY0413x9tUo+lkPhmdXwZh8GHy/kMQBlfji8nHqyAMLm8+B2FwPX5/",
-	"OXk/eXvpzFsoh1rLrXnMOfh0NUqgOvE8v53I8KfQNcGbk9cnr81zFgRmODgL/uvk9cmbQFtvtavToozh",
-	"lBf1DiZpWryCIf2O4D0SRVGnKY0Ia18Z8qiQsstp9eM8vri32d18Iadv9+IDO781vpTy0+vX+/tKit6+",
-	"/+Mo2os0t7LdsIrFnda+nvKtmvSWOFffBIB3ECsVAAyR1DtaDiLd5g4iSeWLuHhL481BUFD/fM23J0H8",
-	"eZIY3IB7pJ+xsWfryzxJNvuiyMxHkTB4eBXRGK0QeWUQ/mpB44398pP8W8E6XVYecPVJWvHI6zMUMX2M",
-	"2bf3nGb9F/IF9+9svhb2rBRDQbbjqYby0pB68427lALlVYY6hDooXuvtow/eHGbapmND0H3toWpzuVkh",
-	"6uc9Er3jQ1UT/T52sRSey5mKdfzPvpFhjhQdKzEdKkeBe+JFVTiOALR73EEZnn4tPkH4TXupCdIufZ2X",
-	"L9TvlpvfVT5bOExPlh889CmE7dioSPPPr38+Fi9ZCk4uVKWk8sr3RUSN2ZKIJ/rgart92gsBDmOmrH04",
-	"gr7vUPc/CINIiyPWqLjhtqSswS0ZFNHaYX/kz/sX2Se2YkfhIoU6VDUepUv7zAzZD8HjCt9Vru5nyfzR",
-	"2Avb78L2HzP9PZEXtj8O22t8D+d76cHx+psrPo+h+jTLS1D7PQW1VcodL66tPo7TEdvWWesw2a7K43VH",
-	"jXCbM7uC3Nqjd08f6FaXc7Bgt/UyooszKwuBCUMw3uinyfj+I9/6cz476M7Tr9VPo/eIgStcP6t/VH2Y",
-	"cq19kf17Coar5D1oQFx7HHZLUHwYiny/0fF23fVjMo07SG5y0LZA+YBy/fSG8VjMZePmui16+iBii218",
-	"FiLwA5poG9I3nvh+XFj/IqR7EFIb5b8I6V9eSIsExA5Sah3pyqWybR6a7faShPiekhDtu4PHSUUMuP7X",
-	"naQoWe8Qat5xCfOoqQr3/I3SWXRfYFPV6cA4RrFFp7lqb3zmDEV4iSPzAuQTmgK94MPlMjyXgn2auODG",
-	"qirWjwNo/EESl0jbf5bDoKNBJT/tdlPjOh+i/zH5kB5afVYZs5MzVgz+juPuPoL4hNG34Z9DRd81Lu0V",
-	"be+fd357Thr+uIw1t59Wqmgqpekze5Rt3p79rpT9s5CQv5TNqYXtevq9RO0vwr5HYbcRPGzIzjOJ4V9k",
-	"+XnIcj26t5Z5mFvYGde/RPTfX1nBsQsK+AkY28802fdLeePJ/o5Pz3YG+YesQXiK6oOOuoPnUnBw0EqD",
-	"Do166OKCLQw5VIvqsLp3gYHyk3b0kL7HcoKD1xF0FhA8FuPfd7nAM0tVHK9CQGeSOy1PRyZjL+L6lKbr",
-	"8NxUqwx4NpHKk4Yohz5ffBrrWU0g7OfA/0W6OqWrdqT/Il0/rnTVQvohsbwo3//zuUH2icCXeP77O6E/",
-	"VkRv2WhrOF4y0uEStE9zyu4Pyu1z9U8flls39rDH5n71Z06iDhucF0/xD9R/p1/tBwl7ROKGj+dmxGDF",
-	"aKfaRzz+TNjoaDZ8bj8KebDEgN7g1sTA/hjge69qeD4JggMyRmngOqP+PauGp7WSx2AWG6EUaqUVozw1",
-	"B/04NtIECZaVHxuDv/D63nn9xZq/iJxeJEfszspRzpLgLDiFGQ6+/fbt/wMAAP//ju1RxVq6AAA=",
+	"H4sIAAAAAAAC/+w9aXPbuJJ/BcV9Ve8oxk5mZz+svzmyklGNr5KUZF+9mXoFk5CECQlwANC2NpX/voWL",
+	"4gUSlHXYWX+zBaABdDf6QqP5LYhomlGCiODB2bcggwymSCCm/ltgEmOynFzIfzAJzoIMilUQBgSmKDgr",
+	"tYcBQ3/mmKE4OBMsR2HAoxVKoRwo1pnszAXDZBl8/x4GeJFCEa0KqCsEY8Q2cCeLN1eqQwsYTARaIqbg",
+	"0BgKOKI5EQWoP3PE1htIf4lUawucO0oTBMkGzvgxgyR2AkK6uXtjCtAHnAjEnIAWutkD0A2LEXu/dkKi",
+	"sv1u3QUqDB7fLOkbM8ICtBPMUIIiN+64bvZY6ewrztxgZKMPJefUDUTQXhg8gmREyQK7GbbSZRjPyqGd",
+	"cLeCOEU8T0Qn3KLLMOgCsiVyQy6ah0D9LjvzjBKOlHyY5VGEuPozokQgfQ5hliU4ggJTcvoHp0T+toH5",
+	"F4YWwVnwH6cbwXOqW/mpgTc1c+gZY8QjhjMJLjizU4IUcQ6XSLLyJ/KV0AcyZoyynS3lPMNdyzBzAqQm",
+	"1dRUAyXc8tizb7WR5wTQuz9QJIBYQQEwBwyJnBEUA0wATBIQQY44oAuwgDjJGeInQRhkjGaICawRb3d/",
+	"9i1gCMY3JFlb6rVwgv5FzyoRdv7AzyMlGGcRzdrW+GUGooTmMYC6H+CqY30ZGuR8rWE0RA9DS0yJ6okF",
+	"Snkvzh/4VA2Rg0meJPAuQbV9QcbgOtCcaNn2X+WF/N6+YQNY8kQcY7lPmNyWNrOACUdhCx70Jhpb18fo",
+	"W5BiconIUqyCs3dhEwX3WTRo/59vR4M3r5bi2PYsgqQg8oCdz1dI01zyIQSRkpk5QzGQIqnJkDBJphtq",
+	"145sBDVjG34IAV4AjgR4wEkC6D1iDMcIQLIWK0yWqgkT21vOVVfZYYAJF5BEaA6X48coybkhbnXmz1fA",
+	"duR6NkIFuENqE+rELYBYobXcn4Dm+FH1G0dAwCUHf0P3iBT9lNkCSpNrDUrZ30/AZAFQmol1qCYR8Ksc",
+	"RwS1Z0huxIsN5nDZzwMVFNhV+GBgyO4Pv6njSZQw4CuaJ7E6MYJmGYonFnMOs3GYBJqhKGdYrD8ymmdb",
+	"CCJuxoOlAlA/gTjuFUe1JePYtVQphYYvUI7aYlVhwMuYGUTcKk6HCk4HAkZS890yeo9jbcYjkqey//mX",
+	"WWnAZv0XmE3Igir/qbL7GLNroycagxKq7ZLWxs5jMIzzxo9ZQrFoLi66R9o6bMxeIW1LO3HtidOcReji",
+	"fWujwCJpH5azpEr15ox9ZHVt+4PxUA15YJLcLIKzf3UzlkXZ9/DbEINnCF06KCUFUJNaSDf6n47NJrbH",
+	"Hte+UstqiIQXO+RiA5yhQhMO5ByJftUhXZUpStR54SusTvqiRlmy9qDsLYy+wiUqc4UkcteQz3lCEIN3",
+	"OMFiPWTgFUweIBs01wxFDIlBk2BubTOFnSFjp5SKr3jQdC2nSrJyjKXASDGBxghJYZYZghfyxxtiGBjU",
+	"DcBsGNQxsQ3GwsAwyAD+CQODxwFoDgNNaX8+CIMKH27BrPbkrbVGKosneWYXNCfxTYsN/WWFCBArzIE5",
+	"ceABciApLi13FIO7NYDKpAwkFJZCua0YCvRG4BQFLfoSx61CHpN7mGA5csBCSoP0Sgh6QGzYeriRuJ1H",
+	"U0ViyiKoQ9CNHzE38dSKuFts5GDXXFZcfg/Ljn4VGxfqvztp1a9wtAI5wX/mSJryXDCIiQARTe/kicSU",
+	"gAjmHHFp2StXLsGRsty3iB2YtbVsLrJx2JonSQVMLMk40OEE6T0wRUNB1aqWWLpZOjTKNzQqwnslL6MK",
+	"/hJzoWIldoJe0F7as0SCfm1ZiKs6SlLd4LQBTbu1Jzy0iT6voQ7mNZBxC8XKeHByw0iHmIx7x4GZLvAi",
+	"tJlwRxZAi8j2Nscseg9sjplp282xdENyL37a7KHXDU2RgDEU0Bv2TLnz7MqO28riu6qyYoNVm+r1mzsm",
+	"2eK3pyjGbn/HRCRuDVc72t3OFEf3iCm9OMxcmtlxEiWIixEUaEnZut2BQVxc9LhGsk+rV9WK8w5TxP90",
+	"1Alz6GNSR2n7ean18vdjWvbXH8nR7LJzp9LJPqUgQb3PL3i5Kvo1QVyhGOdpR4dL+lC0tgUf6v135bMV",
+	"lnBDz2foSYgNgwSSZe4SFQmOkL1f2n4KZ4giy1nSfnJdku8eMd5+3DvQttVRtig/8Am+pXF7+Gr7EFUY",
+	"ZDR2SOth4avCuRqkbvQgp7ow7T5217TUtZXgLe6dN8Ht5g5McDNtu6Q2uPEX0JtNbCFRp1VKFEJ0fHUz",
+	"/WcQBr+Op9fjyyAMzm9vLyej8/nk5joIgw+T6dWX8+k4CINP179e33y5bpWNBvquROI0J9KFnEUrFOeJ",
+	"sgw3kAcEyw0cwA0g5a2CihRXNy+UJGsgYamf5nII5oAjEQIsitscCDgmSwvFwozBgjLlCFQAbOBGjJJL",
+	"TDYglXOYM4aIAGp5dgLZ8FuwYDRVv/8WSM+KC8iEajIzSo+r4XvZSdS0d1R6J5XtQBJvFgIZ2qxkgRkX",
+	"ektqHSwnAIqW4Y0tVtatwajtKF+ovKiiI1osUCTwPQJyk9IxTjEpU/Fd/VrDgmi6YCNGN0QA6DFjiHN7",
+	"j4keYZrJ4xH8F/gZ/AP8A7xri0dUttPiUa8QIOix2BbmYMOKQN9iAcHwcomYCc2ceMZC2rh+9v7makcH",
+	"aHZH03apk2nV5y91NrpyC6lj1+AKqUCQ5onAb3SSTOlMtV9+IxJbSj0pAMbQPa6ZGqUACK+Imz6HUPes",
+	"B803MGYEZnxFhT+sYoSEI0//sD1zAYWDmRO8QNE6kiJMdtIRDCmWDLatVrhFOigTBhdF+DEIg4k8q0t5",
+	"zqSeuKNMqJ8/QJyoPy4oQa3qQc125Yqw/ZKnkLxhCMaSuWzCEZB6XppFZAliJCBOOIB3NNeiJYFSaKlN",
+	"CAYJVxrhxImOKYK8LW/hCkYrTFAxeQg+ZRliI5iiZAQ5AkIe/9JK5NxMASvEfkSJVkh/5XpZ1QUVd5oF",
+	"viQ545tcBGFwQ9ANu6IM6asXjck5nemgqkX+usDwJ4IeMxRpONdUpXEU3W2SWCsF8jSFbO3DhDPTtZTa",
+	"1hEONCd3csG13Je6Rf9mNKNyEZXO4iCTqqzMdOUo4Q7cxqqhsJXQMdZBU/bEmBciuAoZL4BaoFHSBQyp",
+	"8O0opUEJNaaD1hxS0yplj0V76k3siGU+3kIGkwQls5L7HaMFzBMRnP3UlmKUwkec5ikgeXqHmKSBdd1N",
+	"6BIStR5MJJEUcEU9BKOVpZSBEZz99FYpbv3Pu7YYstMr7Je8H2CKE4y4vwSujdiEJWxayYghJZz9QboH",
+	"mwRExTC9BrvTjFVQaL9TVGSVud2iDVTXZchRrza2U6d9W62o286jzko9pbEMKydU71v+cKdsSEhiFB/+",
+	"7Dtw+ARZcNDz71h+izzoZZayfOgH+yoveuWFRxrWrNVWraWWmhZ76VXxoTUny59L7pE5WhIbSDmPvxGJ",
+	"5hBwalhuBckScclytaExVUmQUHmLqhFJ0YbJ8jcV9T75jTwD9fw8zt4A3ft6Wp6iXYdexJc5zfMuvl/g",
+	"9dzNl+bsu59XHJ/BJToBanSi0kZBmnOVt53QB8mqDKA/c5hICLLvDP8v8k5ErhLEsbceY/4ZmzQ+23dv",
+	"rHkOm3KjKmON4DWHDywMAPCApRdYtWuagZNSUqNH2lnpsJfu3z2u3Uvj2u4hh1w/ltZQjpR7BMjLouqO",
+	"pr2E2oTddIo0Q/1T6cSx0kz3pYQwg3TfZMeScHWyi0m6mW3c+FpaODAefplPilydpkUrpIwal7iiKWtU",
+	"l1LGjatHG6EdfW9LwUdHl2mJ1o4usw2JHD0+b0+MdSUE4qKHt/9BjFehIlt1X0S91zGAh4Y6e2WUR+jT",
+	"z8B+OaHQfrl99NCo3xIPEyr1W8v/t9BpP1Z+gFBqrzXm6TZurGfvlwGVt5J9Oe3Vh5U+ADvTr1272FDU",
+	"L52gTSU3Uwv+oHd8RNMskQRs11ayyyVaiDmd5sTx2r6ZZ9Cj+jMjifSLUm0IUAYw0UJTXZ2DLGcZ5Yif",
+	"WCTUMwOkWRSEwedPl9fj6fn7yeVk/s8gDK7OL00+wGw8mo7n8qfJbHRz/WHy8dPUpg1Mb27mv05k4/h/",
+	"bi9vJvPWS4lZnyNZu/Gt28PWFrYPL5uvt+HjLcORKxQt2PoKPp4LgdLMZU/kHM0yKoa8UGwMcZ2eci5p",
+	"w8XpzcTU7TN/aVTq7TRsqhCrK7qAAk4RbLcrZKMG0N4+JktM0GdnipdUoQslnj/gxGUh/kroA/mMWc5d",
+	"PcwSLjBT73RxT7+OuWY5z/rWI9XRHH5FvjlrctZt4gj8oBGE5xE62DZosI1CqhRp8NBJ1aIOnmCHayZq",
+	"EkDrr/zl78XDoHVD6qnYl82P60Zzd+zLPJ1qPLbtSc1GJB7RJE8dl3yIxDajp9m4wAm6bX1yIZFWeXJh",
+	"XltY01I77m0ZAAtMlohlDLcdsmsq0Jm2ojBXYWcdMnKkEjDRtTXVwbU5N4q3Smk01DlwRqOetT21qBQ6",
+	"8Tvldgfb3PRX4i9PTpd6QsWAJSKIwcSUcTlU7YB6AZ+B1W+KyjfcVPlRnXQPdQqkd7TrajhzuNyi2IGA",
+	"zXDmV9T+cOQeJrkH18vhtvPvrQuVTlf3vbJx1vSgEweht0h/4KMuY6B6hWTItoL3CKB7xPSVlfKtMTcr",
+	"bH3iN8CFbbo51pX1UDAakW4No9tHNE0rKKl3eKa3AKJgk34cdO3/KckMhg098xh2FhPcA5d6THwcrvWQ",
+	"xnrErKgh111VwuMCxhrANoB/y6gU0+0arSM7ZMjdjZ3zyTc3G+u9S9gNvNSxQPkd9bAsbPrz1m/OB14E",
+	"FZMJKHLux2C6/pHqvyPm3q6+x/0TL0u6RNvmSDxrGV49uX6kM/29Nr9V7gDTQw+bPGAnPXYEoInnbaIB",
+	"1YPW8sRSVZV88iNLLubFvcWWufo26np9M//3bHR+fT2+CMJgcq1iqOfz+fnoF/PLv2+nNx+n49lMNry/",
+	"mc7V7xc31+OWGGs/UnK+vbKqo/d7aL2hLUZ6Kqu2kUMVVgsMX23UMtQnx6BtmJ9+aRk5UGA3ILiZYljg",
+	"7POVVykj++q1r58t7tYXfyuKwHWDKT237V5XGJiN9G1zYPxOo3So6NcKqUXq70Pk28lMCuZRZPx2kt2S",
+	"rI5bnLqeKttLIkcpPttcLkfYtfhq7cJylVDXQ+0E5iRaDdMPT3oYnkAhZ3HU8diqEuTAMpDSvlr6Q/cq",
+	"XeqOYFZoXMJdjTahYZIShirEaXPw2tO1nhp2rFUaa9aN5P64q8AayZEe1OmL5MeYC0YHTX2hhyjf9XHQ",
+	"yA/4UR+TNWKT2FGygnx9orWWbapteL56zZy1cjxr4VQ9plIhnLIiX7uLOHTzzchwSd2tEgxHw7nmyoxT",
+	"5ThspeMnVupwTtJY9R3kaBbRSr6hDiapiyNtlhaup6sfTjMYCVd77wovCqavOaTqd5Bpmc/L+RQm2wqC",
+	"GAl1ZwwuMckfgTo/+C63CU3V3U4uLvHXFs9XquLJxb8vJ7+OwQKjJAaqZqDN9JXNp0hEp5S/YShBkOsL",
+	"sSe8pdw8GnDfuTV31KawSpxRq4+tG9zQwN9S+AdVJoX64yTFhDJgAP7d7wm9syyj97VaVSYf+HatIQ+b",
+	"d2zWYXRhfuelmJrxnsaiWhyS4TprR6vzy5DeRKhrazdHLUMMWPHuSJ4eMSxw1Jpr7MhK/gUvV/69L+mD",
+	"f2dd3Mq//zVaJniJ7xLkMaYf7y3VuUbTyXwyOr8MwuCXycdfgjC4Gl9MPl0FYXB58yUIg+vxx8vJx8n7",
+	"y9a4hTKo9bk15ayDz1ejBKq71fPbiXR/ClkTvDt5e/LWFPQgMMPBWfCfJ29P3gVae6tdnRYJE6e8yKww",
+	"QdOiDoi0O4KPSBTpoyYJI6x8r8khQjZdTsufJ3L5vfXu5htBvt2LTwz9XvtWzE9v3+7uOzF6++7Pw2gr",
+	"0rw8b4dVLO608v2Y7+Wgt8S5+ioCvIdYiQBgiKQqibUQ6TZvIZIUvoiL9zRe7wUF1Q/4fD8K4s+TxOAG",
+	"PCBdyMfe4i/yJFnviiIzF0XC4PFNRGO0ROSNQfibOxqv7bev5N8K1umiVMLWddKKMrfP8IjpS07f3nOa",
+	"+S/kK/bvbL6X9qwEQ0G2w4mGzWMmVfWOtwkFyssMtQ9xUNQr9pEH7/Yzbd2wIeihUqrbPLpWiPp5h0Tv",
+	"+VTXRFcIL5bCczlTsY7/3jUyzJViy0pMh9JV4I54UaWoIwDtHrcQhqffio85ftdWaoK0SV/l5Qv1u+Xm",
+	"D6UPQA6Tk5tPR7oEQjc2Sqf557c/H4qXLAUnFyonU1nluyKixuyGiCf64qpbP+2EAPtRU1Y/HEDe94j7",
+	"H4RBpMYRK1S8pVtQVuOWzH5VtaZ/5M+7P7JH1mIH4SKFOlRWHhuT9pkpsh+CxxW+y1ztp8nc3tgr22/D",
+	"9p8y/UWVV7Y/DNtrfA/ne2nB8WotGJfFUC4Z8+rUviSntky5w/m15aI9Pb5tlbX2E+0qleA7qIdbn7nN",
+	"ya2U7ju+o1tezt6c3UZ9xzbOLC0EJgzBeK1LpvHde77VMkNbyM7Tb+WPw3v4wCWun1U/Kz9MuFa+Sf+S",
+	"nOEyeffqEFcK4HY4xfuhyMv1jrtl14/JNO1Ocp2DuhzlY3ERXqivi+/NyxiqQw/Fh9bFrqqt4/sbHWr0",
+	"WZyWZ6bNf37306GwMhZwCWIck78K/UX+k12HH2ol158WgngVKIcVKDZ48SpQXgXKsQVKEdjZQqJYB6X0",
+	"WK/L8rXdXoM7Lym403yTeZgQz4Bnlf3Bnw3r7UPPtDxuPWgIqH3+WkoyeiiwqfKfYByj2KLTlEMwvkiG",
+	"IrzAkanheURdpBe8vxiR47G1SxUU3FjWBbokg8YfJPEGabuPHhl01Kjkpt12YlzHmfQ/Js7kIdVnpTFb",
+	"GY7F4Bccz/A5iEeMahj+2VdUo8KlXlGMY/DOvp2O7ZTBYXlwbr/gVRJqSilkNpvAFBp+UXrhWRymF6Oe",
+	"frxwiN7/TqIhr4LpOILJRkZg7Zw/k9jIq9x5lTstURNr8Qwzt3vjJa+RkpeXBnPoBBh+Asb2c2e2si+v",
+	"fcyi52PRvcGTfebMHCNbpidP5rkkyOw1M6ZHpO87GaaDIYdKUR2u8E6IUTbdltbcS0x/2XveS2/Cy1Mx",
+	"/rLTW55ZCOhwGS06Qt+reXoiRPtnnkNcQh/j+rk3k+XZeFVHdaf2fcc8XNH+cIGZ3SSovEqCXUqCSgrK",
+	"qyR4lQSHCZUMiZGITR1Ql3lpS4W+xkleXkbJoSIllo06wxwbRtpf5P04WSHuYIf9BMbxwx3WPdhvmodb",
+	"/prr0P0GPYoPdgyUf6ff7CdQPSIcho/nZsRgwWin2kWc45mw0cGMiLn9DO3eAi56g50Bl90xwEvPwnk+",
+	"gZc9MsZGwfVGUw7JGYe5yj7OBXaXN1VIoIY/dWxmex7q9EdyaOyxe2ps4/VcHvNcvhopr+LhGYgHBQKx",
+	"e3vmc5YEZ8EpzHDw/ffv/xcAAP//6c2SFATBAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/backend/pkg/database/gorm/odata.go
+++ b/backend/pkg/database/gorm/odata.go
@@ -35,7 +35,8 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 	targetScanResultsSchemaName: {
 		Table: "scan_results",
 		Fields: odatasql.Schema{
-			"id": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"id":       odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"revision": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
 			"target": odatasql.FieldMeta{
 				FieldType:            odatasql.RelationshipFieldType,
 				RelationshipSchema:   targetSchemaName,
@@ -265,6 +266,7 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 		Table: "scans",
 		Fields: odatasql.Schema{
 			"id":        odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"revision":  odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
 			"startTime": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
 			"endTime":   odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
 			"scanConfig": odatasql.FieldMeta{
@@ -317,6 +319,7 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 		Table: "targets",
 		Fields: odatasql.Schema{
 			"id":         odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"revision":   odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
 			"scansCount": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
 			"targetInfo": odatasql.FieldMeta{
 				FieldType:             odatasql.ComplexFieldType,
@@ -387,6 +390,7 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 		Table: "scan_configs",
 		Fields: odatasql.Schema{
 			"id":       odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"revision": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
 			"name":     odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
 			"disabled": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
 			"scanFamiliesConfig": odatasql.FieldMeta{

--- a/backend/pkg/database/gorm/scan.go
+++ b/backend/pkg/database/gorm/scan.go
@@ -108,6 +108,9 @@ func (s *ScansTableHandler) CreateScan(scan models.Scan) (models.Scan, error) {
 	// Generate a new UUID
 	scan.Id = utils.PointerTo(uuid.New().String())
 
+	// Initialise revision
+	scan.Revision = utils.PointerTo(1)
+
 	// TODO do we want ScanConfig to be required in the api?
 	if scan.ScanConfig != nil {
 		existingScan, err := s.checkUniqueness(scan)
@@ -142,16 +145,29 @@ func (s *ScansTableHandler) CreateScan(scan models.Scan) (models.Scan, error) {
 }
 
 // nolint:cyclop
-func (s *ScansTableHandler) SaveScan(scan models.Scan) (models.Scan, error) {
+func (s *ScansTableHandler) SaveScan(scan models.Scan, params models.PutScansScanIDParams) (models.Scan, error) {
 	if scan.Id == nil || *scan.Id == "" {
 		return models.Scan{}, &common.BadRequestError{
 			Reason: "id is required to save scan",
 		}
 	}
 
-	var dbScan Scan
-	if err := getExistingObjByID(s.DB, scanSchemaName, *scan.Id, &dbScan); err != nil {
+	var dbObj Scan
+	if err := getExistingObjByID(s.DB, scanSchemaName, *scan.Id, &dbObj); err != nil {
 		return models.Scan{}, fmt.Errorf("failed to get scan from db: %w", err)
+	}
+
+	var dbScan models.Scan
+	if err := json.Unmarshal(dbObj.Data, &dbScan); err != nil {
+		return models.Scan{}, fmt.Errorf("failed to convert DB object to API model: %w", err)
+	}
+
+	if (params.IfMatch != nil && dbScan.Revision != nil && *params.IfMatch != *dbScan.Revision) || (params.IfMatch != nil && dbScan.Revision == nil) {
+		return models.Scan{}, &types.PreconditionFailedError{
+			Reason: fmt.Sprintf(
+				"Revision %d does not match %d. The object may have been modified since you started the request.",
+				*dbScan.Revision, *params.IfMatch),
+		}
 	}
 
 	if err := validateScanConfigID(scan, dbScan); err != nil {
@@ -173,19 +189,25 @@ func (s *ScansTableHandler) SaveScan(scan models.Scan) (models.Scan, error) {
 		}
 	}
 
+	if dbScan.Revision != nil {
+		scan.Revision = utils.PointerTo(*dbScan.Revision + 1)
+	} else {
+		scan.Revision = utils.PointerTo(1)
+	}
+
 	marshaled, err := json.Marshal(scan)
 	if err != nil {
 		return models.Scan{}, fmt.Errorf("failed to convert API model to DB model: %w", err)
 	}
 
-	dbScan.Data = marshaled
+	dbObj.Data = marshaled
 
-	if err = s.DB.Save(&dbScan).Error; err != nil {
+	if err = s.DB.Save(&dbObj).Error; err != nil {
 		return models.Scan{}, fmt.Errorf("failed to save scan in db: %w", err)
 	}
 
 	var apiScan models.Scan
-	if err = json.Unmarshal(dbScan.Data, &apiScan); err != nil {
+	if err = json.Unmarshal(dbObj.Data, &apiScan); err != nil {
 		return models.Scan{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
 	}
 
@@ -193,16 +215,29 @@ func (s *ScansTableHandler) SaveScan(scan models.Scan) (models.Scan, error) {
 }
 
 // nolint:cyclop
-func (s *ScansTableHandler) UpdateScan(scan models.Scan) (models.Scan, error) {
+func (s *ScansTableHandler) UpdateScan(scan models.Scan, params models.PatchScansScanIDParams) (models.Scan, error) {
 	if scan.Id == nil || *scan.Id == "" {
 		return models.Scan{}, &common.BadRequestError{
 			Reason: "id is required to update scan",
 		}
 	}
 
-	var dbScan Scan
-	if err := getExistingObjByID(s.DB, scanSchemaName, *scan.Id, &dbScan); err != nil {
+	var dbObj Scan
+	if err := getExistingObjByID(s.DB, scanSchemaName, *scan.Id, &dbObj); err != nil {
 		return models.Scan{}, err
+	}
+
+	var dbScan models.Scan
+	if err := json.Unmarshal(dbObj.Data, &dbScan); err != nil {
+		return models.Scan{}, fmt.Errorf("failed to convert DB object to API model: %w", err)
+	}
+
+	if (params.IfMatch != nil && dbScan.Revision != nil && *params.IfMatch != *dbScan.Revision) || (params.IfMatch != nil && dbScan.Revision == nil) {
+		return models.Scan{}, &types.PreconditionFailedError{
+			Reason: fmt.Sprintf(
+				"Revision %d does not match %d. The object may have been modified since you started the request.",
+				*dbScan.Revision, *params.IfMatch),
+		}
 	}
 
 	if err := validateScanConfigID(scan, dbScan); err != nil {
@@ -213,14 +248,20 @@ func (s *ScansTableHandler) UpdateScan(scan models.Scan) (models.Scan, error) {
 		return models.Scan{}, fmt.Errorf("scan config id validation failed: %w", err)
 	}
 
+	if dbScan.Revision != nil {
+		scan.Revision = utils.PointerTo(*dbScan.Revision + 1)
+	} else {
+		scan.Revision = utils.PointerTo(1)
+	}
+
 	var err error
-	dbScan.Data, err = patchObject(dbScan.Data, scan)
+	dbObj.Data, err = patchObject(dbObj.Data, scan)
 	if err != nil {
 		return models.Scan{}, fmt.Errorf("failed to apply patch: %w", err)
 	}
 
 	var ret models.Scan
-	err = json.Unmarshal(dbScan.Data, &ret)
+	err = json.Unmarshal(dbObj.Data, &ret)
 	if err != nil {
 		return models.Scan{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
 	}
@@ -236,7 +277,7 @@ func (s *ScansTableHandler) UpdateScan(scan models.Scan) (models.Scan, error) {
 		}
 	}
 
-	if err := s.DB.Save(&dbScan).Error; err != nil {
+	if err := s.DB.Save(&dbObj).Error; err != nil {
 		return models.Scan{}, fmt.Errorf("failed to save scan in db: %w", err)
 	}
 
@@ -277,7 +318,7 @@ func (s *ScansTableHandler) checkUniqueness(scan models.Scan) (models.Scan, erro
 }
 
 // In the case of updating a scan, not allowed to change the scan config ID.
-func validateScanConfigID(scan models.Scan, dbScan Scan) error {
+func validateScanConfigID(scan models.Scan, dbScan models.Scan) error {
 	if scan.ScanConfig == nil {
 		return nil
 	}
@@ -286,13 +327,9 @@ func validateScanConfigID(scan models.Scan, dbScan Scan) error {
 			Reason: "scan config id is required when scan config is defined",
 		}
 	}
-	var apiScan models.Scan
-	if err := json.Unmarshal(dbScan.Data, &apiScan); err != nil {
-		return fmt.Errorf("failed to convert DB model to API model: %w", err)
-	}
-	if scan.ScanConfig.Id != apiScan.ScanConfig.Id {
+	if scan.ScanConfig.Id != dbScan.ScanConfig.Id {
 		return &common.BadRequestError{
-			Reason: fmt.Sprintf("not allowed to change scan config id from=%s to=%s", apiScan.ScanConfig.Id, scan.ScanConfig.Id),
+			Reason: fmt.Sprintf("not allowed to change scan config id from=%s to=%s", dbScan.ScanConfig.Id, scan.ScanConfig.Id),
 		}
 	}
 	return nil

--- a/backend/pkg/database/gorm/scan_config.go
+++ b/backend/pkg/database/gorm/scan_config.go
@@ -120,6 +120,9 @@ func (s *ScanConfigsTableHandler) CreateScanConfig(scanConfig models.ScanConfig)
 	// Generate a new UUID
 	scanConfig.Id = utils.PointerTo(uuid.New().String())
 
+	// Initialise revision
+	scanConfig.Revision = utils.PointerTo(1)
+
 	// TODO(sambetts) Lock the table here to prevent race conditions
 	// checking the uniqueness.
 	//
@@ -198,7 +201,7 @@ func isEmptyOperationTime(operationTime *time.Time) bool {
 }
 
 // nolint: cyclop
-func (s *ScanConfigsTableHandler) SaveScanConfig(scanConfig models.ScanConfig) (models.ScanConfig, error) {
+func (s *ScanConfigsTableHandler) SaveScanConfig(scanConfig models.ScanConfig, params models.PutScanConfigsScanConfigIDParams) (models.ScanConfig, error) {
 	if scanConfig.Id == nil || *scanConfig.Id == "" {
 		return models.ScanConfig{}, &common.BadRequestError{
 			Reason: "id is required to save scan config",
@@ -218,9 +221,23 @@ func (s *ScanConfigsTableHandler) SaveScanConfig(scanConfig models.ScanConfig) (
 		}
 	}
 
-	var dbScanConfig ScanConfig
-	if err := getExistingObjByID(s.DB, "ScanConfig", *scanConfig.Id, &dbScanConfig); err != nil {
+	var dbObj ScanConfig
+	if err := getExistingObjByID(s.DB, "ScanConfig", *scanConfig.Id, &dbObj); err != nil {
 		return models.ScanConfig{}, fmt.Errorf("failed to get scan config from db: %w", err)
+	}
+
+	var dbScanConfig models.ScanConfig
+	err := json.Unmarshal(dbObj.Data, &dbScanConfig)
+	if err != nil {
+		return models.ScanConfig{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	if (params.IfMatch != nil && dbScanConfig.Revision != nil && *params.IfMatch != *dbScanConfig.Revision) || (params.IfMatch != nil && dbScanConfig.Revision == nil) {
+		return models.ScanConfig{}, &types.PreconditionFailedError{
+			Reason: fmt.Sprintf(
+				"Revision %d does not match %d. The object may have been modified since you started the request.",
+				*dbScanConfig.Revision, *params.IfMatch),
+		}
 	}
 
 	// Check the existing DB entries to ensure that the name field is unique
@@ -233,12 +250,18 @@ func (s *ScanConfigsTableHandler) SaveScanConfig(scanConfig models.ScanConfig) (
 		return models.ScanConfig{}, fmt.Errorf("failed to check existing scan config: %w", err)
 	}
 
+	if dbScanConfig.Revision != nil {
+		scanConfig.Revision = utils.PointerTo(*dbScanConfig.Revision + 1)
+	} else {
+		scanConfig.Revision = utils.PointerTo(1)
+	}
+
 	marshaled, err := json.Marshal(scanConfig)
 	if err != nil {
 		return models.ScanConfig{}, fmt.Errorf("failed to convert API model to DB model: %w", err)
 	}
 
-	dbScanConfig.Data = marshaled
+	dbObj.Data = marshaled
 
 	if err := s.DB.Save(&dbScanConfig).Error; err != nil {
 		return models.ScanConfig{}, fmt.Errorf("failed to save scan config in db: %w", err)
@@ -248,7 +271,7 @@ func (s *ScanConfigsTableHandler) SaveScanConfig(scanConfig models.ScanConfig) (
 	// creating any of the data (like the ID) so we can just return the
 	// scanConfig pre-marshal above.
 	var sc models.ScanConfig
-	err = json.Unmarshal(dbScanConfig.Data, &sc)
+	err = json.Unmarshal(dbObj.Data, &sc)
 	if err != nil {
 		return models.ScanConfig{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
 	}
@@ -256,7 +279,7 @@ func (s *ScanConfigsTableHandler) SaveScanConfig(scanConfig models.ScanConfig) (
 }
 
 // nolint: cyclop
-func (s *ScanConfigsTableHandler) UpdateScanConfig(scanConfig models.ScanConfig) (models.ScanConfig, error) {
+func (s *ScanConfigsTableHandler) UpdateScanConfig(scanConfig models.ScanConfig, params models.PatchScanConfigsScanConfigIDParams) (models.ScanConfig, error) {
 	if scanConfig.Id == nil || *scanConfig.Id == "" {
 		return models.ScanConfig{}, &common.BadRequestError{
 			Reason: "id is required to update scan config",
@@ -272,19 +295,39 @@ func (s *ScanConfigsTableHandler) UpdateScanConfig(scanConfig models.ScanConfig)
 		}
 	}
 
-	var dbScanConfig ScanConfig
-	if err := getExistingObjByID(s.DB, "ScanConfig", *scanConfig.Id, &dbScanConfig); err != nil {
+	var err error
+	var dbObj ScanConfig
+	if err := getExistingObjByID(s.DB, "ScanConfig", *scanConfig.Id, &dbObj); err != nil {
 		return models.ScanConfig{}, fmt.Errorf("failed to get scan config from db: %w", err)
 	}
 
-	var err error
-	dbScanConfig.Data, err = patchObject(dbScanConfig.Data, scanConfig)
+	var dbScanConfig models.ScanConfig
+	err = json.Unmarshal(dbObj.Data, &dbScanConfig)
+	if err != nil {
+		return models.ScanConfig{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	if (params.IfMatch != nil && dbScanConfig.Revision != nil && *params.IfMatch != *dbScanConfig.Revision) || (params.IfMatch != nil && dbScanConfig.Revision == nil) {
+		return models.ScanConfig{}, &types.PreconditionFailedError{
+			Reason: fmt.Sprintf(
+				"Revision %d does not match %d. The object may have been modified since you started the request.",
+				*dbScanConfig.Revision, *params.IfMatch),
+		}
+	}
+
+	if dbScanConfig.Revision != nil {
+		scanConfig.Revision = utils.PointerTo(*dbScanConfig.Revision + 1)
+	} else {
+		scanConfig.Revision = utils.PointerTo(1)
+	}
+
+	dbObj.Data, err = patchObject(dbObj.Data, scanConfig)
 	if err != nil {
 		return models.ScanConfig{}, fmt.Errorf("failed to apply patch: %w", err)
 	}
 
 	var sc models.ScanConfig
-	err = json.Unmarshal(dbScanConfig.Data, &sc)
+	err = json.Unmarshal(dbObj.Data, &sc)
 	if err != nil {
 		return models.ScanConfig{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
 	}
@@ -299,7 +342,7 @@ func (s *ScanConfigsTableHandler) UpdateScanConfig(scanConfig models.ScanConfig)
 		return models.ScanConfig{}, fmt.Errorf("failed to check existing scan config: %w", err)
 	}
 
-	if err := s.DB.Save(&dbScanConfig).Error; err != nil {
+	if err := s.DB.Save(&dbObj).Error; err != nil {
 		return models.ScanConfig{}, fmt.Errorf("failed to save scan config in db: %w", err)
 	}
 

--- a/backend/pkg/database/gorm/scan_result.go
+++ b/backend/pkg/database/gorm/scan_result.go
@@ -120,6 +120,9 @@ func (s *ScanResultsTableHandler) CreateScanResult(scanResult models.TargetScanR
 	// Generate a new UUID
 	scanResult.Id = utils.PointerTo(uuid.New().String())
 
+	// Initialise revision
+	scanResult.Revision = utils.PointerTo(1)
+
 	// TODO(sambetts) Lock the table here to prevent race conditions
 	// checking the uniqueness.
 	//
@@ -166,8 +169,8 @@ func (s *ScanResultsTableHandler) CreateScanResult(scanResult models.TargetScanR
 	return tsr, nil
 }
 
-// nolint:cyclop
-func (s *ScanResultsTableHandler) SaveScanResult(scanResult models.TargetScanResult) (models.TargetScanResult, error) {
+// nolint:cyclop,gocognit
+func (s *ScanResultsTableHandler) SaveScanResult(scanResult models.TargetScanResult, params models.PutScanResultsScanResultIDParams) (models.TargetScanResult, error) {
 	if scanResult.Id == nil || *scanResult.Id == "" {
 		return models.TargetScanResult{}, &common.BadRequestError{
 			Reason: "id is required to save scan result",
@@ -196,9 +199,29 @@ func (s *ScanResultsTableHandler) SaveScanResult(scanResult models.TargetScanRes
 		return models.TargetScanResult{}, fmt.Errorf("failed to check existing scan: %w", err)
 	}
 
-	var dbScanResult ScanResult
-	if err := getExistingObjByID(s.DB, targetScanResultsSchemaName, *scanResult.Id, &dbScanResult); err != nil {
+	var dbObj ScanResult
+	if err := getExistingObjByID(s.DB, targetScanResultsSchemaName, *scanResult.Id, &dbObj); err != nil {
 		return models.TargetScanResult{}, err
+	}
+
+	var dbScanResult models.TargetScanResult
+	err = json.Unmarshal(dbObj.Data, &dbScanResult)
+	if err != nil {
+		return models.TargetScanResult{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	if (params.IfMatch != nil && dbScanResult.Revision != nil && *params.IfMatch != *dbScanResult.Revision) || (params.IfMatch != nil && dbScanResult.Revision == nil) {
+		return models.TargetScanResult{}, &types.PreconditionFailedError{
+			Reason: fmt.Sprintf(
+				"Revision %d does not match %d. The object may have been modified since you started the request.",
+				*dbScanResult.Revision, *params.IfMatch),
+		}
+	}
+
+	if dbScanResult.Revision != nil {
+		scanResult.Revision = utils.PointerTo(*dbScanResult.Revision + 1)
+	} else {
+		scanResult.Revision = utils.PointerTo(1)
 	}
 
 	marshaled, err := json.Marshal(scanResult)
@@ -206,7 +229,7 @@ func (s *ScanResultsTableHandler) SaveScanResult(scanResult models.TargetScanRes
 		return models.TargetScanResult{}, fmt.Errorf("failed to convert API model to DB model: %w", err)
 	}
 
-	dbScanResult.Data = marshaled
+	dbObj.Data = marshaled
 
 	if err := s.DB.Save(&dbScanResult).Error; err != nil {
 		return models.TargetScanResult{}, fmt.Errorf("failed to save scan result in db: %w", err)
@@ -216,7 +239,7 @@ func (s *ScanResultsTableHandler) SaveScanResult(scanResult models.TargetScanRes
 	// creating any of the data (like the ID) so we can just return the
 	// scanResult pre-marshal above.
 	var tsr models.TargetScanResult
-	err = json.Unmarshal(dbScanResult.Data, &tsr)
+	err = json.Unmarshal(dbObj.Data, &tsr)
 	if err != nil {
 		return models.TargetScanResult{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
 	}
@@ -224,26 +247,47 @@ func (s *ScanResultsTableHandler) SaveScanResult(scanResult models.TargetScanRes
 	return tsr, nil
 }
 
-func (s *ScanResultsTableHandler) UpdateScanResult(scanResult models.TargetScanResult) (models.TargetScanResult, error) {
+// nolint:cyclop
+func (s *ScanResultsTableHandler) UpdateScanResult(scanResult models.TargetScanResult, params models.PatchScanResultsScanResultIDParams) (models.TargetScanResult, error) {
 	if scanResult.Id == nil || *scanResult.Id == "" {
 		return models.TargetScanResult{}, &common.BadRequestError{
 			Reason: "id is required to update scan result",
 		}
 	}
 
-	var dbScanResult ScanResult
-	if err := getExistingObjByID(s.DB, targetScanResultsSchemaName, *scanResult.Id, &dbScanResult); err != nil {
+	var dbObj ScanResult
+	if err := getExistingObjByID(s.DB, targetScanResultsSchemaName, *scanResult.Id, &dbObj); err != nil {
 		return models.TargetScanResult{}, err
 	}
 
 	var err error
-	dbScanResult.Data, err = patchObject(dbScanResult.Data, scanResult)
+	var dbScanResult models.TargetScanResult
+	err = json.Unmarshal(dbObj.Data, &dbScanResult)
+	if err != nil {
+		return models.TargetScanResult{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	if (params.IfMatch != nil && dbScanResult.Revision != nil && *params.IfMatch != *dbScanResult.Revision) || (params.IfMatch != nil && dbScanResult.Revision == nil) {
+		return models.TargetScanResult{}, &types.PreconditionFailedError{
+			Reason: fmt.Sprintf(
+				"Revision %d does not match %d. The object may have been modified since you started the request.",
+				*dbScanResult.Revision, *params.IfMatch),
+		}
+	}
+
+	if dbScanResult.Revision != nil {
+		scanResult.Revision = utils.PointerTo(*dbScanResult.Revision + 1)
+	} else {
+		scanResult.Revision = utils.PointerTo(1)
+	}
+
+	dbObj.Data, err = patchObject(dbObj.Data, scanResult)
 	if err != nil {
 		return models.TargetScanResult{}, fmt.Errorf("failed to apply patch: %w", err)
 	}
 
 	var tsr models.TargetScanResult
-	err = json.Unmarshal(dbScanResult.Data, &tsr)
+	err = json.Unmarshal(dbObj.Data, &tsr)
 	if err != nil {
 		return models.TargetScanResult{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
 	}
@@ -258,7 +302,7 @@ func (s *ScanResultsTableHandler) UpdateScanResult(scanResult models.TargetScanR
 		return models.TargetScanResult{}, fmt.Errorf("failed to check existing scan: %w", err)
 	}
 
-	if err := s.DB.Save(&dbScanResult).Error; err != nil {
+	if err := s.DB.Save(&dbObj).Error; err != nil {
 		return models.TargetScanResult{}, fmt.Errorf("failed to save scan result in db: %w", err)
 	}
 

--- a/backend/pkg/database/gorm/scan_test.go
+++ b/backend/pkg/database/gorm/scan_test.go
@@ -16,26 +16,21 @@
 package gorm
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/openclarity/vmclarity/api/models"
 )
 
 func Test_validateScanConfigID(t *testing.T) {
-	apiScan := models.Scan{
+	dbScan := models.Scan{
 		ScanConfig: &models.ScanConfigRelationship{
 			Id: "test",
 		},
 	}
-	dbScan, err := json.Marshal(apiScan)
-	if err != nil {
-		t.Errorf("failed to marshal test scan data: %v", err)
-	}
 
 	type args struct {
 		scan   models.Scan
-		dbScan Scan
+		dbScan models.Scan
 	}
 	tests := []struct {
 		name    string
@@ -50,23 +45,15 @@ func Test_validateScanConfigID(t *testing.T) {
 						Id: "test",
 					},
 				},
-				dbScan: Scan{
-					ODataObject{
-						Data: dbScan,
-					},
-				},
+				dbScan: dbScan,
 			},
 			wantErr: false,
 		},
 		{
 			name: "scan config ID is nil",
 			args: args{
-				scan: models.Scan{},
-				dbScan: Scan{
-					ODataObject{
-						Data: dbScan,
-					},
-				},
+				scan:   models.Scan{},
+				dbScan: dbScan,
 			},
 			wantErr: false,
 		},
@@ -78,11 +65,7 @@ func Test_validateScanConfigID(t *testing.T) {
 						Id: "newID",
 					},
 				},
-				dbScan: Scan{
-					ODataObject{
-						Data: dbScan,
-					},
-				},
+				dbScan: dbScan,
 			},
 			wantErr: true,
 		},

--- a/backend/pkg/database/gorm/target.go
+++ b/backend/pkg/database/gorm/target.go
@@ -115,6 +115,9 @@ func (t *TargetsTableHandler) CreateTarget(target models.Target) (models.Target,
 	// Generate a new UUID
 	target.Id = utils.PointerTo(uuid.New().String())
 
+	// Initialise revision
+	target.Revision = utils.PointerTo(1)
+
 	// TODO(sambetts) Lock the table here to prevent race conditions
 	// checking the uniqueness.
 	//
@@ -160,7 +163,8 @@ func (t *TargetsTableHandler) CreateTarget(target models.Target) (models.Target,
 	return apiTarget, nil
 }
 
-func (t *TargetsTableHandler) SaveTarget(target models.Target) (models.Target, error) {
+// nolint:cyclop
+func (t *TargetsTableHandler) SaveTarget(target models.Target, params models.PutTargetsTargetIDParams) (models.Target, error) {
 	if target.Id == nil || *target.Id == "" {
 		return models.Target{}, &common.BadRequestError{
 			Reason: "id is required to save target",
@@ -174,9 +178,29 @@ func (t *TargetsTableHandler) SaveTarget(target models.Target) (models.Target, e
 		}
 	}
 
-	var dbTarget Target
-	if err := getExistingObjByID(t.DB, targetSchemaName, *target.Id, &dbTarget); err != nil {
+	var dbObj Target
+	if err := getExistingObjByID(t.DB, targetSchemaName, *target.Id, &dbObj); err != nil {
 		return models.Target{}, fmt.Errorf("failed to get target from db: %w", err)
+	}
+
+	var dbTarget models.Target
+	err := json.Unmarshal(dbObj.Data, &dbTarget)
+	if err != nil {
+		return models.Target{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	if (params.IfMatch != nil && dbTarget.Revision != nil && *params.IfMatch != *dbTarget.Revision) || (params.IfMatch != nil && dbTarget.Revision == nil) {
+		return models.Target{}, &types.PreconditionFailedError{
+			Reason: fmt.Sprintf(
+				"Revision %d does not match %d. The object may have been modified since you started the request.",
+				*dbTarget.Revision, *params.IfMatch),
+		}
+	}
+
+	if dbTarget.Revision != nil {
+		target.Revision = utils.PointerTo(*dbTarget.Revision + 1)
+	} else {
+		target.Revision = utils.PointerTo(1)
 	}
 
 	existingTarget, err := t.checkUniqueness(target)
@@ -193,9 +217,9 @@ func (t *TargetsTableHandler) SaveTarget(target models.Target) (models.Target, e
 		return models.Target{}, fmt.Errorf("failed to convert API model to DB model: %w", err)
 	}
 
-	dbTarget.Data = marshaled
+	dbObj.Data = marshaled
 
-	if err = t.DB.Save(&dbTarget).Error; err != nil {
+	if err = t.DB.Save(&dbObj).Error; err != nil {
 		return models.Target{}, fmt.Errorf("failed to save target in db: %w", err)
 	}
 
@@ -203,31 +227,52 @@ func (t *TargetsTableHandler) SaveTarget(target models.Target) (models.Target, e
 	// creating any of the data (like the ID) so we can just return the
 	// target pre-marshal above.
 	var apiTarget models.Target
-	if err = json.Unmarshal(dbTarget.Data, &apiTarget); err != nil {
+	if err = json.Unmarshal(dbObj.Data, &apiTarget); err != nil {
 		return models.Target{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
 	}
 
 	return apiTarget, nil
 }
 
-func (t *TargetsTableHandler) UpdateTarget(target models.Target) (models.Target, error) {
+// nolint:cyclop
+func (t *TargetsTableHandler) UpdateTarget(target models.Target, params models.PatchTargetsTargetIDParams) (models.Target, error) {
 	if target.Id == nil || *target.Id == "" {
 		return models.Target{}, fmt.Errorf("ID is required to update target in DB")
 	}
 
-	var dbTarget Target
-	if err := getExistingObjByID(t.DB, targetSchemaName, *target.Id, &dbTarget); err != nil {
+	var dbObj Target
+	if err := getExistingObjByID(t.DB, targetSchemaName, *target.Id, &dbObj); err != nil {
 		return models.Target{}, err
 	}
 
 	var err error
-	dbTarget.Data, err = patchObject(dbTarget.Data, target)
+	var dbTarget models.Target
+	err = json.Unmarshal(dbObj.Data, &dbTarget)
+	if err != nil {
+		return models.Target{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	if (params.IfMatch != nil && dbTarget.Revision != nil && *params.IfMatch != *dbTarget.Revision) || (params.IfMatch != nil && dbTarget.Revision == nil) {
+		return models.Target{}, &types.PreconditionFailedError{
+			Reason: fmt.Sprintf(
+				"Revision %d does not match %d. The object may have been modified since you started the request.",
+				*dbTarget.Revision, *params.IfMatch),
+		}
+	}
+
+	if dbTarget.Revision != nil {
+		target.Revision = utils.PointerTo(*dbTarget.Revision + 1)
+	} else {
+		target.Revision = utils.PointerTo(1)
+	}
+
+	dbObj.Data, err = patchObject(dbObj.Data, target)
 	if err != nil {
 		return models.Target{}, fmt.Errorf("failed to apply patch: %w", err)
 	}
 
 	var ret models.Target
-	err = json.Unmarshal(dbTarget.Data, &ret)
+	err = json.Unmarshal(dbObj.Data, &ret)
 	if err != nil {
 		return models.Target{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
 	}
@@ -241,7 +286,7 @@ func (t *TargetsTableHandler) UpdateTarget(target models.Target) (models.Target,
 		return models.Target{}, fmt.Errorf("failed to check existing target: %w", err)
 	}
 
-	if err := t.DB.Save(&dbTarget).Error; err != nil {
+	if err := t.DB.Save(&dbObj).Error; err != nil {
 		return models.Target{}, fmt.Errorf("failed to save target in db: %w", err)
 	}
 

--- a/backend/pkg/database/types/database.go
+++ b/backend/pkg/database/types/database.go
@@ -33,7 +33,7 @@ type PreconditionFailedError struct {
 }
 
 func (e *PreconditionFailedError) Error() string {
-	return fmt.Sprintf("Precondition Failed: %s", e.Reason)
+	return fmt.Sprintf("Precondition failed: %s", e.Reason)
 }
 
 type DBConfig struct {

--- a/backend/pkg/database/types/database.go
+++ b/backend/pkg/database/types/database.go
@@ -17,6 +17,7 @@ package types
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/openclarity/vmclarity/api/models"
 )
@@ -26,6 +27,14 @@ const (
 )
 
 var ErrNotFound = errors.New("not found")
+
+type PreconditionFailedError struct {
+	Reason string
+}
+
+func (e *PreconditionFailedError) Error() string {
+	return fmt.Sprintf("Precondition Failed: %s", e.Reason)
+}
 
 type DBConfig struct {
 	EnableInfoLogs bool   `json:"enable-info-logs"`
@@ -53,8 +62,8 @@ type ScansTable interface {
 	GetScan(scanID models.ScanID, params models.GetScansScanIDParams) (models.Scan, error)
 
 	CreateScan(scan models.Scan) (models.Scan, error)
-	UpdateScan(scan models.Scan) (models.Scan, error)
-	SaveScan(scan models.Scan) (models.Scan, error)
+	UpdateScan(scan models.Scan, params models.PatchScansScanIDParams) (models.Scan, error)
+	SaveScan(scan models.Scan, params models.PutScansScanIDParams) (models.Scan, error)
 
 	DeleteScan(scanID models.ScanID) error
 }
@@ -64,8 +73,8 @@ type ScanResultsTable interface {
 	GetScanResult(scanResultID models.ScanResultID, params models.GetScanResultsScanResultIDParams) (models.TargetScanResult, error)
 
 	CreateScanResult(scanResults models.TargetScanResult) (models.TargetScanResult, error)
-	UpdateScanResult(scanResults models.TargetScanResult) (models.TargetScanResult, error)
-	SaveScanResult(scanResults models.TargetScanResult) (models.TargetScanResult, error)
+	UpdateScanResult(scanResults models.TargetScanResult, params models.PatchScanResultsScanResultIDParams) (models.TargetScanResult, error)
+	SaveScanResult(scanResults models.TargetScanResult, params models.PutScanResultsScanResultIDParams) (models.TargetScanResult, error)
 
 	// DeleteScanResult(scanResultID models.ScanResultID) error
 }
@@ -75,8 +84,8 @@ type ScanConfigsTable interface {
 	GetScanConfig(scanConfigID models.ScanConfigID, params models.GetScanConfigsScanConfigIDParams) (models.ScanConfig, error)
 
 	CreateScanConfig(scanConfig models.ScanConfig) (models.ScanConfig, error)
-	UpdateScanConfig(scanConfig models.ScanConfig) (models.ScanConfig, error)
-	SaveScanConfig(scanConfig models.ScanConfig) (models.ScanConfig, error)
+	UpdateScanConfig(scanConfig models.ScanConfig, params models.PatchScanConfigsScanConfigIDParams) (models.ScanConfig, error)
+	SaveScanConfig(scanConfig models.ScanConfig, params models.PutScanConfigsScanConfigIDParams) (models.ScanConfig, error)
 
 	DeleteScanConfig(scanConfigID models.ScanConfigID) error
 }
@@ -86,8 +95,8 @@ type TargetsTable interface {
 	GetTarget(targetID models.TargetID, params models.GetTargetsTargetIDParams) (models.Target, error)
 
 	CreateTarget(target models.Target) (models.Target, error)
-	UpdateTarget(target models.Target) (models.Target, error)
-	SaveTarget(target models.Target) (models.Target, error)
+	UpdateTarget(target models.Target, params models.PatchTargetsTargetIDParams) (models.Target, error)
+	SaveTarget(target models.Target, params models.PutTargetsTargetIDParams) (models.Target, error)
 
 	DeleteTarget(targetID models.TargetID) error
 }

--- a/shared/pkg/backendclient/client.go
+++ b/shared/pkg/backendclient/client.go
@@ -105,7 +105,8 @@ func (b *BackendClient) PatchScanResult(ctx context.Context, scanResult models.T
 		return fmt.Errorf("failed to update scan result %v: %w", scanResultID, err)
 	}
 
-	resp, err := b.apiClient.PatchScanResultsScanResultIDWithResponse(ctx, scanResultID, scanResult)
+	params := models.PatchScanResultsScanResultIDParams{}
+	resp, err := b.apiClient.PatchScanResultsScanResultIDWithResponse(ctx, scanResultID, &params, scanResult)
 	if err != nil {
 		return newUpdateScanResultError(err)
 	}
@@ -208,7 +209,8 @@ func (b *BackendClient) PostScanResult(ctx context.Context, scanResult models.Ta
 }
 
 func (b *BackendClient) PatchScan(ctx context.Context, scanID models.ScanID, scan *models.Scan) error {
-	resp, err := b.apiClient.PatchScansScanIDWithResponse(ctx, scanID, *scan)
+	params := models.PatchScansScanIDParams{}
+	resp, err := b.apiClient.PatchScansScanIDWithResponse(ctx, scanID, &params, *scan)
 	if err != nil {
 		return fmt.Errorf("failed to update a scan: %v", err)
 	}
@@ -265,7 +267,8 @@ func (b *BackendClient) PatchTargetScanStatus(ctx context.Context, scanResultID 
 	scanResult := models.TargetScanResult{
 		Status: status,
 	}
-	resp, err := b.apiClient.PatchScanResultsScanResultIDWithResponse(ctx, scanResultID, scanResult)
+	params := models.PatchScanResultsScanResultIDParams{}
+	resp, err := b.apiClient.PatchScanResultsScanResultIDWithResponse(ctx, scanResultID, &params, scanResult)
 	if err != nil {
 		return fmt.Errorf("failed to update a scan result status: %v", err)
 	}
@@ -347,7 +350,8 @@ func (b *BackendClient) PatchScanConfig(ctx context.Context, scanConfigID string
 		return fmt.Errorf("failed to update scan config %v: %w", scanConfigID, err)
 	}
 
-	resp, err := b.apiClient.PatchScanConfigsScanConfigIDWithResponse(ctx, scanConfigID, *scanConfig)
+	params := models.PatchScanConfigsScanConfigIDParams{}
+	resp, err := b.apiClient.PatchScanConfigsScanConfigIDWithResponse(ctx, scanConfigID, &params, *scanConfig)
 	if err != nil {
 		return newPatchScanConfigResultError(err)
 	}
@@ -440,7 +444,8 @@ func (b *BackendClient) PatchTarget(ctx context.Context, target models.Target, t
 		return fmt.Errorf("failed to update target %v: %w", targetID, err)
 	}
 
-	resp, err := b.apiClient.PatchTargetsTargetIDWithResponse(ctx, targetID, target)
+	params := models.PatchTargetsTargetIDParams{}
+	resp, err := b.apiClient.PatchTargetsTargetIDWithResponse(ctx, targetID, &params, target)
 	if err != nil {
 		return newUpdateTargetError(err)
 	}


### PR DESCRIPTION
## Description

This adds a revision number to every VMClarity API object, this number can be used as an eTag in the API through the If-Match header to ensure that we avoid "lost update" issues while reconciling objects.

## Type of Change

[ ] Bug Fix  
[X] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
