### PR TITLE
export results per family scan

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -111,19 +111,15 @@ var rootCmd = &cobra.Command{
 		}
 
 		logger.Infof("Running scanners...")
-		var errs []error
-		famErr := families.New(logger, config).Run(abortCtx, cli)
-		if famErr != nil {
-			errs = append(errs, fmt.Errorf("at least one family failed to run"))
-		}
+		runErrors := families.New(logger, config).Run(abortCtx, cli)
 
-		err = cli.MarkDone(ctx, errs)
+		err = cli.MarkDone(ctx, runErrors)
 		if err != nil {
 			return fmt.Errorf("failed to inform the server %v the scan was completed: %w", server, err)
 		}
 
-		if len(errs) > 0 {
-			return fmt.Errorf("failed to run families: %+v", errs)
+		if len(runErrors) > 0 {
+			logger.Errorf("Errors when running families: %+v", runErrors)
 		}
 
 		return nil

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -40,7 +40,6 @@ import (
 	"github.com/openclarity/vmclarity/shared/pkg/families/rootkits"
 	"github.com/openclarity/vmclarity/shared/pkg/families/sbom"
 	"github.com/openclarity/vmclarity/shared/pkg/families/secrets"
-	"github.com/openclarity/vmclarity/shared/pkg/families/types"
 	"github.com/openclarity/vmclarity/shared/pkg/families/vulnerabilities"
 )
 
@@ -112,44 +111,9 @@ var rootCmd = &cobra.Command{
 		}
 
 		logger.Infof("Running scanners...")
-		resultsChan := make(chan families.FamilyResult, 0)
-		inProgressChan := make(chan types.FamilyType, 0)
-		doneChan := make(chan struct{}, 0)
-		go func() {
-			_ = families.New(logger, config, resultsChan, inProgressChan).Run(abortCtx)
-			doneChan <- struct{}{}
-		}()
-
 		var errs []error
-		var familiesErr []error
-		var exportErrors []error
-	LOOP:
-		for {
-			select {
-			case <-ctx.Done():
-				return fmt.Errorf("failed to wait for all results to arrive")
-			case <-doneChan:
-				logger.Info("got all families results")
-				break LOOP
-			case familyType := <-inProgressChan:
-				if err := cli.MarkFamilyScanInProgress(abortCtx, familyType); err != nil {
-					logger.Warnf("failed to mark scan of %v in progress: %v", familyType, err)
-				}
-			case r := <-resultsChan:
-				logger.Infof("Exporting results of family %v", r.FamilyType)
-				exportErr := cli.ExportFamilyResult(abortCtx, r)
-				if r.Err != nil {
-					familiesErr = append(familiesErr, r.Err)
-				}
-				if exportErr != nil {
-					exportErrors = append(exportErrors, exportErr)
-				}
-			}
-		}
-		errs = append(errs, familiesErr...)
-		errs = append(errs, exportErrors...)
-
-		if len(familiesErr) > 0 {
+		famErr := families.New(logger, config).Run(abortCtx, cli.Presenter, cli.Manager)
+		if famErr != nil {
 			errs = append(errs, fmt.Errorf("at least one family failed to run"))
 		}
 
@@ -158,8 +122,8 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("failed to inform the server %v the scan was completed: %w", server, err)
 		}
 
-		if len(familiesErr) > 0 {
-			return fmt.Errorf("failed to run families: %+v", familiesErr)
+		if len(errs) > 0 {
+			return fmt.Errorf("failed to run families: %+v", errs)
 		}
 
 		return nil

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -112,7 +112,7 @@ var rootCmd = &cobra.Command{
 
 		logger.Infof("Running scanners...")
 		var errs []error
-		famErr := families.New(logger, config).Run(abortCtx, cli.Presenter, cli.Manager)
+		famErr := families.New(logger, config).Run(abortCtx, cli)
 		if famErr != nil {
 			errs = append(errs, fmt.Errorf("at least one family failed to run"))
 		}

--- a/cli/pkg/cli/cli.go
+++ b/cli/pkg/cli/cli.go
@@ -28,7 +28,6 @@ import (
 	"github.com/openclarity/vmclarity/cli/pkg/presenter"
 	"github.com/openclarity/vmclarity/cli/pkg/state"
 	"github.com/openclarity/vmclarity/shared/pkg/families"
-	"github.com/openclarity/vmclarity/shared/pkg/families/types"
 )
 
 const (
@@ -67,30 +66,6 @@ func (c *CLI) MountVolumes(ctx context.Context) ([]string, error) {
 		}
 	}
 	return mountPoints, nil
-}
-
-//nolint:cyclop
-func (c *CLI) ExportFamilyResult(ctx context.Context, res families.FamilyResult) error {
-	var err error
-
-	switch res.FamilyType {
-	case types.SBOM:
-		err = c.ExportSbomResult(ctx, res)
-	case types.Vulnerabilities:
-		err = c.ExportVulResult(ctx, res)
-	case types.Secrets:
-		err = c.ExportSecretsResult(ctx, res)
-	case types.Exploits:
-		err = c.ExportExploitsResult(ctx, res)
-	case types.Misconfiguration:
-		err = c.ExportMisconfigurationResult(ctx, res)
-	case types.Rootkits:
-		err = c.ExportRootkitResult(ctx, res)
-	case types.Malware:
-		err = c.ExportMalwareResult(ctx, res)
-	}
-
-	return err
 }
 
 func (c *CLI) WatchForAbort(ctx context.Context, cancel context.CancelFunc, interval time.Duration) {

--- a/cli/pkg/cli/cli.go
+++ b/cli/pkg/cli/cli.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openclarity/vmclarity/cli/pkg/presenter"
 	"github.com/openclarity/vmclarity/cli/pkg/state"
 	"github.com/openclarity/vmclarity/shared/pkg/families"
+	"github.com/openclarity/vmclarity/shared/pkg/families/types"
 )
 
 const (
@@ -40,6 +41,14 @@ type CLI struct {
 	presenter.Presenter
 
 	FamiliesConfig *families.Config
+}
+
+func (c *CLI) FamilyStarted(ctx context.Context, famType types.FamilyType) error {
+	return c.Manager.MarkFamilyScanInProgress(ctx, famType)
+}
+
+func (c *CLI) FamilyFinished(ctx context.Context, res families.FamilyResult) error {
+	return c.Presenter.ExportFamilyResult(ctx, res)
 }
 
 func (c *CLI) MountVolumes(ctx context.Context) ([]string, error) {

--- a/cli/pkg/presenter/default.go
+++ b/cli/pkg/presenter/default.go
@@ -23,7 +23,6 @@ import (
 	"github.com/openclarity/vmclarity/shared/pkg/families"
 	"github.com/openclarity/vmclarity/shared/pkg/families/exploits"
 	"github.com/openclarity/vmclarity/shared/pkg/families/malware"
-	"github.com/openclarity/vmclarity/shared/pkg/families/results"
 	"github.com/openclarity/vmclarity/shared/pkg/families/rootkits"
 	"github.com/openclarity/vmclarity/shared/pkg/families/sbom"
 	"github.com/openclarity/vmclarity/shared/pkg/families/secrets"
@@ -36,10 +35,10 @@ type DefaultPresenter struct {
 	FamiliesConfig *families.Config
 }
 
-func (p *DefaultPresenter) ExportSbomResult(_ context.Context, res *results.Results, _ families.RunErrors) error {
-	sbomResults, err := results.GetResult[*sbom.Results](res)
-	if err != nil {
-		return fmt.Errorf("failed to get sbom results: %w", err)
+func (p *DefaultPresenter) ExportSbomResult(_ context.Context, res families.FamilyResult) error {
+	sbomResults, ok := res.Result.(*sbom.Results)
+	if !ok {
+		return fmt.Errorf("failed to convert to sbom results")
 	}
 
 	outputFormat := p.FamiliesConfig.SBOM.AnalyzersConfig.Analyzer.OutputFormat
@@ -55,10 +54,10 @@ func (p *DefaultPresenter) ExportSbomResult(_ context.Context, res *results.Resu
 	return nil
 }
 
-func (p *DefaultPresenter) ExportVulResult(_ context.Context, res *results.Results, _ families.RunErrors) error {
-	vulnerabilitiesResults, err := results.GetResult[*vulnerabilities.Results](res)
-	if err != nil {
-		return fmt.Errorf("failed to get sbom results: %w", err)
+func (p *DefaultPresenter) ExportVulResult(_ context.Context, res families.FamilyResult) error {
+	vulnerabilitiesResults, ok := res.Result.(*vulnerabilities.Results)
+	if !ok {
+		return fmt.Errorf("failed to convert to vulnerabilities results")
 	}
 
 	bytes, err := json.Marshal(vulnerabilitiesResults.MergedResults)
@@ -72,10 +71,10 @@ func (p *DefaultPresenter) ExportVulResult(_ context.Context, res *results.Resul
 	return nil
 }
 
-func (p *DefaultPresenter) ExportSecretsResult(_ context.Context, res *results.Results, _ families.RunErrors) error {
-	secretsResults, err := results.GetResult[*secrets.Results](res)
-	if err != nil {
-		return fmt.Errorf("failed to get secrets results: %w", err)
+func (p *DefaultPresenter) ExportSecretsResult(_ context.Context, res families.FamilyResult) error {
+	secretsResults, ok := res.Result.(*secrets.Results)
+	if !ok {
+		return fmt.Errorf("failed to convert to secrets results")
 	}
 
 	bytes, err := json.Marshal(secretsResults)
@@ -89,10 +88,10 @@ func (p *DefaultPresenter) ExportSecretsResult(_ context.Context, res *results.R
 	return nil
 }
 
-func (p *DefaultPresenter) ExportMalwareResult(_ context.Context, res *results.Results, _ families.RunErrors) error {
-	malwareResults, err := results.GetResult[*malware.MergedResults](res)
-	if err != nil {
-		return fmt.Errorf("failed to get malware results: %w", err)
+func (p *DefaultPresenter) ExportMalwareResult(_ context.Context, res families.FamilyResult) error {
+	malwareResults, ok := res.Result.(*malware.MergedResults)
+	if !ok {
+		return fmt.Errorf("failed to convert to malware results")
 	}
 
 	bytes, err := json.Marshal(malwareResults)
@@ -106,10 +105,10 @@ func (p *DefaultPresenter) ExportMalwareResult(_ context.Context, res *results.R
 	return nil
 }
 
-func (p *DefaultPresenter) ExportExploitsResult(_ context.Context, res *results.Results, _ families.RunErrors) error {
-	exploitsResults, err := results.GetResult[*exploits.Results](res)
-	if err != nil {
-		return fmt.Errorf("failed to get exploits results: %w", err)
+func (p *DefaultPresenter) ExportExploitsResult(_ context.Context, res families.FamilyResult) error {
+	exploitsResults, ok := res.Result.(*exploits.Results)
+	if !ok {
+		return fmt.Errorf("failed to convert to exploits results")
 	}
 
 	bytes, err := json.Marshal(exploitsResults)
@@ -123,15 +122,15 @@ func (p *DefaultPresenter) ExportExploitsResult(_ context.Context, res *results.
 	return nil
 }
 
-func (p *DefaultPresenter) ExportMisconfigurationResult(context.Context, *results.Results, families.RunErrors) error {
+func (p *DefaultPresenter) ExportMisconfigurationResult(context.Context, families.FamilyResult) error {
 	// TODO: implement
 	return nil
 }
 
-func (p *DefaultPresenter) ExportRootkitResult(_ context.Context, res *results.Results, _ families.RunErrors) error {
-	rootkitsResults, err := results.GetResult[*rootkits.Results](res)
-	if err != nil {
-		return fmt.Errorf("failed to get rootkits results: %w", err)
+func (p *DefaultPresenter) ExportRootkitResult(_ context.Context, res families.FamilyResult) error {
+	rootkitsResults, ok := res.Result.(*rootkits.Results)
+	if !ok {
+		return fmt.Errorf("failed to convert to rootkits results")
 	}
 
 	bytes, err := json.Marshal(rootkitsResults)

--- a/cli/pkg/presenter/default.go
+++ b/cli/pkg/presenter/default.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openclarity/vmclarity/shared/pkg/families/rootkits"
 	"github.com/openclarity/vmclarity/shared/pkg/families/sbom"
 	"github.com/openclarity/vmclarity/shared/pkg/families/secrets"
+	"github.com/openclarity/vmclarity/shared/pkg/families/types"
 	"github.com/openclarity/vmclarity/shared/pkg/families/vulnerabilities"
 )
 
@@ -33,6 +34,29 @@ type DefaultPresenter struct {
 	Writer
 
 	FamiliesConfig *families.Config
+}
+
+func (p *DefaultPresenter) ExportFamilyResult(ctx context.Context, res families.FamilyResult) error {
+	var err error
+
+	switch res.FamilyType {
+	case types.SBOM:
+		err = p.ExportSbomResult(ctx, res)
+	case types.Vulnerabilities:
+		err = p.ExportVulResult(ctx, res)
+	case types.Secrets:
+		err = p.ExportSecretsResult(ctx, res)
+	case types.Exploits:
+		err = p.ExportExploitsResult(ctx, res)
+	case types.Misconfiguration:
+		err = p.ExportMisconfigurationResult(ctx, res)
+	case types.Rootkits:
+		err = p.ExportRootkitResult(ctx, res)
+	case types.Malware:
+		err = p.ExportMalwareResult(ctx, res)
+	}
+
+	return err
 }
 
 func (p *DefaultPresenter) ExportSbomResult(_ context.Context, res families.FamilyResult) error {

--- a/cli/pkg/presenter/multi.go
+++ b/cli/pkg/presenter/multi.go
@@ -20,16 +20,15 @@ import (
 	"fmt"
 
 	"github.com/openclarity/vmclarity/shared/pkg/families"
-	"github.com/openclarity/vmclarity/shared/pkg/families/results"
 )
 
 type MultiPresenter struct {
 	Presenters []Presenter
 }
 
-func (m *MultiPresenter) ExportSbomResult(ctx context.Context, res *results.Results, famErr families.RunErrors) error {
+func (m *MultiPresenter) ExportSbomResult(ctx context.Context, res families.FamilyResult) error {
 	for _, p := range m.Presenters {
-		if err := p.ExportSbomResult(ctx, res, famErr); err != nil {
+		if err := p.ExportSbomResult(ctx, res); err != nil {
 			return fmt.Errorf("failed to export result: %w", err)
 		}
 	}
@@ -37,9 +36,9 @@ func (m *MultiPresenter) ExportSbomResult(ctx context.Context, res *results.Resu
 	return nil
 }
 
-func (m *MultiPresenter) ExportVulResult(ctx context.Context, res *results.Results, famErr families.RunErrors) error {
+func (m *MultiPresenter) ExportVulResult(ctx context.Context, res families.FamilyResult) error {
 	for _, p := range m.Presenters {
-		if err := p.ExportVulResult(ctx, res, famErr); err != nil {
+		if err := p.ExportVulResult(ctx, res); err != nil {
 			return fmt.Errorf("failed to export result: %w", err)
 		}
 	}
@@ -47,9 +46,9 @@ func (m *MultiPresenter) ExportVulResult(ctx context.Context, res *results.Resul
 	return nil
 }
 
-func (m *MultiPresenter) ExportSecretsResult(ctx context.Context, res *results.Results, famErr families.RunErrors) error {
+func (m *MultiPresenter) ExportSecretsResult(ctx context.Context, res families.FamilyResult) error {
 	for _, p := range m.Presenters {
-		if err := p.ExportSecretsResult(ctx, res, famErr); err != nil {
+		if err := p.ExportSecretsResult(ctx, res); err != nil {
 			return fmt.Errorf("failed to export result: %w", err)
 		}
 	}
@@ -57,9 +56,9 @@ func (m *MultiPresenter) ExportSecretsResult(ctx context.Context, res *results.R
 	return nil
 }
 
-func (m *MultiPresenter) ExportMalwareResult(ctx context.Context, res *results.Results, famErr families.RunErrors) error {
+func (m *MultiPresenter) ExportMalwareResult(ctx context.Context, res families.FamilyResult) error {
 	for _, p := range m.Presenters {
-		if err := p.ExportMalwareResult(ctx, res, famErr); err != nil {
+		if err := p.ExportMalwareResult(ctx, res); err != nil {
 			return fmt.Errorf("failed to export result: %w", err)
 		}
 	}
@@ -67,9 +66,9 @@ func (m *MultiPresenter) ExportMalwareResult(ctx context.Context, res *results.R
 	return nil
 }
 
-func (m *MultiPresenter) ExportExploitsResult(ctx context.Context, res *results.Results, famErr families.RunErrors) error {
+func (m *MultiPresenter) ExportExploitsResult(ctx context.Context, res families.FamilyResult) error {
 	for _, p := range m.Presenters {
-		if err := p.ExportExploitsResult(ctx, res, famErr); err != nil {
+		if err := p.ExportExploitsResult(ctx, res); err != nil {
 			return fmt.Errorf("failed to export result: %w", err)
 		}
 	}
@@ -77,9 +76,9 @@ func (m *MultiPresenter) ExportExploitsResult(ctx context.Context, res *results.
 	return nil
 }
 
-func (m *MultiPresenter) ExportMisconfigurationResult(ctx context.Context, res *results.Results, famErr families.RunErrors) error {
+func (m *MultiPresenter) ExportMisconfigurationResult(ctx context.Context, res families.FamilyResult) error {
 	for _, p := range m.Presenters {
-		if err := p.ExportMisconfigurationResult(ctx, res, famErr); err != nil {
+		if err := p.ExportMisconfigurationResult(ctx, res); err != nil {
 			return fmt.Errorf("failed to export result: %w", err)
 		}
 	}
@@ -87,9 +86,9 @@ func (m *MultiPresenter) ExportMisconfigurationResult(ctx context.Context, res *
 	return nil
 }
 
-func (m *MultiPresenter) ExportRootkitResult(ctx context.Context, res *results.Results, famErr families.RunErrors) error {
+func (m *MultiPresenter) ExportRootkitResult(ctx context.Context, res families.FamilyResult) error {
 	for _, p := range m.Presenters {
-		if err := p.ExportRootkitResult(ctx, res, famErr); err != nil {
+		if err := p.ExportRootkitResult(ctx, res); err != nil {
 			return fmt.Errorf("failed to export result: %w", err)
 		}
 	}

--- a/cli/pkg/presenter/multi.go
+++ b/cli/pkg/presenter/multi.go
@@ -26,69 +26,9 @@ type MultiPresenter struct {
 	Presenters []Presenter
 }
 
-func (m *MultiPresenter) ExportSbomResult(ctx context.Context, res families.FamilyResult) error {
+func (m *MultiPresenter) ExportFamilyResult(ctx context.Context, res families.FamilyResult) error {
 	for _, p := range m.Presenters {
-		if err := p.ExportSbomResult(ctx, res); err != nil {
-			return fmt.Errorf("failed to export result: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (m *MultiPresenter) ExportVulResult(ctx context.Context, res families.FamilyResult) error {
-	for _, p := range m.Presenters {
-		if err := p.ExportVulResult(ctx, res); err != nil {
-			return fmt.Errorf("failed to export result: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (m *MultiPresenter) ExportSecretsResult(ctx context.Context, res families.FamilyResult) error {
-	for _, p := range m.Presenters {
-		if err := p.ExportSecretsResult(ctx, res); err != nil {
-			return fmt.Errorf("failed to export result: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (m *MultiPresenter) ExportMalwareResult(ctx context.Context, res families.FamilyResult) error {
-	for _, p := range m.Presenters {
-		if err := p.ExportMalwareResult(ctx, res); err != nil {
-			return fmt.Errorf("failed to export result: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (m *MultiPresenter) ExportExploitsResult(ctx context.Context, res families.FamilyResult) error {
-	for _, p := range m.Presenters {
-		if err := p.ExportExploitsResult(ctx, res); err != nil {
-			return fmt.Errorf("failed to export result: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (m *MultiPresenter) ExportMisconfigurationResult(ctx context.Context, res families.FamilyResult) error {
-	for _, p := range m.Presenters {
-		if err := p.ExportMisconfigurationResult(ctx, res); err != nil {
-			return fmt.Errorf("failed to export result: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (m *MultiPresenter) ExportRootkitResult(ctx context.Context, res families.FamilyResult) error {
-	for _, p := range m.Presenters {
-		if err := p.ExportRootkitResult(ctx, res); err != nil {
+		if err := p.ExportFamilyResult(ctx, res); err != nil {
 			return fmt.Errorf("failed to export result: %w", err)
 		}
 	}

--- a/cli/pkg/presenter/presenter.go
+++ b/cli/pkg/presenter/presenter.go
@@ -22,11 +22,5 @@ import (
 )
 
 type Presenter interface {
-	ExportSbomResult(context.Context, families.FamilyResult) error
-	ExportVulResult(context.Context, families.FamilyResult) error
-	ExportSecretsResult(context.Context, families.FamilyResult) error
-	ExportMalwareResult(context.Context, families.FamilyResult) error
-	ExportExploitsResult(context.Context, families.FamilyResult) error
-	ExportMisconfigurationResult(context.Context, families.FamilyResult) error
-	ExportRootkitResult(context.Context, families.FamilyResult) error
+	ExportFamilyResult(ctx context.Context, res families.FamilyResult) error
 }

--- a/cli/pkg/presenter/presenter.go
+++ b/cli/pkg/presenter/presenter.go
@@ -19,15 +19,14 @@ import (
 	"context"
 
 	"github.com/openclarity/vmclarity/shared/pkg/families"
-	"github.com/openclarity/vmclarity/shared/pkg/families/results"
 )
 
 type Presenter interface {
-	ExportSbomResult(context.Context, *results.Results, families.RunErrors) error
-	ExportVulResult(context.Context, *results.Results, families.RunErrors) error
-	ExportSecretsResult(context.Context, *results.Results, families.RunErrors) error
-	ExportMalwareResult(context.Context, *results.Results, families.RunErrors) error
-	ExportExploitsResult(context.Context, *results.Results, families.RunErrors) error
-	ExportMisconfigurationResult(context.Context, *results.Results, families.RunErrors) error
-	ExportRootkitResult(context.Context, *results.Results, families.RunErrors) error
+	ExportSbomResult(context.Context, families.FamilyResult) error
+	ExportVulResult(context.Context, families.FamilyResult) error
+	ExportSecretsResult(context.Context, families.FamilyResult) error
+	ExportMalwareResult(context.Context, families.FamilyResult) error
+	ExportExploitsResult(context.Context, families.FamilyResult) error
+	ExportMisconfigurationResult(context.Context, families.FamilyResult) error
+	ExportRootkitResult(context.Context, families.FamilyResult) error
 }

--- a/cli/pkg/presenter/vmclarity.go
+++ b/cli/pkg/presenter/vmclarity.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openclarity/vmclarity/shared/pkg/families/rootkits"
 	"github.com/openclarity/vmclarity/shared/pkg/families/sbom"
 	"github.com/openclarity/vmclarity/shared/pkg/families/secrets"
+	"github.com/openclarity/vmclarity/shared/pkg/families/types"
 	"github.com/openclarity/vmclarity/shared/pkg/families/vulnerabilities"
 	"github.com/openclarity/vmclarity/shared/pkg/utils"
 )
@@ -40,6 +41,29 @@ type VMClarityPresenter struct {
 	client *backendclient.BackendClient
 
 	scanResultID models.ScanResultID
+}
+
+func (v *VMClarityPresenter) ExportFamilyResult(ctx context.Context, res families.FamilyResult) error {
+	var err error
+
+	switch res.FamilyType {
+	case types.SBOM:
+		err = v.ExportSbomResult(ctx, res)
+	case types.Vulnerabilities:
+		err = v.ExportVulResult(ctx, res)
+	case types.Secrets:
+		err = v.ExportSecretsResult(ctx, res)
+	case types.Exploits:
+		err = v.ExportExploitsResult(ctx, res)
+	case types.Misconfiguration:
+		err = v.ExportMisconfigurationResult(ctx, res)
+	case types.Rootkits:
+		err = v.ExportRootkitResult(ctx, res)
+	case types.Malware:
+		err = v.ExportMalwareResult(ctx, res)
+	}
+
+	return err
 }
 
 func (v *VMClarityPresenter) ExportSbomResult(ctx context.Context, res families.FamilyResult) error {

--- a/cli/pkg/state/local.go
+++ b/cli/pkg/state/local.go
@@ -35,58 +35,22 @@ func (l *LocalState) MarkInProgress(context.Context) error {
 }
 
 func (l *LocalState) MarkFamilyScanInProgress(ctx context.Context, familyType types.FamilyType) error {
-	var err error
 	switch familyType {
 	case types.SBOM:
-		err = l.markSBOMScanInProgress(ctx)
+		log.Info("SBOM scan is in progress")
 	case types.Vulnerabilities:
-		err = l.markVulnerabilitiesScanInProgress(ctx)
+		log.Info("Vulnerabilities scan is in progress")
 	case types.Secrets:
-		err = l.markSecretsScanInProgress(ctx)
+		log.Info("Secrets scan is in progress")
 	case types.Exploits:
-		err = l.markExploitsScanInProgress(ctx)
+		log.Info("Exploits scan is in progress")
 	case types.Misconfiguration:
-		err = l.markMisconfigurationsScanInProgress(ctx)
+		log.Info("Misconfiguration scan is in progress")
 	case types.Rootkits:
-		err = l.markRootkitsScanInProgress(ctx)
+		log.Info("Rootkit scan is in progress")
 	case types.Malware:
-		err = l.markRootkitsScanInProgress(ctx)
+		log.Info("Malware scan is in progress")
 	}
-	return err
-}
-
-func (l *LocalState) markExploitsScanInProgress(context.Context) error {
-	log.Info("Exploits scan is in progress")
-	return nil
-}
-
-func (l *LocalState) markSecretsScanInProgress(context.Context) error {
-	log.Info("Secrets scan is in progress")
-	return nil
-}
-
-func (l *LocalState) markSBOMScanInProgress(context.Context) error {
-	log.Info("SBOM scan is in progress")
-	return nil
-}
-
-func (l *LocalState) markVulnerabilitiesScanInProgress(context.Context) error {
-	log.Info("Vulnerabilities scan is in progress")
-	return nil
-}
-
-func (l *LocalState) markMalwareScanInProgress(context.Context) error {
-	log.Info("Malware scan is in progress")
-	return nil
-}
-
-func (l *LocalState) markMisconfigurationsScanInProgress(context.Context) error {
-	log.Info("Misconfiguration scan is in progress")
-	return nil
-}
-
-func (l *LocalState) markRootkitsScanInProgress(context.Context) error {
-	log.Info("Rootkit scan is in progress")
 	return nil
 }
 

--- a/cli/pkg/state/local.go
+++ b/cli/pkg/state/local.go
@@ -19,6 +19,8 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
+
+	"github.com/openclarity/vmclarity/shared/pkg/families/types"
 )
 
 type LocalState struct{}
@@ -29,6 +31,62 @@ func (l *LocalState) WaitForVolumeAttachment(context.Context) error {
 
 func (l *LocalState) MarkInProgress(context.Context) error {
 	log.Info("Scanning is in progress")
+	return nil
+}
+
+func (l *LocalState) MarkFamilyScanInProgress(ctx context.Context, familyType types.FamilyType) error {
+	var err error
+	switch familyType {
+	case types.SBOM:
+		err = l.markSBOMScanInProgress(ctx)
+	case types.Vulnerabilities:
+		err = l.markVulnerabilitiesScanInProgress(ctx)
+	case types.Secrets:
+		err = l.markSecretsScanInProgress(ctx)
+	case types.Exploits:
+		err = l.markExploitsScanInProgress(ctx)
+	case types.Misconfiguration:
+		err = l.markMisconfigurationsScanInProgress(ctx)
+	case types.Rootkits:
+		err = l.markRootkitsScanInProgress(ctx)
+	case types.Malware:
+		err = l.markRootkitsScanInProgress(ctx)
+	}
+	return err
+}
+
+func (l *LocalState) markExploitsScanInProgress(context.Context) error {
+	log.Info("Exploits scan is in progress")
+	return nil
+}
+
+func (l *LocalState) markSecretsScanInProgress(context.Context) error {
+	log.Info("Secrets scan is in progress")
+	return nil
+}
+
+func (l *LocalState) markSBOMScanInProgress(context.Context) error {
+	log.Info("SBOM scan is in progress")
+	return nil
+}
+
+func (l *LocalState) markVulnerabilitiesScanInProgress(context.Context) error {
+	log.Info("Vulnerabilities scan is in progress")
+	return nil
+}
+
+func (l *LocalState) markMalwareScanInProgress(context.Context) error {
+	log.Info("Malware scan is in progress")
+	return nil
+}
+
+func (l *LocalState) markMisconfigurationsScanInProgress(context.Context) error {
+	log.Info("Misconfiguration scan is in progress")
+	return nil
+}
+
+func (l *LocalState) markRootkitsScanInProgress(context.Context) error {
+	log.Info("Rootkit scan is in progress")
 	return nil
 }
 

--- a/cli/pkg/state/manager.go
+++ b/cli/pkg/state/manager.go
@@ -17,11 +17,14 @@ package state
 
 import (
 	"context"
+
+	"github.com/openclarity/vmclarity/shared/pkg/families/types"
 )
 
 type Manager interface {
 	WaitForVolumeAttachment(context.Context) error
 	MarkInProgress(context.Context) error
+	MarkFamilyScanInProgress(context.Context, types.FamilyType) error
 	MarkDone(context.Context, []error) error
 	IsAborted(ctx context.Context) (bool, error)
 }

--- a/cli/pkg/state/vmclarity.go
+++ b/cli/pkg/state/vmclarity.go
@@ -154,7 +154,7 @@ func (v *VMClarityState) MarkFamilyScanInProgress(ctx context.Context, familyTyp
 	case types.Rootkits:
 		err = v.markRootkitsScanInProgress(ctx)
 	case types.Malware:
-		err = v.markRootkitsScanInProgress(ctx)
+		err = v.markMalwareScanInProgress(ctx)
 	}
 	return err
 }
@@ -183,6 +183,7 @@ func (v *VMClarityState) markExploitsScanInProgress(ctx context.Context) error {
 
 	return nil
 }
+
 func (v *VMClarityState) markSecretsScanInProgress(ctx context.Context) error {
 	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
 	if err != nil {
@@ -207,6 +208,7 @@ func (v *VMClarityState) markSecretsScanInProgress(ctx context.Context) error {
 
 	return nil
 }
+
 func (v *VMClarityState) markSBOMScanInProgress(ctx context.Context) error {
 	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
 	if err != nil {
@@ -231,6 +233,7 @@ func (v *VMClarityState) markSBOMScanInProgress(ctx context.Context) error {
 
 	return nil
 }
+
 func (v *VMClarityState) markVulnerabilitiesScanInProgress(ctx context.Context) error {
 	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
 	if err != nil {
@@ -255,6 +258,7 @@ func (v *VMClarityState) markVulnerabilitiesScanInProgress(ctx context.Context) 
 
 	return nil
 }
+
 func (v *VMClarityState) markMalwareScanInProgress(ctx context.Context) error {
 	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
 	if err != nil {
@@ -279,6 +283,7 @@ func (v *VMClarityState) markMalwareScanInProgress(ctx context.Context) error {
 
 	return nil
 }
+
 func (v *VMClarityState) markMisconfigurationsScanInProgress(ctx context.Context) error {
 	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
 	if err != nil {
@@ -303,6 +308,7 @@ func (v *VMClarityState) markMisconfigurationsScanInProgress(ctx context.Context
 
 	return nil
 }
+
 func (v *VMClarityState) markRootkitsScanInProgress(ctx context.Context) error {
 	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
 	if err != nil {

--- a/cli/pkg/state/vmclarity.go
+++ b/cli/pkg/state/vmclarity.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/shared/pkg/backendclient"
+	"github.com/openclarity/vmclarity/shared/pkg/families/types"
 	"github.com/openclarity/vmclarity/shared/pkg/utils"
 )
 
@@ -137,7 +138,197 @@ func (v *VMClarityState) MarkDone(ctx context.Context, errors []error) error {
 	return nil
 }
 
-func (v VMClarityState) IsAborted(ctx context.Context) (bool, error) {
+func (v *VMClarityState) MarkFamilyScanInProgress(ctx context.Context, familyType types.FamilyType) error {
+	var err error
+	switch familyType {
+	case types.SBOM:
+		err = v.markSBOMScanInProgress(ctx)
+	case types.Vulnerabilities:
+		err = v.markVulnerabilitiesScanInProgress(ctx)
+	case types.Secrets:
+		err = v.markSecretsScanInProgress(ctx)
+	case types.Exploits:
+		err = v.markExploitsScanInProgress(ctx)
+	case types.Misconfiguration:
+		err = v.markMisconfigurationsScanInProgress(ctx)
+	case types.Rootkits:
+		err = v.markRootkitsScanInProgress(ctx)
+	case types.Malware:
+		err = v.markRootkitsScanInProgress(ctx)
+	}
+	return err
+}
+
+func (v *VMClarityState) markExploitsScanInProgress(ctx context.Context) error {
+	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
+	if err != nil {
+		return fmt.Errorf("failed to get scan result: %w", err)
+	}
+
+	if scanResult.Status == nil {
+		scanResult.Status = &models.TargetScanStatus{}
+	}
+	if scanResult.Status.Exploits == nil {
+		scanResult.Status.Exploits = &models.TargetScanState{}
+	}
+
+	state := models.INPROGRESS
+	scanResult.Status.Exploits.State = &state
+	scanResult.Status.Exploits.LastTransitionTime = utils.PointerTo(time.Now())
+
+	err = v.client.PatchScanResult(ctx, scanResult, v.scanResultID)
+	if err != nil {
+		return fmt.Errorf("failed to patch scan result: %w", err)
+	}
+
+	return nil
+}
+func (v *VMClarityState) markSecretsScanInProgress(ctx context.Context) error {
+	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
+	if err != nil {
+		return fmt.Errorf("failed to get scan result: %w", err)
+	}
+
+	if scanResult.Status == nil {
+		scanResult.Status = &models.TargetScanStatus{}
+	}
+	if scanResult.Status.Secrets == nil {
+		scanResult.Status.Secrets = &models.TargetScanState{}
+	}
+
+	state := models.INPROGRESS
+	scanResult.Status.Secrets.State = &state
+	scanResult.Status.Secrets.LastTransitionTime = utils.PointerTo(time.Now())
+
+	err = v.client.PatchScanResult(ctx, scanResult, v.scanResultID)
+	if err != nil {
+		return fmt.Errorf("failed to patch scan result: %w", err)
+	}
+
+	return nil
+}
+func (v *VMClarityState) markSBOMScanInProgress(ctx context.Context) error {
+	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
+	if err != nil {
+		return fmt.Errorf("failed to get scan result: %w", err)
+	}
+
+	if scanResult.Status == nil {
+		scanResult.Status = &models.TargetScanStatus{}
+	}
+	if scanResult.Status.Sbom == nil {
+		scanResult.Status.Sbom = &models.TargetScanState{}
+	}
+
+	state := models.INPROGRESS
+	scanResult.Status.Sbom.State = &state
+	scanResult.Status.Sbom.LastTransitionTime = utils.PointerTo(time.Now())
+
+	err = v.client.PatchScanResult(ctx, scanResult, v.scanResultID)
+	if err != nil {
+		return fmt.Errorf("failed to patch scan result: %w", err)
+	}
+
+	return nil
+}
+func (v *VMClarityState) markVulnerabilitiesScanInProgress(ctx context.Context) error {
+	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
+	if err != nil {
+		return fmt.Errorf("failed to get scan result: %w", err)
+	}
+
+	if scanResult.Status == nil {
+		scanResult.Status = &models.TargetScanStatus{}
+	}
+	if scanResult.Status.Vulnerabilities == nil {
+		scanResult.Status.Vulnerabilities = &models.TargetScanState{}
+	}
+
+	state := models.INPROGRESS
+	scanResult.Status.Vulnerabilities.State = &state
+	scanResult.Status.Vulnerabilities.LastTransitionTime = utils.PointerTo(time.Now())
+
+	err = v.client.PatchScanResult(ctx, scanResult, v.scanResultID)
+	if err != nil {
+		return fmt.Errorf("failed to patch scan result: %w", err)
+	}
+
+	return nil
+}
+func (v *VMClarityState) markMalwareScanInProgress(ctx context.Context) error {
+	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
+	if err != nil {
+		return fmt.Errorf("failed to get scan result: %w", err)
+	}
+
+	if scanResult.Status == nil {
+		scanResult.Status = &models.TargetScanStatus{}
+	}
+	if scanResult.Status.Malware == nil {
+		scanResult.Status.Malware = &models.TargetScanState{}
+	}
+
+	state := models.INPROGRESS
+	scanResult.Status.Malware.State = &state
+	scanResult.Status.Malware.LastTransitionTime = utils.PointerTo(time.Now())
+
+	err = v.client.PatchScanResult(ctx, scanResult, v.scanResultID)
+	if err != nil {
+		return fmt.Errorf("failed to patch scan result: %w", err)
+	}
+
+	return nil
+}
+func (v *VMClarityState) markMisconfigurationsScanInProgress(ctx context.Context) error {
+	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
+	if err != nil {
+		return fmt.Errorf("failed to get scan result: %w", err)
+	}
+
+	if scanResult.Status == nil {
+		scanResult.Status = &models.TargetScanStatus{}
+	}
+	if scanResult.Status.Misconfigurations == nil {
+		scanResult.Status.Misconfigurations = &models.TargetScanState{}
+	}
+
+	state := models.INPROGRESS
+	scanResult.Status.Misconfigurations.State = &state
+	scanResult.Status.Misconfigurations.LastTransitionTime = utils.PointerTo(time.Now())
+
+	err = v.client.PatchScanResult(ctx, scanResult, v.scanResultID)
+	if err != nil {
+		return fmt.Errorf("failed to patch scan result: %w", err)
+	}
+
+	return nil
+}
+func (v *VMClarityState) markRootkitsScanInProgress(ctx context.Context) error {
+	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{})
+	if err != nil {
+		return fmt.Errorf("failed to get scan result: %w", err)
+	}
+
+	if scanResult.Status == nil {
+		scanResult.Status = &models.TargetScanStatus{}
+	}
+	if scanResult.Status.Rootkits == nil {
+		scanResult.Status.Rootkits = &models.TargetScanState{}
+	}
+
+	state := models.INPROGRESS
+	scanResult.Status.Rootkits.State = &state
+	scanResult.Status.Rootkits.LastTransitionTime = utils.PointerTo(time.Now())
+
+	err = v.client.PatchScanResult(ctx, scanResult, v.scanResultID)
+	if err != nil {
+		return fmt.Errorf("failed to patch scan result: %w", err)
+	}
+
+	return nil
+}
+
+func (v *VMClarityState) IsAborted(ctx context.Context) (bool, error) {
 	scanResult, err := v.client.GetScanResult(ctx, v.scanResultID, models.GetScanResultsScanResultIDParams{
 		Select: utils.PointerTo("id,status"),
 	})

--- a/shared/pkg/families/manager.go
+++ b/shared/pkg/families/manager.go
@@ -125,7 +125,7 @@ func (m *Manager) Run(ctx context.Context, notifier FamilyNotifier) []error {
 				errors = append(errors, fmt.Errorf("family finished notification failed: %v", err))
 			}
 		case r := <-result:
-			log.Debugf("received result from family %q: %v", family, r)
+			log.Debugf("received result from family %q: %v", family.GetType(), r)
 			if r.Err != nil {
 				oneOrMoreFamilyFailed = true
 			} else {

--- a/shared/pkg/families/manager.go
+++ b/shared/pkg/families/manager.go
@@ -136,7 +136,6 @@ func (m *Manager) Run(ctx context.Context, notifier FamilyNotifier) []error {
 			}
 			close(result)
 		}
-
 	}
 
 	if oneOrMoreFamilyFailed {


### PR DESCRIPTION
Export scan results when family finish scanning, and not after all family scan is completed like today. 
This will make the scan progress more informative and granular. Also mark in progress for each family scan

## Type of Change

[* ] New Feature  

