### PR TITLE
Fix grype-server container reference in the cloudformation

### DIFF
--- a/installation/aws/VmClarity.cfn
+++ b/installation/aws/VmClarity.cfn
@@ -347,7 +347,7 @@ Resources:
 
                     [Install]
                     WantedBy=multi-user.target
-                  - GrypeServerContainerImage: !If [GrypeServerContainerImageOverridden, !Ref GrypeServerContainerImageOverride, "gcr.io/eticloud/k8sec/grype-server:v0.2.0"]
+                  - GrypeServerContainerImage: !If [GrypeServerContainerImageOverridden, !Ref GrypeServerContainerImageOverride, "ghcr.io/openclarity/grype-server:v0.2.0"]
               mode: "000644"
             "/lib/systemd/system/vmclarity_freshclam_mirror.service":
               content:
@@ -831,7 +831,7 @@ Parameters:
   GrypeServerContainerImageOverride:
     Description: >
       Name of the container image used for the grype server.
-      "gcr.io/eticloud/k8sec/grype-server:v0.2.0" will be used if not overridden.
+      "ghcr.io/openclarity/grype-server:v0.2.0" will be used if not overridden.
     Type: String
     Default: ''
   AssetScanDeletePolicy:


### PR DESCRIPTION
## Description

This was a regression introduced when the cloud formation was refactored, this ensures we have the correct reference.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
