### PR TITLE
remove mount prefix

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openclarity/vmclarity/cli/pkg/cli"
 	"github.com/openclarity/vmclarity/cli/pkg/presenter"
 	"github.com/openclarity/vmclarity/cli/pkg/state"
+	"github.com/openclarity/vmclarity/runtime_scan/pkg/utils"
 	"github.com/openclarity/vmclarity/shared/pkg/backendclient"
 	"github.com/openclarity/vmclarity/shared/pkg/families"
 	"github.com/openclarity/vmclarity/shared/pkg/families/malware"
@@ -277,22 +278,25 @@ func setMountPointsForFamiliesInput(mountPoints []string, familiesConfig *famili
 
 		if familiesConfig.Secrets.Enabled {
 			familiesConfig.Secrets.Inputs = append(familiesConfig.Secrets.Inputs, secrets.Input{
-				Input:     mountDir,
-				InputType: string(kubeclarityutils.ROOTFS),
+				StripPathFromResult: utils.PointerTo(true),
+				Input:               mountDir,
+				InputType:           string(kubeclarityutils.ROOTFS),
 			})
 		}
 
 		if familiesConfig.Malware.Enabled {
 			familiesConfig.Malware.Inputs = append(familiesConfig.Malware.Inputs, malware.Input{
-				Input:     mountDir,
-				InputType: string(kubeclarityutils.ROOTFS),
+				StripPathFromResult: utils.PointerTo(true),
+				Input:               mountDir,
+				InputType:           string(kubeclarityutils.ROOTFS),
 			})
 		}
 
 		if familiesConfig.Rootkits.Enabled {
 			familiesConfig.Rootkits.Inputs = append(familiesConfig.Rootkits.Inputs, rootkits.Input{
-				Input:     mountDir,
-				InputType: string(kubeclarityutils.ROOTFS),
+				StripPathFromResult: utils.PointerTo(true),
+				Input:               mountDir,
+				InputType:           string(kubeclarityutils.ROOTFS),
 			})
 		}
 
@@ -300,8 +304,9 @@ func setMountPointsForFamiliesInput(mountPoints []string, familiesConfig *famili
 			familiesConfig.Misconfiguration.Inputs = append(
 				familiesConfig.Misconfiguration.Inputs,
 				misconfigurationTypes.Input{
-					Input:     mountDir,
-					InputType: string(kubeclarityutils.ROOTFS),
+					StripPathFromResult: utils.PointerTo(true),
+					Input:               mountDir,
+					InputType:           string(kubeclarityutils.ROOTFS),
 				},
 			)
 		}

--- a/cli/cmd/root_test.go
+++ b/cli/cmd/root_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/openclarity/vmclarity/shared/pkg/families/malware"
+	utils2 "github.com/openclarity/vmclarity/shared/pkg/utils"
 
 	"github.com/openclarity/kubeclarity/shared/pkg/utils"
 
@@ -81,8 +82,9 @@ func Test_setMountPointsForFamiliesInput(t *testing.T) {
 					Enabled: true,
 					Inputs: []secrets.Input{
 						{
-							Input:     "/mnt/snapshot1",
-							InputType: string(utils.ROOTFS),
+							StripPathFromResult: utils2.PointerTo(true),
+							Input:               "/mnt/snapshot1",
+							InputType:           string(utils.ROOTFS),
 						},
 					},
 				},
@@ -90,8 +92,9 @@ func Test_setMountPointsForFamiliesInput(t *testing.T) {
 					Enabled: true,
 					Inputs: []malware.Input{
 						{
-							Input:     "/mnt/snapshot1",
-							InputType: string(utils.ROOTFS),
+							StripPathFromResult: utils2.PointerTo(true),
+							Input:               "/mnt/snapshot1",
+							InputType:           string(utils.ROOTFS),
 						},
 					},
 				},

--- a/cli/pkg/presenter/writer.go
+++ b/cli/pkg/presenter/writer.go
@@ -53,7 +53,7 @@ func (w *FileWriter) Write(b []byte, filename string) error {
 	filePath := path.Join(w.Path, filename)
 	log.Infof("Writing results to %v...", filePath)
 
-	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0666) // nolint:gomnd,gofumpt
+	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0o666) // nolint:gomnd,gofumpt
 	if err != nil {
 		return fmt.Errorf("failed open file %s: %w", filePath, err)
 	}

--- a/shared/pkg/families/malware/config.go
+++ b/shared/pkg/families/malware/config.go
@@ -18,13 +18,16 @@ package malware
 import "github.com/openclarity/vmclarity/shared/pkg/families/malware/common"
 
 type Config struct {
-	Enabled        bool                   `yaml:"enabled" mapstructure:"enabled"`
-	ScannersList   []string               `yaml:"scanners_list" mapstructure:"scanners_list"`
-	Inputs         []Input                `yaml:"inputs" mapstructure:"inputs"`
-	ScannersConfig *common.ScannersConfig `yaml:"scanners_config" mapstructure:"scanners_config"`
+	Enabled         bool                   `yaml:"enabled" mapstructure:"enabled"`
+	ScannersList    []string               `yaml:"scanners_list" mapstructure:"scanners_list"`
+	StripInputPaths bool                   `yaml:"strip_input_paths" mapstructure:"strip_input_paths"`
+	Inputs          []Input                `yaml:"inputs" mapstructure:"inputs"`
+	ScannersConfig  *common.ScannersConfig `yaml:"scanners_config" mapstructure:"scanners_config"`
 }
 
 type Input struct {
-	Input     string `yaml:"input" mapstructure:"input"`
-	InputType string `yaml:"input_type" mapstructure:"input_type"`
+	// StripPathFromResult overrides global StripInputPaths value
+	StripPathFromResult *bool  `yaml:"strip_path_from_result" mapstructure:"strip_path_from_result"`
+	Input               string `yaml:"input" mapstructure:"input"`
+	InputType           string `yaml:"input_type" mapstructure:"input_type"`
 }

--- a/shared/pkg/families/malware/family.go
+++ b/shared/pkg/families/malware/family.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openclarity/vmclarity/shared/pkg/families/malware/job"
 	"github.com/openclarity/vmclarity/shared/pkg/families/results"
 	"github.com/openclarity/vmclarity/shared/pkg/families/types"
+	familiesutils "github.com/openclarity/vmclarity/shared/pkg/families/utils"
 )
 
 type Malware struct {
@@ -52,12 +53,23 @@ func (m Malware) Run(res *results.Results) (interfaces.IsResults, error) {
 			if !ok {
 				return nil, fmt.Errorf("received results of a wrong type: %T", result)
 			}
+			if familiesutils.ShouldStripInputPath(input.StripPathFromResult, m.conf.StripInputPaths) {
+				res = StripPathFromResult(res, input.Input)
+			}
 			mergedResults = mergedResults.Merge(res)
 		}
 	}
 
 	m.logger.Info("Malware Done...")
 	return mergedResults, nil
+}
+
+// StripPathFromResult strip input path from results wherever it is found.
+func StripPathFromResult(result *common.Results, path string) *common.Results {
+	for i, _ := range result.Malware {
+		result.Malware[i].Path = familiesutils.TrimMountPath(result.Malware[i].Path, path)
+	}
+	return result
 }
 
 func (m Malware) GetType() types.FamilyType {

--- a/shared/pkg/families/malware/family.go
+++ b/shared/pkg/families/malware/family.go
@@ -66,7 +66,7 @@ func (m Malware) Run(res *results.Results) (interfaces.IsResults, error) {
 
 // StripPathFromResult strip input path from results wherever it is found.
 func StripPathFromResult(result *common.Results, path string) *common.Results {
-	for i, _ := range result.Malware {
+	for i := range result.Malware {
 		result.Malware[i].Path = familiesutils.TrimMountPath(result.Malware[i].Path, path)
 	}
 	return result

--- a/shared/pkg/families/malware/family_test.go
+++ b/shared/pkg/families/malware/family_test.go
@@ -1,0 +1,66 @@
+package malware
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openclarity/vmclarity/shared/pkg/families/malware/common"
+)
+
+func TestStripPathFromResult(t *testing.T) {
+	type args struct {
+		result *common.Results
+		path   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *common.Results
+	}{
+		{
+			name: "sanity",
+			args: args{
+				result: &common.Results{
+					Source:      "source1",
+					ScannerName: "scanner1",
+					Malware: []common.DetectedMalware{
+						{
+							MalwareName: "name1",
+							MalwareType: "type1",
+							Path:        "/mnt/foo1",
+						},
+						{
+							MalwareName: "name2",
+							MalwareType: "type2",
+							Path:        "/mnt/foo2",
+						},
+					},
+				},
+				path: "/mnt",
+			},
+			want: &common.Results{
+				Source:      "source1",
+				ScannerName: "scanner1",
+				Malware: []common.DetectedMalware{
+					{
+						MalwareName: "name1",
+						MalwareType: "type1",
+						Path:        "/foo1",
+					},
+					{
+						MalwareName: "name2",
+						MalwareType: "type2",
+						Path:        "/foo2",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripPathFromResult(tt.args.result, tt.args.path); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StripPathFromResult() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/shared/pkg/families/malware/family_test.go
+++ b/shared/pkg/families/malware/family_test.go
@@ -1,3 +1,18 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package malware
 
 import (

--- a/shared/pkg/families/misconfiguration/family.go
+++ b/shared/pkg/families/misconfiguration/family.go
@@ -69,7 +69,7 @@ func (m Misconfiguration) Run(res *results.Results) (interfaces.IsResults, error
 
 // StripPathFromResult strip input path from results wherever it is found.
 func StripPathFromResult(result misconfigurationTypes.ScannerResult, path string) misconfigurationTypes.ScannerResult {
-	for i, _ := range result.Misconfigurations {
+	for i := range result.Misconfigurations {
 		result.Misconfigurations[i].ScannedPath = familiesutils.TrimMountPath(result.Misconfigurations[i].ScannedPath, path)
 	}
 	return result

--- a/shared/pkg/families/misconfiguration/family.go
+++ b/shared/pkg/families/misconfiguration/family.go
@@ -28,6 +28,7 @@ import (
 	misconfigurationTypes "github.com/openclarity/vmclarity/shared/pkg/families/misconfiguration/types"
 	"github.com/openclarity/vmclarity/shared/pkg/families/results"
 	"github.com/openclarity/vmclarity/shared/pkg/families/types"
+	familiesutils "github.com/openclarity/vmclarity/shared/pkg/families/utils"
 )
 
 type Misconfiguration struct {
@@ -51,6 +52,9 @@ func (m Misconfiguration) Run(res *results.Results) (interfaces.IsResults, error
 		for name, result := range managerResults {
 			m.logger.Infof("Merging result from %q", name)
 			if scanResult, ok := result.(misconfigurationTypes.ScannerResult); ok {
+				if familiesutils.ShouldStripInputPath(input.StripPathFromResult, m.conf.StripInputPaths) {
+					scanResult = StripPathFromResult(scanResult, input.Input)
+				}
 				results.AddScannerResult(scanResult)
 			} else {
 				return nil, fmt.Errorf("received bad scanner result type %T, expected misconfigurationTypes.ScannerResult", result)
@@ -61,6 +65,14 @@ func (m Misconfiguration) Run(res *results.Results) (interfaces.IsResults, error
 	m.logger.Info("Misconfiguration Done...")
 
 	return results, nil
+}
+
+// StripPathFromResult strip input path from results wherever it is found.
+func StripPathFromResult(result misconfigurationTypes.ScannerResult, path string) misconfigurationTypes.ScannerResult {
+	for i, _ := range result.Misconfigurations {
+		result.Misconfigurations[i].ScannedPath = familiesutils.TrimMountPath(result.Misconfigurations[i].ScannedPath, path)
+	}
+	return result
 }
 
 func (m Misconfiguration) GetType() types.FamilyType {

--- a/shared/pkg/families/misconfiguration/family_test.go
+++ b/shared/pkg/families/misconfiguration/family_test.go
@@ -1,0 +1,80 @@
+package misconfiguration
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openclarity/vmclarity/shared/pkg/families/misconfiguration/types"
+)
+
+func TestStripPathFromResult(t *testing.T) {
+	type args struct {
+		result types.ScannerResult
+		path   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want types.ScannerResult
+	}{
+		{
+			name: "sanity",
+			args: args{
+				result: types.ScannerResult{
+					ScannerName: "scanner1",
+					Misconfigurations: []types.Misconfiguration{
+						{
+							ScannedPath:     "/mnt/foo",
+							TestCategory:    "test1",
+							TestID:          "id1",
+							TestDescription: "desc1",
+						},
+						{
+							ScannedPath:     "/mnt/foo2",
+							TestCategory:    "test2",
+							TestID:          "id2",
+							TestDescription: "desc2",
+						},
+						{
+							ScannedPath:     "/foo3",
+							TestCategory:    "test3",
+							TestID:          "id3",
+							TestDescription: "desc3",
+						},
+					},
+				},
+				path: "/mnt",
+			},
+			want: types.ScannerResult{
+				ScannerName: "scanner1",
+				Misconfigurations: []types.Misconfiguration{
+					{
+						ScannedPath:     "/foo",
+						TestCategory:    "test1",
+						TestID:          "id1",
+						TestDescription: "desc1",
+					},
+					{
+						ScannedPath:     "/foo2",
+						TestCategory:    "test2",
+						TestID:          "id2",
+						TestDescription: "desc2",
+					},
+					{
+						ScannedPath:     "/foo3",
+						TestCategory:    "test3",
+						TestID:          "id3",
+						TestDescription: "desc3",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripPathFromResult(tt.args.result, tt.args.path); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StripPathFromResult() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/shared/pkg/families/misconfiguration/family_test.go
+++ b/shared/pkg/families/misconfiguration/family_test.go
@@ -1,3 +1,18 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package misconfiguration
 
 import (

--- a/shared/pkg/families/misconfiguration/types/config.go
+++ b/shared/pkg/families/misconfiguration/types/config.go
@@ -16,15 +16,18 @@
 package types
 
 type Config struct {
-	Enabled        bool           `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
-	ScannersList   []string       `yaml:"scanners_list" mapstructure:"scanners_list"`
-	Inputs         []Input        `yaml:"inputs" mapstructure:"inputs"`
-	ScannersConfig ScannersConfig `yaml:"scanners_config" mapstructure:"scanners_config"`
+	Enabled         bool           `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	ScannersList    []string       `yaml:"scanners_list" mapstructure:"scanners_list"`
+	StripInputPaths bool           `yaml:"strip_input_paths" mapstructure:"strip_input_paths"`
+	Inputs          []Input        `yaml:"inputs" mapstructure:"inputs"`
+	ScannersConfig  ScannersConfig `yaml:"scanners_config" mapstructure:"scanners_config"`
 }
 
 type Input struct {
-	Input     string `yaml:"input" mapstructure:"input"`
-	InputType string `yaml:"input_type" mapstructure:"input_type"`
+	// StripPathFromResult overrides global StripInputPaths value
+	StripPathFromResult *bool  `yaml:"strip_path_from_result" mapstructure:"strip_path_from_result"`
+	Input               string `yaml:"input" mapstructure:"input"`
+	InputType           string `yaml:"input_type" mapstructure:"input_type"`
 }
 
 // Add scanner specific configurations here, where the key is the scanner name,

--- a/shared/pkg/families/rootkits/config.go
+++ b/shared/pkg/families/rootkits/config.go
@@ -20,13 +20,16 @@ import (
 )
 
 type Config struct {
-	Enabled        bool                   `yaml:"enabled" mapstructure:"enabled"`
-	ScannersList   []string               `yaml:"scanners_list" mapstructure:"scanners_list"`
-	Inputs         []Input                `yaml:"inputs" mapstructure:"inputs"`
-	ScannersConfig *common.ScannersConfig `yaml:"scanners_config" mapstructure:"scanners_config"`
+	Enabled         bool                   `yaml:"enabled" mapstructure:"enabled"`
+	ScannersList    []string               `yaml:"scanners_list" mapstructure:"scanners_list"`
+	StripInputPaths bool                   `yaml:"strip_input_paths" mapstructure:"strip_input_paths"`
+	Inputs          []Input                `yaml:"inputs" mapstructure:"inputs"`
+	ScannersConfig  *common.ScannersConfig `yaml:"scanners_config" mapstructure:"scanners_config"`
 }
 
 type Input struct {
-	Input     string `yaml:"input" mapstructure:"input"`
-	InputType string `yaml:"input_type" mapstructure:"input_type"`
+	// StripPathFromResult overrides global StripInputPaths value
+	StripPathFromResult *bool  `yaml:"strip_path_from_result" mapstructure:"strip_path_from_result"`
+	Input               string `yaml:"input" mapstructure:"input"`
+	InputType           string `yaml:"input_type" mapstructure:"input_type"`
 }

--- a/shared/pkg/families/rootkits/family.go
+++ b/shared/pkg/families/rootkits/family.go
@@ -67,7 +67,7 @@ func (r Rootkits) Run(res *familiesresults.Results) (familiesinterface.IsResults
 
 // StripPathFromResult strip input path from results wherever it is found.
 func StripPathFromResult(result *common.Results, path string) *common.Results {
-	for i, _ := range result.Rootkits {
+	for i := range result.Rootkits {
 		result.Rootkits[i].Message = familiesutils.RemoveMountPathSubStringIfNeeded(result.Rootkits[i].Message, path)
 	}
 	return result

--- a/shared/pkg/families/rootkits/family.go
+++ b/shared/pkg/families/rootkits/family.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openclarity/vmclarity/shared/pkg/families/rootkits/common"
 	"github.com/openclarity/vmclarity/shared/pkg/families/rootkits/job"
 	"github.com/openclarity/vmclarity/shared/pkg/families/types"
+	familiesutils "github.com/openclarity/vmclarity/shared/pkg/families/utils"
 )
 
 type Rootkits struct {
@@ -50,7 +51,11 @@ func (r Rootkits) Run(res *familiesresults.Results) (familiesinterface.IsResults
 		// Merge results.
 		for name, result := range results {
 			r.logger.Infof("Merging result from %q", name)
-			mergedResults = mergedResults.Merge(result.(*common.Results)) // nolint:forcetypeassert
+			scannerResult := result.(*common.Results) // nolint:forcetypeassert
+			if familiesutils.ShouldStripInputPath(input.StripPathFromResult, r.conf.StripInputPaths) {
+				scannerResult = StripPathFromResult(scannerResult, input.Input)
+			}
+			mergedResults = mergedResults.Merge(scannerResult)
 		}
 	}
 
@@ -58,6 +63,14 @@ func (r Rootkits) Run(res *familiesresults.Results) (familiesinterface.IsResults
 	return &Results{
 		MergedResults: mergedResults,
 	}, nil
+}
+
+// StripPathFromResult strip input path from results wherever it is found.
+func StripPathFromResult(result *common.Results, path string) *common.Results {
+	for i, _ := range result.Rootkits {
+		result.Rootkits[i].Message = familiesutils.RemoveMountPathSubStringIfNeeded(result.Rootkits[i].Message, path)
+	}
+	return result
 }
 
 func (r Rootkits) GetType() types.FamilyType {

--- a/shared/pkg/families/rootkits/family_test.go
+++ b/shared/pkg/families/rootkits/family_test.go
@@ -1,3 +1,18 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rootkits
 
 import (

--- a/shared/pkg/families/rootkits/family_test.go
+++ b/shared/pkg/families/rootkits/family_test.go
@@ -1,0 +1,66 @@
+package rootkits
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openclarity/vmclarity/shared/pkg/families/rootkits/common"
+)
+
+func TestStripPathFromResult(t *testing.T) {
+	type args struct {
+		result *common.Results
+		path   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *common.Results
+	}{
+		{
+			name: "sanity",
+			args: args{
+				result: &common.Results{
+					Rootkits: []common.Rootkit{
+						{
+							Message:     "rootkit found in /mnt/foo path",
+							RootkitName: "rk1",
+							RootkitType: "t1",
+						},
+						{
+							Message:     "rootkit found in /mnt/bar path",
+							RootkitName: "rk2",
+							RootkitType: "t2",
+						},
+					},
+					ScannedInput: "/mnt/foo",
+					ScannerName:  "scanner1",
+				},
+				path: "/mnt",
+			},
+			want: &common.Results{
+				Rootkits: []common.Rootkit{
+					{
+						Message:     "rootkit found in /foo path",
+						RootkitName: "rk1",
+						RootkitType: "t1",
+					},
+					{
+						Message:     "rootkit found in /bar path",
+						RootkitName: "rk2",
+						RootkitType: "t2",
+					},
+				},
+				ScannedInput: "/mnt/foo",
+				ScannerName:  "scanner1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripPathFromResult(tt.args.result, tt.args.path); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StripPathFromResult() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/shared/pkg/families/secrets/config.go
+++ b/shared/pkg/families/secrets/config.go
@@ -20,13 +20,16 @@ import (
 )
 
 type Config struct {
-	Enabled        bool                   `yaml:"enabled" mapstructure:"enabled"`
-	ScannersList   []string               `yaml:"scanners_list" mapstructure:"scanners_list"`
-	Inputs         []Input                `yaml:"inputs" mapstructure:"inputs"`
-	ScannersConfig *common.ScannersConfig `yaml:"scanners_config" mapstructure:"scanners_config"`
+	Enabled         bool                   `yaml:"enabled" mapstructure:"enabled"`
+	ScannersList    []string               `yaml:"scanners_list" mapstructure:"scanners_list"`
+	StripInputPaths bool                   `yaml:"strip_input_paths" mapstructure:"strip_input_paths"`
+	Inputs          []Input                `yaml:"inputs" mapstructure:"inputs"`
+	ScannersConfig  *common.ScannersConfig `yaml:"scanners_config" mapstructure:"scanners_config"`
 }
 
 type Input struct {
-	Input     string `yaml:"input" mapstructure:"input"`
-	InputType string `yaml:"input_type" mapstructure:"input_type"`
+	// StripPathFromResult overrides global StripInputPaths value
+	StripPathFromResult *bool  `yaml:"strip_path_from_result" mapstructure:"strip_path_from_result"`
+	Input               string `yaml:"input" mapstructure:"input"`
+	InputType           string `yaml:"input_type" mapstructure:"input_type"`
 }

--- a/shared/pkg/families/secrets/family.go
+++ b/shared/pkg/families/secrets/family.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openclarity/vmclarity/shared/pkg/families/secrets/common"
 	"github.com/openclarity/vmclarity/shared/pkg/families/secrets/job"
 	"github.com/openclarity/vmclarity/shared/pkg/families/types"
+	familiesutils "github.com/openclarity/vmclarity/shared/pkg/families/utils"
 )
 
 type Secrets struct {
@@ -49,8 +50,12 @@ func (s Secrets) Run(res *familiesresults.Results) (interfaces.IsResults, error)
 
 		// Merge results.
 		for name, result := range results {
+			secretResult := result.(*common.Results) // nolint:forcetypeassert
+			if familiesutils.ShouldStripInputPath(input.StripPathFromResult, s.conf.StripInputPaths) {
+				secretResult = StripPathFromResult(secretResult, input.Input)
+			}
 			s.logger.Infof("Merging result from %q", name)
-			mergedResults = mergedResults.Merge(result.(*common.Results)) // nolint:forcetypeassert
+			mergedResults = mergedResults.Merge(secretResult)
 		}
 	}
 
@@ -58,6 +63,15 @@ func (s Secrets) Run(res *familiesresults.Results) (interfaces.IsResults, error)
 	return &Results{
 		MergedResults: mergedResults,
 	}, nil
+}
+
+// StripPathFromResult strip input path from results wherever it is found.
+func StripPathFromResult(result *common.Results, path string) *common.Results {
+	for i, _ := range result.Findings {
+		result.Findings[i].File = familiesutils.TrimMountPath(result.Findings[i].File, path)
+		result.Findings[i].Fingerprint = familiesutils.RemoveMountPathSubStringIfNeeded(result.Findings[i].Fingerprint, path)
+	}
+	return result
 }
 
 func (s Secrets) GetType() types.FamilyType {

--- a/shared/pkg/families/secrets/family.go
+++ b/shared/pkg/families/secrets/family.go
@@ -67,7 +67,7 @@ func (s Secrets) Run(res *familiesresults.Results) (interfaces.IsResults, error)
 
 // StripPathFromResult strip input path from results wherever it is found.
 func StripPathFromResult(result *common.Results, path string) *common.Results {
-	for i, _ := range result.Findings {
+	for i := range result.Findings {
 		result.Findings[i].File = familiesutils.TrimMountPath(result.Findings[i].File, path)
 		result.Findings[i].Fingerprint = familiesutils.RemoveMountPathSubStringIfNeeded(result.Findings[i].Fingerprint, path)
 	}

--- a/shared/pkg/families/secrets/family_test.go
+++ b/shared/pkg/families/secrets/family_test.go
@@ -1,3 +1,18 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package secrets
 
 import (

--- a/shared/pkg/families/secrets/family_test.go
+++ b/shared/pkg/families/secrets/family_test.go
@@ -1,0 +1,82 @@
+package secrets
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openclarity/vmclarity/shared/pkg/families/secrets/common"
+)
+
+func TestStripPathFromResult(t *testing.T) {
+	type args struct {
+		result *common.Results
+		path   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *common.Results
+	}{
+		{
+			name: "sanity",
+			args: args{
+				result: &common.Results{
+					Findings: []common.Findings{
+						{
+							Description: "description",
+							File:        "/mnt/file1",
+							Message:     "message",
+							Fingerprint: "finger:/mnt:hello",
+						},
+						{
+							Description: "description2",
+							File:        "/mnt/file2",
+							Message:     "message",
+							Fingerprint: "finger:/mnt/foo:hello2",
+						},
+						{
+							Description: "description3",
+							File:        "file3",
+							Message:     "message",
+							Fingerprint: "finger:hello3",
+						},
+					},
+					Source:      "source",
+					ScannerName: "name",
+				},
+				path: "/mnt",
+			},
+			want: &common.Results{
+				Findings: []common.Findings{
+					{
+						Description: "description",
+						File:        "/file1",
+						Message:     "message",
+						Fingerprint: "finger:/:hello",
+					},
+					{
+						Description: "description2",
+						File:        "/file2",
+						Message:     "message",
+						Fingerprint: "finger:/foo:hello2",
+					},
+					{
+						Description: "description3",
+						File:        "file3",
+						Message:     "message",
+						Fingerprint: "finger:hello3",
+					},
+				},
+				Source:      "source",
+				ScannerName: "name",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripPathFromResult(tt.args.result, tt.args.path); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StripPathFromResult() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/shared/pkg/families/utils/utils.go
+++ b/shared/pkg/families/utils/utils.go
@@ -1,0 +1,44 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "strings"
+
+func TrimMountPath(toTrim string, mountPath string) string {
+	// avoid representing root directory as empty string
+	if toTrim == mountPath {
+		return "/"
+	}
+	return strings.TrimPrefix(toTrim, mountPath)
+}
+
+func RemoveMountPathSubStringIfNeeded(toTrim string, mountPath string) string {
+	if strings.Contains(toTrim, mountPath) {
+		// assume prefix is /mnt:
+		// first address cases like /mnt/foo -> should be /foo
+		toTrim = strings.ReplaceAll(toTrim, mountPath+"/", "/")
+		// then address cases like /mnt -> should be /
+		return strings.ReplaceAll(toTrim, mountPath, "/")
+	}
+	return toTrim
+}
+
+func ShouldStripInputPath(inputShouldStrip *bool, familyShouldStrip bool) bool {
+	if inputShouldStrip == nil {
+		return familyShouldStrip
+	}
+	return *inputShouldStrip
+}

--- a/shared/pkg/families/utils/utils_test.go
+++ b/shared/pkg/families/utils/utils_test.go
@@ -1,3 +1,18 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package utils
 
 import (

--- a/shared/pkg/families/utils/utils_test.go
+++ b/shared/pkg/families/utils/utils_test.go
@@ -1,0 +1,171 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/openclarity/vmclarity/shared/pkg/utils"
+)
+
+func TestTrimMountPath(t *testing.T) {
+	type args struct {
+		toTrim    string
+		mountPath string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "root path",
+			args: args{
+				toTrim:    "/mnt",
+				mountPath: "/mnt",
+			},
+			want: "/",
+		},
+		{
+			name: "not root path",
+			args: args{
+				toTrim:    "/mnt/foo",
+				mountPath: "/mnt",
+			},
+			want: "/foo",
+		},
+		{
+			name: "no trim",
+			args: args{
+				toTrim:    "/bar/foo",
+				mountPath: "/mnt",
+			},
+			want: "/bar/foo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TrimMountPath(tt.args.toTrim, tt.args.mountPath); got != tt.want {
+				t.Errorf("TrimMountPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRemoveMountPathSubStringIfNeeded(t *testing.T) {
+	type args struct {
+		toTrim    string
+		mountPath string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "from prefix",
+			args: args{
+				toTrim:    "/mnt/foo some massage",
+				mountPath: "/mnt",
+			},
+			want: "/foo some massage",
+		},
+		{
+			name: "from prefix replace with /",
+			args: args{
+				toTrim:    "/mnt some massage",
+				mountPath: "/mnt",
+			},
+			want: "/ some massage",
+		},
+		{
+			name: "from middle",
+			args: args{
+				toTrim:    "some message /mnt/foo some massage",
+				mountPath: "/mnt",
+			},
+			want: "some message /foo some massage",
+		},
+		{
+			name: "from middle replace with /",
+			args: args{
+				toTrim:    "some message /mnt some massage",
+				mountPath: "/mnt",
+			},
+			want: "some message / some massage",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RemoveMountPathSubStringIfNeeded(tt.args.toTrim, tt.args.mountPath); got != tt.want {
+				t.Errorf("RemoveMountPathSubStringIfNeeded() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldStripInputPath(t *testing.T) {
+	type args struct {
+		inputShouldStrip  *bool
+		familyShouldStrip bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "inputShouldStrip = nil, familyShouldStrip = false",
+			args: args{
+				inputShouldStrip:  nil,
+				familyShouldStrip: false,
+			},
+			want: false,
+		},
+		{
+			name: "inputShouldStrip = nil, familyShouldStrip = true",
+			args: args{
+				inputShouldStrip:  nil,
+				familyShouldStrip: true,
+			},
+			want: true,
+		},
+		{
+			name: "inputShouldStrip = false, familyShouldStrip = false",
+			args: args{
+				inputShouldStrip:  utils.PointerTo(false),
+				familyShouldStrip: false,
+			},
+			want: false,
+		},
+		{
+			name: "inputShouldStrip = false, familyShouldStrip = true",
+			args: args{
+				inputShouldStrip:  utils.PointerTo(false),
+				familyShouldStrip: true,
+			},
+			want: false,
+		},
+		{
+			name: "inputShouldStrip = true, familyShouldStrip = false",
+			args: args{
+				inputShouldStrip:  utils.PointerTo(true),
+				familyShouldStrip: false,
+			},
+			want: true,
+		},
+		{
+			name: "inputShouldStrip = true, familyShouldStrip = true",
+			args: args{
+				inputShouldStrip:  utils.PointerTo(true),
+				familyShouldStrip: true,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldStripInputPath(tt.args.inputShouldStrip, tt.args.familyShouldStrip); got != tt.want {
+				t.Errorf("ShouldStripInputPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/shared/pkg/families/vulnerabilities/family.go
+++ b/shared/pkg/families/vulnerabilities/family.go
@@ -62,7 +62,7 @@ func (v Vulnerabilities) Run(res *results.Results) (interfaces.IsResults, error)
 		}
 
 		// TODO: need to avoid writing sbom to file
-		if err := os.WriteFile(sbomTempFilePath, sbomBytes, 0600 /* read & write */); err != nil { // nolint:gomnd,gofumpt
+		if err := os.WriteFile(sbomTempFilePath, sbomBytes, 0o600 /* read & write */); err != nil { // nolint:gomnd,gofumpt
 			return nil, fmt.Errorf("failed to write sbom to file: %v", err)
 		}
 

--- a/ui_backend/pkg/rest/dashboard_findings_impact_test.go
+++ b/ui_backend/pkg/rest/dashboard_findings_impact_test.go
@@ -67,7 +67,7 @@ func Test_processFindings(t *testing.T) {
 			},
 			wantErr: false,
 			expectedFindingAssetMap: map[findingAssetKey]struct{}{
-				findingAssetKey{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
+				{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
 			},
 			expectedFindingToAssetCount: map[string]findingInfoCount{
 				rfKey1: {
@@ -88,7 +88,7 @@ func Test_processFindings(t *testing.T) {
 					},
 				},
 				findingAssetMap: map[findingAssetKey]struct{}{
-					findingAssetKey{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
+					{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
 				},
 				findingToAssetCount: map[string]findingInfoCount{
 					rfKey1: {
@@ -99,7 +99,7 @@ func Test_processFindings(t *testing.T) {
 			},
 			wantErr: false,
 			expectedFindingAssetMap: map[findingAssetKey]struct{}{
-				findingAssetKey{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
+				{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
 			},
 			expectedFindingToAssetCount: map[string]findingInfoCount{
 				rfKey1: {
@@ -120,7 +120,7 @@ func Test_processFindings(t *testing.T) {
 					},
 				},
 				findingAssetMap: map[findingAssetKey]struct{}{
-					findingAssetKey{FindingKey: rfKey1, AssetID: "target-2"}: {}, // nolint:gofmt,gofumpt
+					{FindingKey: rfKey1, AssetID: "target-2"}: {}, // nolint:gofmt,gofumpt
 				},
 				findingToAssetCount: map[string]findingInfoCount{
 					rfKey1: {
@@ -131,8 +131,8 @@ func Test_processFindings(t *testing.T) {
 			},
 			wantErr: false,
 			expectedFindingAssetMap: map[findingAssetKey]struct{}{
-				findingAssetKey{FindingKey: rfKey1, AssetID: "target-2"}: {}, // nolint:gofmt,gofumpt
-				findingAssetKey{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
+				{FindingKey: rfKey1, AssetID: "target-2"}: {}, // nolint:gofmt,gofumpt
+				{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
 			},
 			expectedFindingToAssetCount: map[string]findingInfoCount{
 				rfKey1: {
@@ -171,8 +171,8 @@ func Test_processFindings(t *testing.T) {
 					},
 				},
 				findingAssetMap: map[findingAssetKey]struct{}{
-					findingAssetKey{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
-					findingAssetKey{FindingKey: rfKey2, AssetID: "target-2"}: {}, // nolint:gofmt,gofumpt
+					{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
+					{FindingKey: rfKey2, AssetID: "target-2"}: {}, // nolint:gofmt,gofumpt
 				},
 				findingToAssetCount: map[string]findingInfoCount{
 					rfKey1: {
@@ -187,10 +187,10 @@ func Test_processFindings(t *testing.T) {
 			},
 			wantErr: false,
 			expectedFindingAssetMap: map[findingAssetKey]struct{}{
-				findingAssetKey{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
-				findingAssetKey{FindingKey: rfKey2, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
-				findingAssetKey{FindingKey: rfKey2, AssetID: "target-2"}: {}, // nolint:gofmt,gofumpt
-				findingAssetKey{FindingKey: rfKey3, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
+				{FindingKey: rfKey1, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
+				{FindingKey: rfKey2, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
+				{FindingKey: rfKey2, AssetID: "target-2"}: {}, // nolint:gofmt,gofumpt
+				{FindingKey: rfKey3, AssetID: "target-1"}: {}, // nolint:gofmt,gofumpt
 			},
 			expectedFindingToAssetCount: map[string]findingInfoCount{
 				rfKey1: {


### PR DESCRIPTION
## Description

add a configuration option to the family config, that indicates whether the input path should be cleaned from the results. This is in order to not show the mount path in the results, but only the actually path on disk.

## Type of Change

[* ] Bug Fix  



