### PR TITLE
increase root vol size

### DIFF
--- a/installation/aws/VmClarity.cfn
+++ b/installation/aws/VmClarity.cfn
@@ -76,6 +76,13 @@ Resources:
           - !Ref InstanceType
           - Arch
       KeyName: !Ref KeyName
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            VolumeType: gp2
+            VolumeSize: '30'
+            DeleteOnTermination: 'true'
+            Encrypted: 'false'
       IamInstanceProfile:
         Ref: VmClarityServerInstanceProfile
       NetworkInterfaces:


### PR DESCRIPTION
## Description

Proposal to include a root volume definition in the Cloudformation template to increase the root volume size(from the default 8Gb) of the VMClarity Server to avoid very quickly running out of disk space when performing scans. Proposed increase to 30 Gb which is the max free tier limit.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ x] Other (please describe)  

Minor enhancement suggestion to avoid users rapidly running out of disk space on the VM clarity Server when performing scans. 

## Checklist

- [ x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ x] Existing issues have been referenced (where applicable)
- [x ] I have verified this change is not present in other open pull requests
- [n/a ] Functionality is documented
- [ x] All code style checks pass
- [ n/a] New code contribution is covered by automated tests
- [ n/a] All new and existing tests pass

This is a config change so some of the above are not applicable for cfn changes. 