### PR TITLE
Add support for any, all and not ODATA operators

### DIFF
--- a/pkg/backend/database/odatasql/query_test.go
+++ b/pkg/backend/database/odatasql/query_test.go
@@ -1154,6 +1154,85 @@ func TestBuildSQLQuery(t *testing.T) {
 				car4,
 			},
 		},
+		{
+			name: "filter if list contains an item",
+			args: args{
+				filterString: PointerTo("Engine/Options/SubOptions/any(o:o/Name eq 'bluePaint')"),
+			},
+			want: []Car{
+				car1,
+				car2,
+				car3,
+				car4,
+			},
+		},
+		{
+			name: "filter if list contains an item, no match",
+			args: args{
+				filterString: PointerTo("Engine/Options/SubOptions/any(o:o/Name eq 'yellow')"),
+			},
+			want: []Car{},
+		},
+		{
+			name: "filter if list contains an item with expanded properties",
+			args: args{
+				filterString: PointerTo("Engine/Options/SubOptions/any(o:o/Manufacturer/Name eq 'manu1')"),
+			},
+			want: []Car{
+				car1,
+				car2,
+			},
+		},
+		{
+			name: "filter if list contains an item, multi-part query",
+			args: args{
+				filterString: PointerTo("Engine/Options/SubOptions/any(o:o/Manufacturer/Name eq 'manu1' and o/Name eq 'bluePaint')"),
+			},
+			want: []Car{
+				car1,
+				car2,
+			},
+		},
+		{
+			name: "filter if list contains an item as part of a larger query",
+			args: args{
+				filterString: PointerTo("ModelName eq 'model1' and Engine/Options/SubOptions/any(o:o/Manufacturer/Name eq 'manu1')"),
+			},
+			want: []Car{
+				car1,
+			},
+		},
+		{
+			name: "negated filter if list contains an item with expanded properties",
+			args: args{
+				filterString: PointerTo("not Engine/Options/SubOptions/any(o:o/Manufacturer/Name eq 'manu1')"),
+			},
+			want: []Car{
+				car3,
+				car4,
+			},
+		},
+		{
+			name: "negated eq filter by primitive type ModelName",
+			args: args{
+				filterString: PointerTo("not (ModelName eq 'model1')"),
+			},
+			want: []Car{
+				car2,
+				car3,
+				car4,
+			},
+		},
+		{
+			name: "if every item in list matches",
+			args: args{
+				filterString: PointerTo(fmt.Sprintf("Engine/Options/SubOptions/all(o: o/Manufacturer/Id eq '%s' or o/Manufacturer/Id eq '%s')", manu1.ID, manu2.ID)),
+			},
+			want: []Car{
+				car1,
+				car2,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

The any() lamdba operator can be used like:

    GET api/Targets?$filter=findingInfo/tags/any(t: t/Key eq 'Name' and t/Value eq 'vmclarity-server')

This will return all Targets with at least one tag which has Key Name and the Value vmclarity-server.

The all lamba operator can be used like:

    GET api/Targets?$filter=findingInfo/securityGroups/all(g: g/id eq 'sg1' or g/id eq 'sg2')

This will return Targets which are only in the security groups sg1 and sg2, no other security groups.

The not operator can be used like:

    GET api/Targets?$filter=not(startswith(location, 'us-east-2'))

This will return all Targets which do not have a location which starts with us-east-2.

## Type of Change

[ ] Bug Fix  
[X] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
