### PR TITLE
Installer for VMClarity on Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ The VMClarity project is focused on unifying detection and management of VM secu
 
 For a detailed installation guide, please see [AWS](installation/aws/README.md).
 
+### Azure
+
+1. Click the [![Deploy To Azure](https://docs.microsoft.com/en-us/azure/templates/media/deploy-to-azure.svg)](https://portal.azure.com/#blade/Microsoft_Azure_CreateUIDef/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fopenclarity%2Fvmclarity%2Fazure_installer%2Finstallation%2Fazure%2Fvmclarity.json/uiFormDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2Fopenclarity%2Fvmclarity%2Fazure_installer%2Finstallation%2Fazure%2Fvmclarity-UI.json) button.
+2. Fill out the required fields in the wizard
+3. Once deployed, copy the VMClarity SSH address from the Outputs tab
+
 ## Access VMClarity UI
 1. Open an SSH tunnel to VMClarity server
     ```

--- a/installation/azure/vmclarity-UI.json
+++ b/installation/azure/vmclarity-UI.json
@@ -1,0 +1,488 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2021-09-09/uiFormDefinition.schema.json",
+    "view": {
+        "kind": "Form",
+        "properties": {
+            "title": "VMClarity",
+            "steps": [
+                {
+                    "name": "basics",
+                    "label": "Basics",
+                    "elements": [
+                        {
+                            "name": "resourceScope",
+                            "type": "Microsoft.Common.ResourceScope",
+                            "location": {
+                                "resourceTypes": []
+                            }
+                        },
+                        {
+                            "name": "deploypostfix",
+                            "type": "Microsoft.Common.TextBox",
+                            "label": "VMClarity Deploy Postfix",
+                            "placeholder": "postfix",
+                            "subLabel": "[concat('Resource Group for VMClarity will be named ', concat('vmclarity-', steps('basics').deploypostfix))]",
+                            "defaultValue": "",
+                            "toolTip": "Specify the postfix to add to 'vmclarity' which will be used as the resource group name to identify this VMClarity installation.",
+                            "constraints": {
+                                "required": true,
+                                "regex": "",
+                                "validationMessage": "",
+                                "validations": []
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "adminUsername",
+                            "type": "Microsoft.Common.TextBox",
+                            "label": "VMClarity Server SSH Username",
+                            "subLabel": "",
+                            "defaultValue": "",
+                            "toolTip": "Username for the Virtual Machine.",
+                            "constraints": {
+                                "required": true,
+                                "regex": "",
+                                "validationMessage": "",
+                                "validations": [
+                                    {
+                                        "isValid": "[or(or(empty(steps('basics').adminUsername),and(not(startsWith(steps('basics').adminUsername,'[[')),startsWith(steps('basics').adminUsername,'['),endsWith(steps('basics').adminUsername,']'),greater(indexOf(steps('basics').adminUsername,'('),-1),greater(indexOf(steps('basics').adminUsername,')'),-1))),and(not(regex(steps('basics').adminUsername,'/[\\\\/\\\"\\\"\\[\\]:|<>+=;,$ ?*@]+/')),not(endsWith(steps('basics').adminUsername,'.'))),regex(steps('basics').adminUsername,'^[a-zA-Z0-9-]+$'))]",
+                                        "message": "User name cannot contain special characters \\/\\\"[]:|<>+=;,?*@ or end with '.', and must be between 1 and 15 characters."
+                                    },
+                                    {
+                                        "isValid": "[or(or(empty(steps('basics').adminUsername),and(not(startsWith(steps('basics').adminUsername,'[[')),startsWith(steps('basics').adminUsername,'['),endsWith(steps('basics').adminUsername,']'),greater(indexOf(steps('basics').adminUsername,'('),-1),greater(indexOf(steps('basics').adminUsername,')'),-1))),equals(length(filter(parse('[\"administrator\", \"admin\", \"user\", \"user1\", \"test\", \"user2\", \"test1\", \"user3\", \"admin1\", \"1\", \"123\", \"a\", \"actuser\", \"adm\", \"admin2\", \"aspnet\", \"backup\", \"console\", \"david\", \"guest\", \"john\", \"owner\", \"root\", \"server\", \"sql\", \"support\", \"support_388945a0\", \"sys\", \"test2\", \"test3\", \"user4\", \"user5\"]'),(item) => equals(toLower(item),toLower(steps('basics').adminUsername)))),0))]",
+                                        "message": "The specified username is not allowed. Please choose a different value."
+                                    }
+                                ]
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "adminSSHKey",
+                            "type": "Microsoft.Compute.CredentialsCombo",
+                            "label": {
+                                "authenticationType": "",
+                                "password": "",
+                                "sshPublicKey": "VMClarity Server SSH Public Key"
+                            },
+                            "toolTip": {
+                                "authenticationType": "",
+                                "password": "",
+                                "sshPublicKey": "SSH Public Key for the VMClarity Server VM."
+                            },
+                            "defaultValue": {
+                                "sshPublicKey": "",
+                                "authenticationType": ""
+                            },
+                            "constraints": {
+                                "required": true
+                            },
+                            "options": {
+                                "hideConfirmation": true,
+                                "hidePassword": true
+                            },
+                            "osPlatform": "Linux",
+                            "visible": true
+                        },
+                        {
+                            "name": "serverVmSize",
+                            "type": "Microsoft.Compute.SizeSelector",
+                            "label": "VMClarity Server VM Size",
+                            "toolTip": "The size of the VMClarity Server VM",
+                            "recommendedSizes": [
+                                "Standard_D2s_v3"
+                            ],
+                            "constraints": {
+                                "required": true,
+                                "allowedSizes": [
+                                    "Standard_D2s_v3"
+                                ]
+                            },
+                            "imageReference": {
+                                "publisher": "Canonical",
+                                "offer": "0001-com-ubuntu-server-focal",
+                                "sku": "20_04-lts-gen2"
+                            },
+                            "visible": true,
+                            "scope": {
+                                "subscriptionId": "[steps('basics').resourceScope.subscription.subscriptionId]",
+                                "location": "[steps('basics').resourceScope.location.name]"
+                            },
+                            "osPlatform": "Linux"
+                        },
+                        {
+                            "name": "scannerVmSize",
+                            "type": "Microsoft.Compute.SizeSelector",
+                            "label": "VMClarity Scanner VMs Size",
+                            "toolTip": "The size of the VMClarity Scanner VMs",
+                            "recommendedSizes": [
+                                "Standard_D2s_v3"
+                            ],
+                            "constraints": {
+                                "required": true,
+                                "allowedSizes": [
+                                    "Standard_D2s_v3"
+                                ]
+                            },
+                            "imageReference": {
+                                "publisher": "Canonical",
+                                "offer": "0001-com-ubuntu-server-focal",
+                                "sku": "20_04-lts-gen2"
+                            },
+                            "visible": true,
+                            "scope": {
+                                "subscriptionId": "[steps('basics').resourceScope.subscription.subscriptionId]",
+                                "location": "[steps('basics').resourceScope.location.name]"
+                            },
+                            "osPlatform": "Linux"
+                        },
+                        {
+                            "name": "securityType",
+                            "type": "Microsoft.Common.DropDown",
+                            "label": "Security Type",
+                            "subLabel": "",
+                            "defaultValue": "TrustedLaunch",
+                            "toolTip": "Security Type of the VMClarity Server VM.",
+                            "constraints": {
+                                "required": false,
+                                "allowedValues": [
+                                    {
+                                        "label": "Standard",
+                                        "value": "Standard"
+                                    },
+                                    {
+                                        "label": "TrustedLaunch",
+                                        "value": "TrustedLaunch"
+                                    }
+                                ],
+                                "validations": []
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        }
+                    ]
+                },
+                {
+                    "name": "advanced",
+                    "label": "Advanced",
+                    "elements": [
+                        {
+                            "name": "backendContainerImage",
+                            "type": "Microsoft.Common.TextBox",
+                            "label": "Backend Container Image",
+                            "subLabel": "",
+                            "defaultValue": "ghcr.io/openclarity/vmclarity-backend:latest",
+                            "toolTip": "VMClarity Backend Container Image",
+                            "constraints": {
+                                "required": false,
+                                "regex": "",
+                                "validationMessage": "",
+                                "validations": []
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "scannerContainerImage",
+                            "type": "Microsoft.Common.TextBox",
+                            "label": "Scanner Container Image",
+                            "subLabel": "",
+                            "defaultValue": "ghcr.io/openclarity/vmclarity-cli:latest",
+                            "toolTip": "VMClarity Scanner Container Image",
+                            "constraints": {
+                                "required": false,
+                                "regex": "",
+                                "validationMessage": "",
+                                "validations": []
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "trivyServerContainerImage",
+                            "type": "Microsoft.Common.TextBox",
+                            "label": "Trivy Server Container Image",
+                            "subLabel": "",
+                            "defaultValue": "docker.io/aquasec/trivy:0.41.0",
+                            "toolTip": "Trivy Server Container Image",
+                            "constraints": {
+                                "required": false,
+                                "regex": "",
+                                "validationMessage": "",
+                                "validations": []
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "grypeServerContainerImage",
+                            "type": "Microsoft.Common.TextBox",
+                            "label": "Grype Server Container Image",
+                            "subLabel": "",
+                            "defaultValue": "ghcr.io/openclarity/grype-server:v0.2.0",
+                            "toolTip": "Grype Server Container Image",
+                            "constraints": {
+                                "required": false,
+                                "regex": "",
+                                "validationMessage": "",
+                                "validations": []
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "exploitDBContainerImage",
+                            "type": "Microsoft.Common.TextBox",
+                            "label": "Exploit DB Container Image",
+                            "subLabel": "",
+                            "defaultValue": "ghcr.io/openclarity/exploit-db-server:v0.1.2",
+                            "toolTip": "Exploit DB Container Image",
+                            "constraints": {
+                                "required": false,
+                                "regex": "",
+                                "validationMessage": "",
+                                "validations": []
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "freshclamMirrorContainerImage",
+                            "type": "Microsoft.Common.TextBox",
+                            "label": "Freshclam Mirror Container Image",
+                            "subLabel": "",
+                            "defaultValue": "ghcr.io/openclarity/freshclam-mirror:v0.1.0",
+                            "toolTip": "Freshclam Mirror Container Image",
+                            "constraints": {
+                                "required": false,
+                                "regex": "",
+                                "validationMessage": "",
+                                "validations": []
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "assetScanDeletePolicy",
+                            "type": "Microsoft.Common.DropDown",
+                            "label": "Asset Scan Delete Policy",
+                            "subLabel": "",
+                            "defaultValue": "Always",
+                            "toolTip": "Asset Scan Delete Policy",
+                            "constraints": {
+                                "required": false,
+                                "allowedValues": [
+                                    {
+                                        "label": "Always",
+                                        "value": "Always"
+                                    },
+                                    {
+                                        "label": "OnSuccess",
+                                        "value": "OnSuccess"
+                                    },
+                                    {
+                                        "label": "Never",
+                                        "value": "Never"
+                                    }
+                                ],
+                                "validations": []
+                            },
+                            "infoMessages": [],
+                            "visible": true
+                        },
+                        {
+                            "name": "databaseSection",
+                            "type": "Microsoft.Common.Section",
+                            "label": "Database Configuration",
+                            "elements": [
+                                {
+                                    "name": "databaseToUse",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "label": "Database To Use",
+                                    "subLabel": "",
+                                    "defaultValue": "SQLite",
+                                    "toolTip": "Database to Use",
+                                    "constraints": {
+                                        "required": false,
+                                        "allowedValues": [
+                                            {
+                                                "label": "Postgresql",
+                                                "value": "Postgresql"
+                                            },
+                                            {
+                                                "label": "External Postgresql",
+                                                "value": "External Postgresql"
+                                            },
+                                            {
+                                                "label": "SQLite",
+                                                "value": "SQLite"
+                                            }
+                                        ],
+                                        "validations": []
+                                    },
+                                    "infoMessages": [],
+                                    "visible": true
+                                },
+                                {
+                                    "name": "postgresContainerImage",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "Postgres Container Image",
+                                    "subLabel": "",
+                                    "defaultValue": "docker.io/bitnami/postgresql:12.14.0-debian-11-r28",
+                                    "toolTip": "Postgres Container Image",
+                                    "constraints": {
+                                        "required": false,
+                                        "regex": "",
+                                        "validationMessage": "",
+                                        "validations": []
+                                    },
+                                    "infoMessages": [],
+                                    "visible": "[equals(steps('advanced').databaseSection.databaseToUse, 'Postgresql')]"
+                                },
+                                {
+                                    "name": "postgresDBPassword",
+                                    "type": "Microsoft.Common.PasswordBox",
+                                    "label": {
+                                        "password": "Postgres DB Password",
+                                        "confirmPassword": "Confirm password"
+                                    },
+                                    "defaultValue": "",
+                                    "toolTip": "Password to configure Postgresql with on first install. Required if Postgres is selected as the Database To Use. Do not change this on stack update.",
+                                    "constraints": {
+                                        "required": "[equals(steps('advanced').databaseSection.databaseToUse, 'Postgresql')]",
+                                        "regex": "",
+                                        "validationMessage": "",
+                                        "validations": []
+                                    },
+                                    "options": {
+                                        "hideConfirmation": true
+                                    },
+                                    "visible": "[equals(steps('advanced').databaseSection.databaseToUse, 'Postgresql')]"
+                                },
+                                {
+                                    "name": "externalDBHost",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "External DB Host",
+                                    "subLabel": "",
+                                    "defaultValue": "",
+                                    "toolTip": "Hostname or IP address of the External DB to connect to. Required if an external database type is selected as the Database To Use.",
+                                    "constraints": {
+                                        "required": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]",
+                                        "regex": "",
+                                        "validationMessage": "",
+                                        "validations": []
+                                    },
+                                    "infoMessages": [],
+                                    "visible": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]"
+                                },
+                                {
+                                    "name": "externalDBPort",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "External DB Port",
+                                    "subLabel": "",
+                                    "defaultValue": "0",
+                                    "toolTip": "Network Port of the External DB to connect to. Required if an external database type is selected as the Database To Use.",
+                                    "constraints": {
+                                        "required": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]",
+                                        "regex": "",
+                                        "validationMessage": "",
+                                        "validations": [
+                                            {
+                                                "isValid": "[or(or(empty(steps('basics').externalDBPort),and(not(startsWith(steps('basics').externalDBPort,'[[')),startsWith(steps('basics').externalDBPort,'['),endsWith(steps('basics').externalDBPort,']'),greater(indexOf(steps('basics').externalDBPort,'('),-1),greater(indexOf(steps('basics').externalDBPort,')'),-1))),greaterOrEquals(if(regex(steps('basics').externalDBPort,'[a-zA-Z]+'),-1,steps('basics').externalDBPort),0))]",
+                                                "message": "The value must be at least 0."
+                                            }
+                                        ]
+                                    },
+                                    "infoMessages": [],
+                                    "visible": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]"
+                                },
+                                {
+                                    "name": "externalDBName",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "External DB Name",
+                                    "subLabel": "",
+                                    "defaultValue": "",
+                                    "toolTip": "Name of the Database to use on the External DB. Required if an external database type is selected as the Database To Use.",
+                                    "constraints": {
+                                        "required": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]",
+                                        "regex": "",
+                                        "validationMessage": "",
+                                        "validations": []
+                                    },
+                                    "infoMessages": [],
+                                    "visible": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]"
+                                },
+                                {
+                                    "name": "externalDBUsername",
+                                    "type": "Microsoft.Common.TextBox",
+                                    "label": "External DB Username",
+                                    "subLabel": "",
+                                    "defaultValue": "",
+                                    "toolTip": "Username to use to connect to the External DB. Required if an external database type is selected as the Database To Use.",
+                                    "constraints": {
+                                        "required": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]",
+                                        "regex": "",
+                                        "validationMessage": "",
+                                        "validations": []
+                                    },
+                                    "infoMessages": [],
+                                    "visible": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]"
+                                },
+                                {
+                                    "name": "externalDBPassword",
+                                    "type": "Microsoft.Common.PasswordBox",
+                                    "label": {
+                                        "password": "External DB Password",
+                                        "confirmPassword": "Confirm password"
+                                    },
+                                    "defaultValue": "",
+                                    "toolTip": "Password to use to connect to the External DB. Required if an external database type is selected as the Database To Use.",
+                                    "constraints": {
+                                        "required": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]",
+                                        "regex": "",
+                                        "validationMessage": "",
+                                        "validations": []
+                                    },
+                                    "options": {
+                                        "hideConfirmation": true
+                                    },
+                                    "visible": "[equals(steps('advanced').databaseSection.databaseToUse, 'External Postgresql')]"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "outputs": {
+            "parameters": {
+                "location": "[steps('basics').resourceScope.location.name]",
+                "adminUsername": "[steps('basics').adminUsername]",
+                "adminSSHKey": "[steps('basics').adminSSHKey.sshPublicKey]",
+                "serverVmSize": "[steps('basics').serverVmSize]",
+                "scannerVmSize": "[steps('basics').scannerVmSize]",
+                "securityType": "[steps('basics').securityType]",
+                "deploypostfix": "[steps('basics').deploypostfix]",
+                "backendContainerImage": "[steps('advanced').backendContainerImage]",
+                "scannerContainerImage": "[steps('advanced').scannerContainerImage]",
+                "trivyServerContainerImage": "[steps('advanced').trivyServerContainerImage]",
+                "grypeServerContainerImage": "[steps('advanced').grypeServerContainerImage]",
+                "exploitDBContainerImage": "[steps('advanced').exploitDBContainerImage]",
+                "freshclamMirrorContainerImage": "[steps('advanced').freshclamMirrorContainerImage]",
+                "assetScanDeletePolicy": "[steps('advanced').assetScanDeletePolicy]",
+                "databaseToUse": "[steps('advanced').databaseSection.databaseToUse]",
+                "postgresContainerImage": "[steps('advanced').databaseSection.postgresContainerImage]",
+                "postgresDBPassword": "[steps('advanced').databaseSection.postgresDBPassword]",
+                "externalDBHost": "[steps('advanced').databaseSection.externalDBHost]",
+                "externalDBPort": "[steps('advanced').databaseSection.externalDBPort]",
+                "externalDBName": "[steps('advanced').databaseSection.externalDBName]",
+                "externalDBUsername": "[steps('advanced').databaseSection.externalDBUsername]",
+                "externalDBPassword": "[steps('advanced').databaseSection.externalDBPassword]"
+            },
+            "kind": "Subscription",
+            "location": "[steps('basics').resourceScope.location.name]",
+            "subscriptionId": "[steps('basics').resourceScope.subscription.id]"
+        }
+    }
+}

--- a/installation/azure/vmclarity-install.sh
+++ b/installation/azure/vmclarity-install.sh
@@ -1,0 +1,287 @@
+#!/bin/bash 
+
+set -euo pipefail
+
+apt-get update
+apt-get install -y docker.io 
+
+mkdir -p /etc/vmclarity
+mkdir -p /opt/vmclarity
+
+cat << 'EOF' > /etc/vmclarity/deploy.sh
+#!/bin/bash
+set -euo pipefail
+
+# Create the docker network for the VMClarity services if it
+# doesn't exist.
+if docker network ls | grep vmclarity; then
+  echo "network already exists"
+else
+  docker network create vmclarity
+fi
+
+# Reload the systemd daemon to ensure that all the VMClarity
+# units have been detected.
+systemctl daemon-reload
+
+# Enable and start/restart exploit-db-server
+systemctl enable exploit-db-server.service
+systemctl restart exploit-db-server.service
+
+# Enable and start/restart trivy server
+systemctl enable trivy_server.service
+systemctl restart trivy_server.service
+
+# Enable and start/restart grype_server
+systemctl enable grype_server.service
+systemctl restart grype_server.service
+
+# Enable and start/restart freshclam mirror
+systemctl enable vmclarity_freshclam_mirror.service
+systemctl restart vmclarity_freshclam_mirror.service
+
+if [ "__DatabaseToUse__" == "Postgresql" ]; then
+  # Enable and start/restart postgres
+  systemctl enable postgres.service
+  systemctl restart postgres.service
+
+  # Configure the VMClarity backend to use the local postgres
+  # service
+  echo "DATABASE_DRIVER=POSTGRES" >> /etc/vmclarity/config.env
+  echo "DB_NAME=vmclarity" >> /etc/vmclarity/config.env
+  echo "DB_USER=vmclarity" >> /etc/vmclarity/config.env
+  echo "DB_PASS=__PostgresDBPassword__" >> /etc/vmclarity/config.env
+  echo "DB_HOST=postgres.service" >> /etc/vmclarity/config.env
+  echo "DB_PORT_NUMBER=5432" >> /etc/vmclarity/config.env
+elif [ "__DatabaseToUse__" == "External Postgresql" ]; then
+  # Configure the VMClarity backend to use the postgres
+  # database configured by the user.
+  echo "DATABASE_DRIVER=POSTGRES" >> /etc/vmclarity/config.env
+  echo "DB_NAME=__ExternalDBName__" >> /etc/vmclarity/config.env
+  echo "DB_USER=__ExternalDBUsername__" >> /etc/vmclarity/config.env
+  echo "DB_PASS=__ExternalDBPassword__" >> /etc/vmclarity/config.env
+  echo "DB_HOST=__ExternalDBHost__" >> /etc/vmclarity/config.env
+  echo "DB_PORT_NUMBER=__ExternalDBPort__" >> /etc/vmclarity/config.env
+elif [ "__DatabaseToUse__" == "SQLite" ]; then
+  # Configure the VMClarity backend to use the SQLite DB
+  # driver and configure the storage location so that it
+  # persists.
+  echo "DATABASE_DRIVER=LOCAL" >> /etc/vmclarity/config.env
+  echo "LOCAL_DB_PATH=/data/vmclarity.db" >> /etc/vmclarity/config.env
+fi
+
+# Replace anywhere in the config.env __BACKEND_REST_HOST__
+# with the local ipv4 IP address of the VMClarity server.
+local_ip_address="$(curl -s -H Metadata:true --noproxy "*" "http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2021-02-01&format=text")"
+sed -i "s/__BACKEND_REST_HOST__/${local_ip_address}/" /etc/vmclarity/config.env
+
+# Enable and start/restart VMClarity backend
+systemctl enable vmclarity.service
+systemctl restart vmclarity.service
+EOF
+chmod 744 /etc/vmclarity/deploy.sh
+
+cat << 'EOF' > /etc/vmclarity/config.env
+PROVIDER=Azure
+VMCLARITY_AZURE_SUBSCRIPTION_ID=__AZURE_SUBSCRIPTION_ID__
+VMCLARITY_AZURE_SCANNER_LOCATION=__AZURE_SCANNER_LOCATION__
+VMCLARITY_AZURE_SCANNER_RESOURCE_GROUP=__AZURE_SCANNER_RESOURCE_GROUP__
+VMCLARITY_AZURE_SCANNER_SUBNET_ID=__AZURE_SCANNER_SUBNET_ID__
+VMCLARITY_AZURE_SCANNER_PUBLIC_KEY=__AZURE_SCANNER_PUBLIC_KEY__
+VMCLARITY_AZURE_SCANNER_VM_SIZE=__AZURE_SCANNER_VM_SIZE__
+VMCLARITY_AZURE_SCANNER_IMAGE_PUBLISHER=__AZURE_SCANNER_IMAGE_PUBLISHER__
+VMCLARITY_AZURE_SCANNER_IMAGE_OFFER=__AZURE_SCANNER_IMAGE_OFFER__
+VMCLARITY_AZURE_SCANNER_IMAGE_SKU=__AZURE_SCANNER_IMAGE_SKU__
+VMCLARITY_AZURE_SCANNER_IMAGE_VERSION=__AZURE_SCANNER_IMAGE_VERSION__
+VMCLARITY_AZURE_SCANNER_SECURITY_GROUP=__AZURE_SCANNER_SECURITY_GROUP__
+VMCLARITY_AZURE_SCANNER_STORAGE_ACCOUNT_NAME=__AZURE_SCANNER_STORAGE_ACCOUNT_NAME__
+VMCLARITY_AZURE_SCANNER_STORAGE_CONTAINER_NAME=__AZURE_SCANNER_STORAGE_CONTAINER_NAME__
+
+BACKEND_REST_HOST=__BACKEND_REST_HOST__
+BACKEND_REST_PORT=8888
+SCANNER_CONTAINER_IMAGE=__ScannerContainerImage__
+TRIVY_SERVER_ADDRESS=http://__BACKEND_REST_HOST__:9992
+GRYPE_SERVER_ADDRESS=__BACKEND_REST_HOST__:9991
+DELETE_JOB_POLICY=__AssetScanDeletePolicy__
+ALTERNATIVE_FRESHCLAM_MIRROR_URL=http://__BACKEND_REST_HOST__:1000/clamav
+EOF
+chmod 644 /etc/vmclarity/config.env 
+
+cat << 'EOF' > /etc/vmclarity/service.env
+BACKEND_CONTAINER_IMAGE=__BackendContainerImage__
+BACKEND_LOG_LEVEL=info
+EOF
+chmod 644 /etc/vmclarity/service.env 
+
+cat << 'EOF' > /lib/systemd/system/vmclarity.service
+[Unit]
+Description=VmClarity
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+EnvironmentFile=/etc/vmclarity/service.env
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=/usr/bin/mkdir -p /opt/vmclarity
+ExecStartPre=/usr/bin/docker pull ${BACKEND_CONTAINER_IMAGE}
+ExecStart=/usr/bin/docker run \
+  --rm --name %n \
+  --network vmclarity \
+  -p 0.0.0.0:8888:8888/tcp \
+  -v /opt/vmclarity:/data \
+  --env-file /etc/vmclarity/config.env \
+  ${BACKEND_CONTAINER_IMAGE} \
+  run \
+  --log-level ${BACKEND_LOG_LEVEL}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+chmod 644 /lib/systemd/system/vmclarity.service
+
+cat << 'EOF' > /lib/systemd/system/exploit-db-server.service
+[Unit]
+Description=Exploit DB Server
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=/usr/bin/mkdir -p /opt/exploits
+ExecStartPre=/usr/bin/docker pull __ExploitDBServerContainerImage__
+ExecStart=/usr/bin/docker run \
+  --rm --name %n \
+  --network vmclarity \
+  -p 0.0.0.0:1326:1326/tcp \
+  -v /opt/exploits:/vuls \
+  __ExploitDBServerContainerImage__
+
+[Install]
+WantedBy=multi-user.target
+EOF
+chmod 644 /lib/systemd/system/exploit-db-server.service 
+
+mkdir -p /etc/trivy-server
+
+cat << 'EOF' > /etc/trivy-server/config.env
+TRIVY_LISTEN=0.0.0.0:9992
+TRIVY_CACHE_DIR=/home/scanner/.cache/trivy
+EOF
+chmod 644 /etc/trivy-server/config.env
+
+cat << 'EOF' > /lib/systemd/system/trivy_server.service
+[Unit]
+Description=Trivy Server
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=/usr/bin/mkdir -p /opt/trivy-server
+ExecStartPre=/usr/bin/docker pull __TrivyServerContainerImage__
+ExecStart=/usr/bin/docker run \
+  --rm --name %n \
+  --network vmclarity \
+  -p 0.0.0.0:9992:9992/tcp \
+  -v /opt/trivy-server:/home/scanner/.cache \
+  --env-file /etc/trivy-server/config.env \
+  __TrivyServerContainerImage__ server
+
+[Install]
+WantedBy=multi-user.target
+EOF
+chmod 644 /lib/systemd/system/trivy_server.service 
+
+mkdir -p /etc/grype-server
+
+cat << 'EOF' > /etc/grype-server/config.env
+DB_ROOT_DIR=/opt/grype-server/db
+EOF
+chmod 644 /etc/grype-server/config.env 
+
+cat << 'EOF' > /lib/systemd/system/grype_server.service
+[Unit]
+Description=Grype Server
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=/usr/bin/mkdir -p /opt/grype-server
+ExecStartPre=/usr/bin/chown -R 1000:1000 /opt/grype-server
+ExecStartPre=/usr/bin/docker pull __GrypeServerContainerImage__
+ExecStart=/usr/bin/docker run \
+  --rm --name %n \
+  --network vmclarity \
+  -p 0.0.0.0:9991:9991/tcp \
+  -v /opt/grype-server:/opt/grype-server \
+  --env-file /etc/grype-server/config.env \
+  __GrypeServerContainerImage__ run --log-level warning
+
+[Install]
+WantedBy=multi-user.target
+EOF
+chmod 644 /lib/systemd/system/grype_server.service
+
+cat << 'EOF' > /lib/systemd/system/vmclarity_freshclam_mirror.service
+[Unit]
+Description=Deploys the freshclam mirror service
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=/usr/bin/docker pull __FreshclamMirrorContainerImage__
+ExecStart=/usr/bin/docker run \
+  --rm --name %n \
+  --network vmclarity \
+  -p 0.0.0.0:1000:80/tcp \
+  __FreshclamMirrorContainerImage__
+
+[Install]
+WantedBy=multi-user.target
+EOF
+chmod 644 /lib/systemd/system/vmclarity_freshclam_mirror.service 
+
+cat << 'EOF' > /lib/systemd/system/postgres.service
+[Unit]
+Description=Postgresql Database Server
+After=docker.service
+Requires=docker.service
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+ExecStartPre=-/usr/bin/docker stop %n
+ExecStartPre=-/usr/bin/docker rm %n
+ExecStartPre=/usr/bin/docker pull __PostgresqlContainerImage__
+ExecStart=/usr/bin/docker run \
+  --rm --name %n \
+  --network vmclarity \
+  -e POSTGRESQL_USERNAME=vmclarity \
+  -e POSTGRESQL_PASSWORD=__PostgresDBPassword__ \
+  -e POSTGRESQL_DATABASE=vmclarity \
+  -p 127.0.0.1:5432:5432/tcp \
+  __PostgresqlContainerImage__
+
+[Install]
+WantedBy=multi-user.target
+EOF
+chmod 644 /lib/systemd/system/postgres.service
+
+/etc/vmclarity/deploy.sh

--- a/installation/azure/vmclarity.bicep
+++ b/installation/azure/vmclarity.bicep
@@ -1,0 +1,151 @@
+targetScope = 'subscription'
+
+@description('Location for the VMClarity resource group')
+param location string = 'eastus'
+
+@description('Username for the VMClarity Server VM')
+param adminUsername string
+
+@description('SSH Public Key for the VMClarity Server VM')
+@secure()
+param adminSSHKey string
+
+@description('The size of the VMClarity Server VM')
+param serverVmSize string = 'Standard_D2s_v3'
+
+@description('The size of the Scanner VMs')
+param scannerVmSize string = 'Standard_D2s_v3'
+
+@description('Security Type of the VMClartiy Server VM')
+@allowed([
+  'Standard'
+  'TrustedLaunch'
+])
+param securityType string = 'TrustedLaunch'
+
+@description ('VMClarity Backend Container Image')
+param backendContainerImage string = 'ghcr.io/openclarity/vmclarity-backend:latest'
+
+@description ('VMClarity Scanner Container Image')
+param scannerContainerImage string = 'ghcr.io/openclarity/vmclarity-cli:latest'
+
+@description ('Trivy Server Container Image')
+param trivyServerContainerImage string = 'docker.io/aquasec/trivy:0.41.0'
+
+@description ('Grype Server Container Image')
+param grypeServerContainerImage string = 'ghcr.io/openclarity/grype-server:v0.2.0'
+
+@description ('Exploit DB Container Image')
+param exploitDBContainerImage string = 'ghcr.io/openclarity/exploit-db-server:v0.1.2'
+
+@description ('Freshclam Mirror Container Image')
+param freshclamMirrorContainerImage string = 'ghcr.io/openclarity/freshclam-mirror:v0.1.0'
+
+@description('Postgres Container Image')
+param postgresContainerImage string = 'docker.io/bitnami/postgresql:12.14.0-debian-11-r28'
+
+@description('Asset Scan Delete Policy')
+@allowed([
+  'Always'
+  'OnSuccess'
+  'Never'
+])
+param assetScanDeletePolicy string = 'Always'
+
+@description('Database to Use')
+@allowed([
+  //'Postgresql'
+  //'External Postgresql'
+  'SQLite'
+])
+param databaseToUse string = 'SQLite'
+
+@description('Password to configure Postgresql with on first install. Required if Postgres is selected as the Database To Use. Do not change this on stack update.')
+@secure()
+param postgresDBPassword string = ''
+
+@description('Hostname or IP address of the External DB to connect to. Required if an external database type is selected as the Database To Use.')
+param externalDBHost string = ''
+
+@description('Network Port of the External DB to connect to. Required if an external database type is selected as the Database To Use.')
+@minValue(0)
+param externalDBPort int = 0
+
+@description('Name of the Database to use on the External DB. Required if an external database type is selected as the Database To Use.')
+param externalDBName string = ''
+
+@description('Username to use to connect to the External DB. Required if an external database type is selected as the Database To Use.')
+param externalDBUsername string = ''
+
+@description('Password to use to connect to the External DB. Required if an external database type is selected as the Database To Use.')
+@secure()
+param externalDBPassword string = ''
+
+@description('VMClarity Deploy Postfix')
+param deploypostfix string
+
+var resourceGroupName = 'vmclarity-${deploypostfix}'
+
+resource vmClarityResourceGroup 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module vmClarityManagedIdentity 'vmclarityManagedIdentity.bicep' = {
+  name: 'vmclarity-managed-identity'
+  scope: vmClarityResourceGroup
+  params: {
+    location: location
+  }
+}
+
+module vmClarityScanRole 'vmclarityScanRole.bicep' = {
+  name: 'vmclarity-${deploypostfix}-scan-role'
+  scope: vmClarityResourceGroup
+  params: {
+    principalID: vmClarityManagedIdentity.outputs.vmClarityIdentityPrincipalId
+  }
+}
+
+module vmClarityDiscoverRole 'vmclarityDiscoverRole.bicep' = {
+  name: 'vmclarity-${deploypostfix}-discover-role'
+  scope: subscription()
+  params: {
+    resourceGroupName: resourceGroupName
+    principalID: vmClarityManagedIdentity.outputs.vmClarityIdentityPrincipalId
+  }
+}
+
+module vmClarityDeploy 'vmclarityDeployModule.bicep' = {
+  name: 'vmclarity-deploy'
+  scope: vmClarityResourceGroup
+  params: {
+    location: location
+    adminSSHKey: adminSSHKey
+    adminUsername: adminUsername
+    serverVmSize: serverVmSize
+    scannerVmSize: scannerVmSize
+    securityType: securityType
+    vmClarityIdentityID: vmClarityManagedIdentity.outputs.vmClarityIdentityId
+    principalID: vmClarityManagedIdentity.outputs.vmClarityIdentityPrincipalId
+    backendContainerImage: backendContainerImage
+    scannerContainerImage: scannerContainerImage
+    trivyServerContainerImage: trivyServerContainerImage
+    grypeServerContainerImage: grypeServerContainerImage
+    exploitDBContainerImage: exploitDBContainerImage
+    freshclamMirrorContainerImage: freshclamMirrorContainerImage
+    postgresContainerImage: postgresContainerImage
+    assetScanDeletePolicy: assetScanDeletePolicy
+    databaseToUse: databaseToUse
+    postgresDBPassword: postgresDBPassword
+    externalDBHost: externalDBHost
+    externalDBPort: externalDBPort
+    externalDBName: externalDBName
+    externalDBUsername: externalDBUsername
+    externalDBPassword: externalDBPassword
+  }
+}
+
+output adminUsername string = vmClarityDeploy.outputs.adminUsername
+output hostname string = vmClarityDeploy.outputs.hostname
+output sshCommand string = vmClarityDeploy.outputs.sshCommand

--- a/installation/azure/vmclarity.json
+++ b/installation/azure/vmclarity.json
@@ -1,0 +1,1103 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.18.4.5664",
+      "templateHash": "1975093144371206712"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "eastus",
+      "metadata": {
+        "description": "Location for the VMClarity resource group"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the VMClarity Server VM"
+      }
+    },
+    "adminSSHKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Public Key for the VMClarity Server VM"
+      }
+    },
+    "serverVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "The size of the VMClarity Server VM"
+      }
+    },
+    "scannerVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "The size of the Scanner VMs"
+      }
+    },
+    "securityType": {
+      "type": "string",
+      "defaultValue": "TrustedLaunch",
+      "allowedValues": [
+        "Standard",
+        "TrustedLaunch"
+      ],
+      "metadata": {
+        "description": "Security Type of the VMClartiy Server VM"
+      }
+    },
+    "backendContainerImage": {
+      "type": "string",
+      "defaultValue": "ghcr.io/openclarity/vmclarity-backend:latest",
+      "metadata": {
+        "description": "VMClarity Backend Container Image"
+      }
+    },
+    "scannerContainerImage": {
+      "type": "string",
+      "defaultValue": "ghcr.io/openclarity/vmclarity-cli:latest",
+      "metadata": {
+        "description": "VMClarity Scanner Container Image"
+      }
+    },
+    "trivyServerContainerImage": {
+      "type": "string",
+      "defaultValue": "docker.io/aquasec/trivy:0.41.0",
+      "metadata": {
+        "description": "Trivy Server Container Image"
+      }
+    },
+    "grypeServerContainerImage": {
+      "type": "string",
+      "defaultValue": "ghcr.io/openclarity/grype-server:v0.2.0",
+      "metadata": {
+        "description": "Grype Server Container Image"
+      }
+    },
+    "exploitDBContainerImage": {
+      "type": "string",
+      "defaultValue": "ghcr.io/openclarity/exploit-db-server:v0.1.2",
+      "metadata": {
+        "description": "Exploit DB Container Image"
+      }
+    },
+    "freshclamMirrorContainerImage": {
+      "type": "string",
+      "defaultValue": "ghcr.io/openclarity/freshclam-mirror:v0.1.0",
+      "metadata": {
+        "description": "Freshclam Mirror Container Image"
+      }
+    },
+    "postgresContainerImage": {
+      "type": "string",
+      "defaultValue": "docker.io/bitnami/postgresql:12.14.0-debian-11-r28",
+      "metadata": {
+        "description": "Postgres Container Image"
+      }
+    },
+    "assetScanDeletePolicy": {
+      "type": "string",
+      "defaultValue": "Always",
+      "allowedValues": [
+        "Always",
+        "OnSuccess",
+        "Never"
+      ],
+      "metadata": {
+        "description": "Asset Scan Delete Policy"
+      }
+    },
+    "databaseToUse": {
+      "type": "string",
+      "defaultValue": "SQLite",
+      "allowedValues": [
+        "SQLite"
+      ],
+      "metadata": {
+        "description": "Database to Use"
+      }
+    },
+    "postgresDBPassword": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Password to configure Postgresql with on first install. Required if Postgres is selected as the Database To Use. Do not change this on stack update."
+      }
+    },
+    "externalDBHost": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Hostname or IP address of the External DB to connect to. Required if an external database type is selected as the Database To Use."
+      }
+    },
+    "externalDBPort": {
+      "type": "int",
+      "defaultValue": 0,
+      "minValue": 0,
+      "metadata": {
+        "description": "Network Port of the External DB to connect to. Required if an external database type is selected as the Database To Use."
+      }
+    },
+    "externalDBName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Name of the Database to use on the External DB. Required if an external database type is selected as the Database To Use."
+      }
+    },
+    "externalDBUsername": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Username to use to connect to the External DB. Required if an external database type is selected as the Database To Use."
+      }
+    },
+    "externalDBPassword": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Password to use to connect to the External DB. Required if an external database type is selected as the Database To Use."
+      }
+    },
+    "deploypostfix": {
+      "type": "string",
+      "metadata": {
+        "description": "VMClarity Deploy Postfix"
+      }
+    }
+  },
+  "variables": {
+    "resourceGroupName": "[format('vmclarity-{0}', parameters('deploypostfix'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Resources/resourceGroups",
+      "apiVersion": "2022-09-01",
+      "name": "[variables('resourceGroupName')]",
+      "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "vmclarity-managed-identity",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.18.4.5664",
+              "templateHash": "240849925380037017"
+            }
+          },
+          "parameters": {
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Location where to create the resources"
+              }
+            }
+          },
+          "variables": {
+            "vmClarityIdentityName": "[format('vmclarity-discoverer-deployer-{0}', uniqueString(resourceGroup().id))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+              "apiVersion": "2018-11-30",
+              "name": "[variables('vmClarityIdentityName')]",
+              "location": "[parameters('location')]"
+            }
+          ],
+          "outputs": {
+            "vmClarityIdentityId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('vmClarityIdentityName'))]"
+            },
+            "vmClarityIdentityPrincipalId": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('vmClarityIdentityName')), '2018-11-30').principalId]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resourceGroupName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('vmclarity-{0}-scan-role', parameters('deploypostfix'))]",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "principalID": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-managed-identity'), '2022-09-01').outputs.vmClarityIdentityPrincipalId.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.18.4.5664",
+              "templateHash": "7040041022808729062"
+            }
+          },
+          "parameters": {
+            "principalID": {
+              "type": "string",
+              "metadata": {
+                "description": "VMClarity Managed Identity Principal ID"
+              }
+            }
+          },
+          "variables": {
+            "scanRoleName": "[guid(resourceGroup().id, 'vmclarity-scanner')]",
+            "scanRoleDescription": "IAM Role to allow VMClarity to deploy virtual machines that mount and scan snapshots."
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleDefinitions",
+              "apiVersion": "2022-04-01",
+              "name": "[variables('scanRoleName')]",
+              "properties": {
+                "roleName": "[variables('scanRoleName')]",
+                "description": "[variables('scanRoleDescription')]",
+                "type": "customRole",
+                "assignableScopes": [
+                  "[resourceGroup().id]"
+                ],
+                "permissions": [
+                  {
+                    "actions": [
+                      "Microsoft.Compute/virtualMachines/read",
+                      "Microsoft.Compute/virtualMachines/write",
+                      "Microsoft.Compute/virtualMachines/delete",
+                      "Microsoft.Compute/snapshots/read",
+                      "Microsoft.Compute/snapshots/write",
+                      "Microsoft.Compute/snapshots/delete",
+                      "Microsoft.Compute/disks/read",
+                      "Microsoft.Compute/disks/write",
+                      "Microsoft.Compute/disks/delete",
+                      "Microsoft.Network/networkInterfaces/write",
+                      "Microsoft.Network/networkInterfaces/read",
+                      "Microsoft.Network/networkInterfaces/delete",
+                      "Microsoft.Network/networkSecurityGroups/join/action",
+                      "Microsoft.Network/virtualNetworks/subnets/join/action",
+                      "Microsoft.Network/networkInterfaces/join/action",
+                      "Microsoft.Compute/snapshots/beginGetAccess/action",
+                      "Microsoft.Compute/snapshots/endGetAccess/action",
+                      "Microsoft.Storage/storageAccounts/listkeys/action"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(resourceGroup().id, 'vmclarity-server', resourceId('Microsoft.Authorization/roleDefinitions', variables('scanRoleName')))]",
+              "properties": {
+                "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', variables('scanRoleName'))]",
+                "principalId": "[parameters('principalID')]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Authorization/roleDefinitions', variables('scanRoleName'))]"
+              ]
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-managed-identity')]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resourceGroupName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "[format('vmclarity-{0}-discover-role', parameters('deploypostfix'))]",
+      "location": "[deployment().location]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "resourceGroupName": {
+            "value": "[variables('resourceGroupName')]"
+          },
+          "principalID": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-managed-identity'), '2022-09-01').outputs.vmClarityIdentityPrincipalId.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.18.4.5664",
+              "templateHash": "10497713072497503606"
+            }
+          },
+          "parameters": {
+            "resourceGroupName": {
+              "type": "string",
+              "metadata": {
+                "description": "VMClarity Resource Group Name"
+              }
+            },
+            "principalID": {
+              "type": "string",
+              "metadata": {
+                "description": "VMClarity Managed Identity Principal ID"
+              }
+            }
+          },
+          "variables": {
+            "discoverRoleName": "[guid(subscription().id, parameters('resourceGroupName'), 'vmclarity-discoverer-snapshotter')]",
+            "discoverRoleDescription": "IAM Role to allow VMClarity to discover and snapshot virtual machines."
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Authorization/roleDefinitions",
+              "apiVersion": "2022-04-01",
+              "name": "[variables('discoverRoleName')]",
+              "properties": {
+                "roleName": "[variables('discoverRoleName')]",
+                "description": "[variables('discoverRoleDescription')]",
+                "type": "customRole",
+                "assignableScopes": [
+                  "[subscription().id]"
+                ],
+                "permissions": [
+                  {
+                    "actions": [
+                      "Microsoft.Resources/subscriptions/resourceGroups/read",
+                      "Microsoft.Resources/subscriptions/resourceGroups/moveResources/action",
+                      "Microsoft.Resources/subscriptions/resourceGroups/validateMoveResources/action",
+                      "Microsoft.Compute/virtualMachines/read",
+                      "Microsoft.Compute/disks/read",
+                      "Microsoft.Compute/snapshots/read",
+                      "Microsoft.Compute/snapshots/write",
+                      "Microsoft.Compute/snapshots/delete",
+                      "Microsoft.Compute/disks/beginGetAccess/action"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "name": "[guid(subscription().id, parameters('resourceGroupName'), 'vmclarity-server', variables('discoverRoleName'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('discoverRoleName'))]",
+                "principalId": "[parameters('principalID')]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('discoverRoleName'))]"
+              ]
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-managed-identity')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2022-09-01",
+      "name": "vmclarity-deploy",
+      "resourceGroup": "[variables('resourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "adminSSHKey": {
+            "value": "[parameters('adminSSHKey')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "serverVmSize": {
+            "value": "[parameters('serverVmSize')]"
+          },
+          "scannerVmSize": {
+            "value": "[parameters('scannerVmSize')]"
+          },
+          "securityType": {
+            "value": "[parameters('securityType')]"
+          },
+          "vmClarityIdentityID": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-managed-identity'), '2022-09-01').outputs.vmClarityIdentityId.value]"
+          },
+          "principalID": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-managed-identity'), '2022-09-01').outputs.vmClarityIdentityPrincipalId.value]"
+          },
+          "backendContainerImage": {
+            "value": "[parameters('backendContainerImage')]"
+          },
+          "scannerContainerImage": {
+            "value": "[parameters('scannerContainerImage')]"
+          },
+          "trivyServerContainerImage": {
+            "value": "[parameters('trivyServerContainerImage')]"
+          },
+          "grypeServerContainerImage": {
+            "value": "[parameters('grypeServerContainerImage')]"
+          },
+          "exploitDBContainerImage": {
+            "value": "[parameters('exploitDBContainerImage')]"
+          },
+          "freshclamMirrorContainerImage": {
+            "value": "[parameters('freshclamMirrorContainerImage')]"
+          },
+          "postgresContainerImage": {
+            "value": "[parameters('postgresContainerImage')]"
+          },
+          "assetScanDeletePolicy": {
+            "value": "[parameters('assetScanDeletePolicy')]"
+          },
+          "databaseToUse": {
+            "value": "[parameters('databaseToUse')]"
+          },
+          "postgresDBPassword": {
+            "value": "[parameters('postgresDBPassword')]"
+          },
+          "externalDBHost": {
+            "value": "[parameters('externalDBHost')]"
+          },
+          "externalDBPort": {
+            "value": "[parameters('externalDBPort')]"
+          },
+          "externalDBName": {
+            "value": "[parameters('externalDBName')]"
+          },
+          "externalDBUsername": {
+            "value": "[parameters('externalDBUsername')]"
+          },
+          "externalDBPassword": {
+            "value": "[parameters('externalDBPassword')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.18.4.5664",
+              "templateHash": "17417527612845233996"
+            }
+          },
+          "parameters": {
+            "adminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Username for the VMClarity Server VM"
+              }
+            },
+            "adminSSHKey": {
+              "type": "securestring",
+              "metadata": {
+                "description": "SSH Public Key for the VMClarity Server VM"
+              }
+            },
+            "serverVmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D2s_v3",
+              "metadata": {
+                "description": "The size of the VMClarity Server VM"
+              }
+            },
+            "scannerVmSize": {
+              "type": "string",
+              "defaultValue": "Standard_D2s_v3",
+              "metadata": {
+                "description": "The size of the Scanner VMs"
+              }
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Location where to create the resources"
+              }
+            },
+            "dnsLabelPrefix": {
+              "type": "string",
+              "defaultValue": "[toLower(format('vmclarity-server-{0}', uniqueString(resourceGroup().id)))]",
+              "metadata": {
+                "description": "Public IP DNS prefix"
+              }
+            },
+            "securityType": {
+              "type": "string",
+              "defaultValue": "TrustedLaunch",
+              "allowedValues": [
+                "Standard",
+                "TrustedLaunch"
+              ],
+              "metadata": {
+                "description": "Security Type of the VMClartiy Server VM"
+              }
+            },
+            "vmClarityIdentityID": {
+              "type": "string",
+              "metadata": {
+                "description": "VMClarity Server Identity ID"
+              }
+            },
+            "principalID": {
+              "type": "string",
+              "metadata": {
+                "description": "VMClarity Managed Identity Principal ID"
+              }
+            },
+            "backendContainerImage": {
+              "type": "string",
+              "defaultValue": "ghcr.io/openclarity/vmclarity-backend:latest",
+              "metadata": {
+                "description": "VMClarity Backend Container Image"
+              }
+            },
+            "scannerContainerImage": {
+              "type": "string",
+              "defaultValue": "ghcr.io/openclarity/vmclarity-cli:latest",
+              "metadata": {
+                "description": "VMClarity Scanner Container Image"
+              }
+            },
+            "trivyServerContainerImage": {
+              "type": "string",
+              "defaultValue": "docker.io/aquasec/trivy:0.41.0",
+              "metadata": {
+                "description": "Trivy Server Container Image"
+              }
+            },
+            "grypeServerContainerImage": {
+              "type": "string",
+              "defaultValue": "ghcr.io/openclarity/grype-server:v0.2.0",
+              "metadata": {
+                "description": "Grype Server Container Image"
+              }
+            },
+            "exploitDBContainerImage": {
+              "type": "string",
+              "defaultValue": "ghcr.io/openclarity/exploit-db-server:v0.1.2",
+              "metadata": {
+                "description": "Exploit DB Container Image"
+              }
+            },
+            "freshclamMirrorContainerImage": {
+              "type": "string",
+              "defaultValue": "ghcr.io/openclarity/freshclam-mirror:v0.1.0",
+              "metadata": {
+                "description": "Freshclam Mirror Container Image"
+              }
+            },
+            "postgresContainerImage": {
+              "type": "string",
+              "defaultValue": "docker.io/bitnami/postgresql:12.14.0-debian-11-r28",
+              "metadata": {
+                "description": "Postgres Container Image"
+              }
+            },
+            "assetScanDeletePolicy": {
+              "type": "string",
+              "defaultValue": "Always",
+              "allowedValues": [
+                "Always",
+                "OnSuccess",
+                "Never"
+              ],
+              "metadata": {
+                "description": "Asset Scan Delete Policy"
+              }
+            },
+            "databaseToUse": {
+              "type": "string",
+              "defaultValue": "Postgresql",
+              "allowedValues": [
+                "Postgresql",
+                "External Postgresql",
+                "SQLite"
+              ],
+              "metadata": {
+                "description": "Database to Use"
+              }
+            },
+            "postgresDBPassword": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Password to configure Postgresql with on first install. Required if Postgres is selected as the Database To Use. Do not change this on stack update."
+              }
+            },
+            "externalDBHost": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Hostname or IP address of the External DB to connect to. Required if an external database type is selected as the Database To Use."
+              }
+            },
+            "externalDBPort": {
+              "type": "int",
+              "defaultValue": 0,
+              "minValue": 0,
+              "metadata": {
+                "description": "Network Port of the External DB to connect to. Required if an external database type is selected as the Database To Use."
+              }
+            },
+            "externalDBName": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Name of the Database to use on the External DB. Required if an external database type is selected as the Database To Use."
+              }
+            },
+            "externalDBUsername": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Username to use to connect to the External DB. Required if an external database type is selected as the Database To Use."
+              }
+            },
+            "externalDBPassword": {
+              "type": "securestring",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Password to use to connect to the External DB. Required if an external database type is selected as the Database To Use."
+              }
+            }
+          },
+          "variables": {
+            "imageReference": {
+              "publisher": "Canonical",
+              "offer": "0001-com-ubuntu-server-focal",
+              "sku": "20_04-lts-gen2",
+              "version": "latest"
+            },
+            "vmClarityNetName": "vmclarity-server-net",
+            "addressPrefix": "10.1.0.0/16",
+            "vmClarityServerSubnetName": "vmclarity-server-subnet",
+            "vmClarityServerSecurityGroupName": "vmclarity-server-security-group",
+            "vmClarityServerSubnetAddressPrefix": "10.1.0.0/24",
+            "vmClarityScannerSubnetName": "vmclarity-scanner-subnet",
+            "vmClarityScannerSecurityGroupName": "vmclarity-scanner-security-group",
+            "vmClarityScannerSubnetAddressPrefix": "10.1.1.0/24",
+            "vmclarityServerVMName": "vmclarity-server",
+            "publicIPAddressName": "[format('{0}-public-ip', variables('vmclarityServerVMName'))]",
+            "networkInterfaceName": "[format('{0}-net-int', variables('vmclarityServerVMName'))]",
+            "params": {
+              "BackendContainerImage": "[parameters('backendContainerImage')]",
+              "ScannerContainerImage": "[parameters('scannerContainerImage')]",
+              "TrivyServerContainerImage": "[parameters('trivyServerContainerImage')]",
+              "GrypeServerContainerImage": "[parameters('grypeServerContainerImage')]",
+              "ExploitDBServerContainerImage": "[parameters('exploitDBContainerImage')]",
+              "FreshclamMirrorContainerImage": "[parameters('freshclamMirrorContainerImage')]",
+              "PostgresqlContainerImage": "[parameters('postgresContainerImage')]",
+              "ScannerInstanceType": "[parameters('scannerVmSize')]",
+              "AssetScanDeletePolicy": "[parameters('assetScanDeletePolicy')]",
+              "DatabaseToUse": "[parameters('databaseToUse')]",
+              "PostgresDBPassword": "[parameters('postgresDBPassword')]",
+              "ExternalDBHost": "[parameters('externalDBHost')]",
+              "ExternalDBPort": "[string(parameters('externalDBPort'))]",
+              "ExternalDBName": "[parameters('externalDBName')]",
+              "ExternalDBUsername": "[parameters('externalDBUsername')]",
+              "ExternalDBPassword": "[parameters('externalDBPassword')]",
+              "AZURE_SUBSCRIPTION_ID": "[subscription().subscriptionId]",
+              "AZURE_SCANNER_LOCATION": "[parameters('location')]",
+              "AZURE_SCANNER_RESOURCE_GROUP": "[resourceGroup().name]",
+              "AZURE_SCANNER_SUBNET_ID": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vmClarityNetName'), variables('vmClarityScannerSubnetName'))]",
+              "AZURE_SCANNER_PUBLIC_KEY": "[base64(parameters('adminSSHKey'))]",
+              "AZURE_SCANNER_VM_SIZE": "[parameters('scannerVmSize')]",
+              "AZURE_SCANNER_IMAGE_PUBLISHER": "[variables('imageReference').publisher]",
+              "AZURE_SCANNER_IMAGE_OFFER": "[variables('imageReference').offer]",
+              "AZURE_SCANNER_IMAGE_SKU": "[variables('imageReference').sku]",
+              "AZURE_SCANNER_IMAGE_VERSION": "[variables('imageReference').version]",
+              "AZURE_SCANNER_SECURITY_GROUP": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('vmClarityScannerSecurityGroupName'))]",
+              "AZURE_SCANNER_STORAGE_ACCOUNT_NAME": "[variables('storageAccountName')]",
+              "AZURE_SCANNER_STORAGE_CONTAINER_NAME": "[variables('snapshotContainerName')]"
+            },
+            "scriptTemplate": "#!/bin/bash \n\nset -euo pipefail\n\napt-get update\napt-get install -y docker.io \n\nmkdir -p /etc/vmclarity\nmkdir -p /opt/vmclarity\n\ncat << 'EOF' > /etc/vmclarity/deploy.sh\n#!/bin/bash\nset -euo pipefail\n\n# Create the docker network for the VMClarity services if it\n# doesn't exist.\nif docker network ls | grep vmclarity; then\n  echo \"network already exists\"\nelse\n  docker network create vmclarity\nfi\n\n# Reload the systemd daemon to ensure that all the VMClarity\n# units have been detected.\nsystemctl daemon-reload\n\n# Enable and start/restart exploit-db-server\nsystemctl enable exploit-db-server.service\nsystemctl restart exploit-db-server.service\n\n# Enable and start/restart trivy server\nsystemctl enable trivy_server.service\nsystemctl restart trivy_server.service\n\n# Enable and start/restart grype_server\nsystemctl enable grype_server.service\nsystemctl restart grype_server.service\n\n# Enable and start/restart freshclam mirror\nsystemctl enable vmclarity_freshclam_mirror.service\nsystemctl restart vmclarity_freshclam_mirror.service\n\nif [ \"__DatabaseToUse__\" == \"Postgresql\" ]; then\n  # Enable and start/restart postgres\n  systemctl enable postgres.service\n  systemctl restart postgres.service\n\n  # Configure the VMClarity backend to use the local postgres\n  # service\n  echo \"DATABASE_DRIVER=POSTGRES\" >> /etc/vmclarity/config.env\n  echo \"DB_NAME=vmclarity\" >> /etc/vmclarity/config.env\n  echo \"DB_USER=vmclarity\" >> /etc/vmclarity/config.env\n  echo \"DB_PASS=__PostgresDBPassword__\" >> /etc/vmclarity/config.env\n  echo \"DB_HOST=postgres.service\" >> /etc/vmclarity/config.env\n  echo \"DB_PORT_NUMBER=5432\" >> /etc/vmclarity/config.env\nelif [ \"__DatabaseToUse__\" == \"External Postgresql\" ]; then\n  # Configure the VMClarity backend to use the postgres\n  # database configured by the user.\n  echo \"DATABASE_DRIVER=POSTGRES\" >> /etc/vmclarity/config.env\n  echo \"DB_NAME=__ExternalDBName__\" >> /etc/vmclarity/config.env\n  echo \"DB_USER=__ExternalDBUsername__\" >> /etc/vmclarity/config.env\n  echo \"DB_PASS=__ExternalDBPassword__\" >> /etc/vmclarity/config.env\n  echo \"DB_HOST=__ExternalDBHost__\" >> /etc/vmclarity/config.env\n  echo \"DB_PORT_NUMBER=__ExternalDBPort__\" >> /etc/vmclarity/config.env\nelif [ \"__DatabaseToUse__\" == \"SQLite\" ]; then\n  # Configure the VMClarity backend to use the SQLite DB\n  # driver and configure the storage location so that it\n  # persists.\n  echo \"DATABASE_DRIVER=LOCAL\" >> /etc/vmclarity/config.env\n  echo \"LOCAL_DB_PATH=/data/vmclarity.db\" >> /etc/vmclarity/config.env\nfi\n\n# Replace anywhere in the config.env __BACKEND_REST_HOST__\n# with the local ipv4 IP address of the VMClarity server.\nlocal_ip_address=\"$(curl -s -H Metadata:true --noproxy \"*\" \"http://169.254.169.254/metadata/instance/network/interface/0/ipv4/ipAddress/0/privateIpAddress?api-version=2021-02-01&format=text\")\"\nsed -i \"s/__BACKEND_REST_HOST__/${local_ip_address}/\" /etc/vmclarity/config.env\n\n# Enable and start/restart VMClarity backend\nsystemctl enable vmclarity.service\nsystemctl restart vmclarity.service\nEOF\nchmod 744 /etc/vmclarity/deploy.sh\n\ncat << 'EOF' > /etc/vmclarity/config.env\nPROVIDER=Azure\nVMCLARITY_AZURE_SUBSCRIPTION_ID=__AZURE_SUBSCRIPTION_ID__\nVMCLARITY_AZURE_SCANNER_LOCATION=__AZURE_SCANNER_LOCATION__\nVMCLARITY_AZURE_SCANNER_RESOURCE_GROUP=__AZURE_SCANNER_RESOURCE_GROUP__\nVMCLARITY_AZURE_SCANNER_SUBNET_ID=__AZURE_SCANNER_SUBNET_ID__\nVMCLARITY_AZURE_SCANNER_PUBLIC_KEY=__AZURE_SCANNER_PUBLIC_KEY__\nVMCLARITY_AZURE_SCANNER_VM_SIZE=__AZURE_SCANNER_VM_SIZE__\nVMCLARITY_AZURE_SCANNER_IMAGE_PUBLISHER=__AZURE_SCANNER_IMAGE_PUBLISHER__\nVMCLARITY_AZURE_SCANNER_IMAGE_OFFER=__AZURE_SCANNER_IMAGE_OFFER__\nVMCLARITY_AZURE_SCANNER_IMAGE_SKU=__AZURE_SCANNER_IMAGE_SKU__\nVMCLARITY_AZURE_SCANNER_IMAGE_VERSION=__AZURE_SCANNER_IMAGE_VERSION__\nVMCLARITY_AZURE_SCANNER_SECURITY_GROUP=__AZURE_SCANNER_SECURITY_GROUP__\nVMCLARITY_AZURE_SCANNER_STORAGE_ACCOUNT_NAME=__AZURE_SCANNER_STORAGE_ACCOUNT_NAME__\nVMCLARITY_AZURE_SCANNER_STORAGE_CONTAINER_NAME=__AZURE_SCANNER_STORAGE_CONTAINER_NAME__\n\nBACKEND_REST_HOST=__BACKEND_REST_HOST__\nBACKEND_REST_PORT=8888\nSCANNER_CONTAINER_IMAGE=__ScannerContainerImage__\nTRIVY_SERVER_ADDRESS=http://__BACKEND_REST_HOST__:9992\nGRYPE_SERVER_ADDRESS=__BACKEND_REST_HOST__:9991\nDELETE_JOB_POLICY=__AssetScanDeletePolicy__\nALTERNATIVE_FRESHCLAM_MIRROR_URL=http://__BACKEND_REST_HOST__:1000/clamav\nEOF\nchmod 644 /etc/vmclarity/config.env \n\ncat << 'EOF' > /etc/vmclarity/service.env\nBACKEND_CONTAINER_IMAGE=__BackendContainerImage__\nBACKEND_LOG_LEVEL=info\nEOF\nchmod 644 /etc/vmclarity/service.env \n\ncat << 'EOF' > /lib/systemd/system/vmclarity.service\n[Unit]\nDescription=VmClarity\nAfter=docker.service\nRequires=docker.service\n\n[Service]\nTimeoutStartSec=0\nRestart=always\nEnvironmentFile=/etc/vmclarity/service.env\nExecStartPre=-/usr/bin/docker stop %n\nExecStartPre=-/usr/bin/docker rm %n\nExecStartPre=/usr/bin/mkdir -p /opt/vmclarity\nExecStartPre=/usr/bin/docker pull ${BACKEND_CONTAINER_IMAGE}\nExecStart=/usr/bin/docker run \\\n  --rm --name %n \\\n  --network vmclarity \\\n  -p 0.0.0.0:8888:8888/tcp \\\n  -v /opt/vmclarity:/data \\\n  --env-file /etc/vmclarity/config.env \\\n  ${BACKEND_CONTAINER_IMAGE} \\\n  run \\\n  --log-level ${BACKEND_LOG_LEVEL}\n\n[Install]\nWantedBy=multi-user.target\nEOF\nchmod 644 /lib/systemd/system/vmclarity.service\n\ncat << 'EOF' > /lib/systemd/system/exploit-db-server.service\n[Unit]\nDescription=Exploit DB Server\nAfter=docker.service\nRequires=docker.service\n\n[Service]\nTimeoutStartSec=0\nRestart=always\nExecStartPre=-/usr/bin/docker stop %n\nExecStartPre=-/usr/bin/docker rm %n\nExecStartPre=/usr/bin/mkdir -p /opt/exploits\nExecStartPre=/usr/bin/docker pull __ExploitDBServerContainerImage__\nExecStart=/usr/bin/docker run \\\n  --rm --name %n \\\n  --network vmclarity \\\n  -p 0.0.0.0:1326:1326/tcp \\\n  -v /opt/exploits:/vuls \\\n  __ExploitDBServerContainerImage__\n\n[Install]\nWantedBy=multi-user.target\nEOF\nchmod 644 /lib/systemd/system/exploit-db-server.service \n\nmkdir -p /etc/trivy-server\n\ncat << 'EOF' > /etc/trivy-server/config.env\nTRIVY_LISTEN=0.0.0.0:9992\nTRIVY_CACHE_DIR=/home/scanner/.cache/trivy\nEOF\nchmod 644 /etc/trivy-server/config.env\n\ncat << 'EOF' > /lib/systemd/system/trivy_server.service\n[Unit]\nDescription=Trivy Server\nAfter=docker.service\nRequires=docker.service\n\n[Service]\nTimeoutStartSec=0\nRestart=always\nExecStartPre=-/usr/bin/docker stop %n\nExecStartPre=-/usr/bin/docker rm %n\nExecStartPre=/usr/bin/mkdir -p /opt/trivy-server\nExecStartPre=/usr/bin/docker pull __TrivyServerContainerImage__\nExecStart=/usr/bin/docker run \\\n  --rm --name %n \\\n  --network vmclarity \\\n  -p 0.0.0.0:9992:9992/tcp \\\n  -v /opt/trivy-server:/home/scanner/.cache \\\n  --env-file /etc/trivy-server/config.env \\\n  __TrivyServerContainerImage__ server\n\n[Install]\nWantedBy=multi-user.target\nEOF\nchmod 644 /lib/systemd/system/trivy_server.service \n\nmkdir -p /etc/grype-server\n\ncat << 'EOF' > /etc/grype-server/config.env\nDB_ROOT_DIR=/opt/grype-server/db\nEOF\nchmod 644 /etc/grype-server/config.env \n\ncat << 'EOF' > /lib/systemd/system/grype_server.service\n[Unit]\nDescription=Grype Server\nAfter=docker.service\nRequires=docker.service\n\n[Service]\nTimeoutStartSec=0\nRestart=always\nExecStartPre=-/usr/bin/docker stop %n\nExecStartPre=-/usr/bin/docker rm %n\nExecStartPre=/usr/bin/mkdir -p /opt/grype-server\nExecStartPre=/usr/bin/chown -R 1000:1000 /opt/grype-server\nExecStartPre=/usr/bin/docker pull __GrypeServerContainerImage__\nExecStart=/usr/bin/docker run \\\n  --rm --name %n \\\n  --network vmclarity \\\n  -p 0.0.0.0:9991:9991/tcp \\\n  -v /opt/grype-server:/opt/grype-server \\\n  --env-file /etc/grype-server/config.env \\\n  __GrypeServerContainerImage__ run --log-level warning\n\n[Install]\nWantedBy=multi-user.target\nEOF\nchmod 644 /lib/systemd/system/grype_server.service\n\ncat << 'EOF' > /lib/systemd/system/vmclarity_freshclam_mirror.service\n[Unit]\nDescription=Deploys the freshclam mirror service\nAfter=docker.service\nRequires=docker.service\n\n[Service]\nTimeoutStartSec=0\nRestart=always\nExecStartPre=-/usr/bin/docker stop %n\nExecStartPre=-/usr/bin/docker rm %n\nExecStartPre=/usr/bin/docker pull __FreshclamMirrorContainerImage__\nExecStart=/usr/bin/docker run \\\n  --rm --name %n \\\n  --network vmclarity \\\n  -p 0.0.0.0:1000:80/tcp \\\n  __FreshclamMirrorContainerImage__\n\n[Install]\nWantedBy=multi-user.target\nEOF\nchmod 644 /lib/systemd/system/vmclarity_freshclam_mirror.service \n\ncat << 'EOF' > /lib/systemd/system/postgres.service\n[Unit]\nDescription=Postgresql Database Server\nAfter=docker.service\nRequires=docker.service\n\n[Service]\nTimeoutStartSec=0\nRestart=always\nExecStartPre=-/usr/bin/docker stop %n\nExecStartPre=-/usr/bin/docker rm %n\nExecStartPre=/usr/bin/docker pull __PostgresqlContainerImage__\nExecStart=/usr/bin/docker run \\\n  --rm --name %n \\\n  --network vmclarity \\\n  -e POSTGRESQL_USERNAME=vmclarity \\\n  -e POSTGRESQL_PASSWORD=__PostgresDBPassword__ \\\n  -e POSTGRESQL_DATABASE=vmclarity \\\n  -p 127.0.0.1:5432:5432/tcp \\\n  __PostgresqlContainerImage__\n\n[Install]\nWantedBy=multi-user.target\nEOF\nchmod 644 /lib/systemd/system/postgres.service\n\n/etc/vmclarity/deploy.sh\n",
+            "renderedScript": "[reduce(items(variables('params')), createObject('value', variables('scriptTemplate')), lambda('curr', 'next', createObject('value', replace(lambdaVariables('curr').value, format('__{0}__', lambdaVariables('next').key), lambdaVariables('next').value)))).value]",
+            "osDiskType": "StandardSSD_LRS",
+            "linuxConfiguration": {
+              "disablePasswordAuthentication": true,
+              "ssh": {
+                "publicKeys": [
+                  {
+                    "path": "[format('/home/{0}/.ssh/authorized_keys', parameters('adminUsername'))]",
+                    "keyData": "[parameters('adminSSHKey')]"
+                  }
+                ]
+              }
+            },
+            "securityProfileJson": {
+              "uefiSettings": {
+                "secureBootEnabled": true,
+                "vTpmEnabled": true
+              },
+              "securityType": "[parameters('securityType')]"
+            },
+            "vmClarityGuestAttestationName": "VmClarityServerGuestAttestation",
+            "extensionName": "GuestAttestation",
+            "extensionPublisher": "Microsoft.Azure.Security.LinuxAttestation",
+            "extensionVersion": "1.0",
+            "maaTenantName": "GuestAttestation",
+            "maaEndpoint": "[substring('emptystring', 0, 0)]",
+            "vmClarityServerCustomScriptName": "VmClarityServerCustomScript",
+            "storageAccountName": "[toLower(format('store{0}', uniqueString(resourceGroup().id)))]",
+            "storageAccountType": "Standard_LRS",
+            "snapshotContainerName": "snapshots"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/networkInterfaces",
+              "apiVersion": "2021-05-01",
+              "name": "[variables('networkInterfaceName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "subnet": {
+                        "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vmClarityNetName'), variables('vmClarityServerSubnetName'))]"
+                      },
+                      "privateIPAllocationMethod": "Dynamic",
+                      "publicIPAddress": {
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+                      }
+                    }
+                  }
+                ],
+                "networkSecurityGroup": {
+                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('vmClarityServerSecurityGroupName'))]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vmClarityNetName'))]",
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('vmClarityServerSecurityGroupName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2021-05-01",
+              "name": "[variables('vmClarityServerSecurityGroupName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "securityRules": [
+                  {
+                    "name": "SSH",
+                    "properties": {
+                      "priority": 1000,
+                      "protocol": "Tcp",
+                      "access": "Allow",
+                      "direction": "Inbound",
+                      "sourceAddressPrefix": "*",
+                      "sourcePortRange": "*",
+                      "destinationAddressPrefix": "*",
+                      "destinationPortRange": "22"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Network/virtualNetworks",
+              "apiVersion": "2021-05-01",
+              "name": "[variables('vmClarityNetName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[variables('addressPrefix')]"
+                  ]
+                },
+                "subnets": [
+                  {
+                    "name": "[variables('vmClarityServerSubnetName')]",
+                    "properties": {
+                      "addressPrefix": "[variables('vmClarityServerSubnetAddressPrefix')]",
+                      "serviceEndpoints": [
+                        {
+                          "service": "Microsoft.Storage"
+                        }
+                      ],
+                      "privateEndpointNetworkPolicies": "Enabled",
+                      "privateLinkServiceNetworkPolicies": "Enabled"
+                    }
+                  },
+                  {
+                    "name": "[variables('vmClarityScannerSubnetName')]",
+                    "properties": {
+                      "addressPrefix": "[variables('vmClarityScannerSubnetAddressPrefix')]",
+                      "privateEndpointNetworkPolicies": "Enabled",
+                      "privateLinkServiceNetworkPolicies": "Enabled"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Network/publicIPAddresses",
+              "apiVersion": "2021-05-01",
+              "name": "[variables('publicIPAddressName')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "Basic"
+              },
+              "properties": {
+                "publicIPAllocationMethod": "Dynamic",
+                "publicIPAddressVersion": "IPv4",
+                "dnsSettings": {
+                  "domainNameLabel": "[parameters('dnsLabelPrefix')]"
+                },
+                "idleTimeoutInMinutes": 4
+              }
+            },
+            {
+              "type": "Microsoft.Compute/virtualMachines",
+              "apiVersion": "2021-11-01",
+              "name": "[variables('vmclarityServerVMName')]",
+              "location": "[parameters('location')]",
+              "identity": {
+                "type": "UserAssigned",
+                "userAssignedIdentities": {
+                  "[format('{0}', parameters('vmClarityIdentityID'))]": {}
+                }
+              },
+              "properties": {
+                "hardwareProfile": {
+                  "vmSize": "[parameters('serverVmSize')]"
+                },
+                "storageProfile": {
+                  "osDisk": {
+                    "createOption": "FromImage",
+                    "managedDisk": {
+                      "storageAccountType": "[variables('osDiskType')]"
+                    }
+                  },
+                  "imageReference": "[variables('imageReference')]"
+                },
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
+                    }
+                  ]
+                },
+                "osProfile": {
+                  "computerName": "[variables('vmclarityServerVMName')]",
+                  "adminUsername": "[parameters('adminUsername')]",
+                  "linuxConfiguration": "[variables('linuxConfiguration')]"
+                },
+                "securityProfile": "[if(equals(parameters('securityType'), 'TrustedLaunch'), variables('securityProfileJson'), null())]"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
+              ]
+            },
+            {
+              "condition": "[and(equals(parameters('securityType'), 'TrustedLaunch'), and(equals(variables('securityProfileJson').uefiSettings.secureBootEnabled, true()), equals(variables('securityProfileJson').uefiSettings.vTpmEnabled, true())))]",
+              "type": "Microsoft.Compute/virtualMachines/extensions",
+              "apiVersion": "2022-03-01",
+              "name": "[format('{0}/{1}', variables('vmclarityServerVMName'), variables('vmClarityGuestAttestationName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "publisher": "[variables('extensionPublisher')]",
+                "type": "[variables('extensionName')]",
+                "typeHandlerVersion": "[variables('extensionVersion')]",
+                "autoUpgradeMinorVersion": true,
+                "enableAutomaticUpgrade": true,
+                "settings": {
+                  "AttestationConfig": {
+                    "MaaSettings": {
+                      "maaEndpoint": "[variables('maaEndpoint')]",
+                      "maaTenantName": "[variables('maaTenantName')]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Compute/virtualMachines', variables('vmclarityServerVMName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Compute/virtualMachines/extensions",
+              "apiVersion": "2023-03-01",
+              "name": "[format('{0}/{1}', variables('vmclarityServerVMName'), variables('vmClarityServerCustomScriptName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "publisher": "Microsoft.Azure.Extensions",
+                "type": "CustomScript",
+                "typeHandlerVersion": "2.1",
+                "autoUpgradeMinorVersion": true,
+                "protectedSettings": {
+                  "script": "[base64(variables('renderedScript'))]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vmClarityNetName'))]",
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('vmClarityScannerSecurityGroupName'))]",
+                "[resourceId('Microsoft.Compute/virtualMachines', variables('vmclarityServerVMName'))]",
+                "[resourceId('Microsoft.Compute/virtualMachines/extensions', variables('vmclarityServerVMName'), variables('vmClarityGuestAttestationName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2021-05-01",
+              "name": "[variables('vmClarityScannerSecurityGroupName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "securityRules": [
+                  {
+                    "name": "SSH-From-VMClarity-Server",
+                    "properties": {
+                      "priority": 1000,
+                      "protocol": "Tcp",
+                      "access": "Allow",
+                      "direction": "Inbound",
+                      "sourceAddressPrefix": "[variables('vmClarityServerSubnetAddressPrefix')]",
+                      "sourcePortRange": "*",
+                      "destinationAddressPrefix": "*",
+                      "destinationPortRange": "22"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2022-09-01",
+              "name": "[variables('storageAccountName')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "[variables('storageAccountType')]"
+              },
+              "kind": "StorageV2",
+              "properties": {
+                "accessTier": "Hot",
+                "networkAcls": {
+                  "bypass": "AzureServices",
+                  "virtualNetworkRules": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vmClarityNetName'), variables('vmClarityServerSubnetName'))]",
+                      "action": "Allow"
+                    }
+                  ],
+                  "defaultAction": "Deny"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vmClarityNetName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Storage/storageAccounts/blobServices",
+              "apiVersion": "2021-02-01",
+              "name": "[format('{0}/{1}', variables('storageAccountName'), 'default')]",
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+              "apiVersion": "2022-09-01",
+              "name": "[format('{0}/{1}/{2}', variables('storageAccountName'), 'default', variables('snapshotContainerName'))]",
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices', variables('storageAccountName'), 'default')]"
+              ]
+            },
+            {
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[format('Microsoft.Storage/storageAccounts/{0}', variables('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), parameters('vmClarityIdentityID'), subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'))]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
+                "principalId": "[parameters('principalID')]",
+                "principalType": "ServicePrincipal"
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "adminUsername": {
+              "type": "string",
+              "value": "[parameters('adminUsername')]"
+            },
+            "hostname": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName')), '2021-05-01').dnsSettings.fqdn]"
+            },
+            "sshCommand": {
+              "type": "string",
+              "value": "[format('ssh {0}@{1}', parameters('adminUsername'), reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName')), '2021-05-01').dnsSettings.fqdn)]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-managed-identity')]",
+        "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('resourceGroupName'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "adminUsername": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-deploy'), '2022-09-01').outputs.adminUsername.value]"
+    },
+    "hostname": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-deploy'), '2022-09-01').outputs.hostname.value]"
+    },
+    "sshCommand": {
+      "type": "string",
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, variables('resourceGroupName')), 'Microsoft.Resources/deployments', 'vmclarity-deploy'), '2022-09-01').outputs.sshCommand.value]"
+    }
+  }
+}

--- a/installation/azure/vmclarityDeployModule.bicep
+++ b/installation/azure/vmclarityDeployModule.bicep
@@ -1,0 +1,445 @@
+@description('Username for the VMClarity Server VM')
+param adminUsername string
+
+@description('SSH Public Key for the VMClarity Server VM')
+@secure()
+param adminSSHKey string
+
+@description('The size of the VMClarity Server VM')
+param serverVmSize string = 'Standard_D2s_v3'
+
+@description('The size of the Scanner VMs')
+param scannerVmSize string = 'Standard_D2s_v3'
+
+@description('Location where to create the resources')
+param location string = resourceGroup().location
+
+@description('Public IP DNS prefix')
+param dnsLabelPrefix string = toLower('vmclarity-server-${uniqueString(resourceGroup().id)}')
+
+@description('Security Type of the VMClartiy Server VM')
+@allowed([
+  'Standard'
+  'TrustedLaunch'
+])
+param securityType string = 'TrustedLaunch'
+
+@description('VMClarity Server Identity ID')
+param vmClarityIdentityID string
+
+@description('VMClarity Managed Identity Principal ID')
+param principalID string
+
+@description ('VMClarity Backend Container Image')
+param backendContainerImage string = 'ghcr.io/openclarity/vmclarity-backend:latest'
+
+@description ('VMClarity Scanner Container Image')
+param scannerContainerImage string = 'ghcr.io/openclarity/vmclarity-cli:latest'
+
+@description ('Trivy Server Container Image')
+param trivyServerContainerImage string = 'docker.io/aquasec/trivy:0.41.0'
+
+@description ('Grype Server Container Image')
+param grypeServerContainerImage string = 'ghcr.io/openclarity/grype-server:v0.2.0'
+
+@description ('Exploit DB Container Image')
+param exploitDBContainerImage string = 'ghcr.io/openclarity/exploit-db-server:v0.1.2'
+
+@description ('Freshclam Mirror Container Image')
+param freshclamMirrorContainerImage string = 'ghcr.io/openclarity/freshclam-mirror:v0.1.0'
+
+@description('Postgres Container Image')
+param postgresContainerImage string = 'docker.io/bitnami/postgresql:12.14.0-debian-11-r28'
+
+@description('Asset Scan Delete Policy')
+@allowed([
+  'Always'
+  'OnSuccess'
+  'Never'
+])
+param assetScanDeletePolicy string = 'Always'
+
+@description('Database to Use')
+@allowed([
+  'Postgresql'
+  'External Postgresql'
+  'SQLite'
+])
+param databaseToUse string = 'Postgresql'
+
+@description('Password to configure Postgresql with on first install. Required if Postgres is selected as the Database To Use. Do not change this on stack update.')
+@secure()
+param postgresDBPassword string = ''
+
+@description('Hostname or IP address of the External DB to connect to. Required if an external database type is selected as the Database To Use.')
+param externalDBHost string = ''
+
+@description('Network Port of the External DB to connect to. Required if an external database type is selected as the Database To Use.')
+@minValue(0)
+param externalDBPort int = 0
+
+@description('Name of the Database to use on the External DB. Required if an external database type is selected as the Database To Use.')
+param externalDBName string = ''
+
+@description('Username to use to connect to the External DB. Required if an external database type is selected as the Database To Use.')
+param externalDBUsername string = ''
+
+@description('Password to use to connect to the External DB. Required if an external database type is selected as the Database To Use.')
+@secure()
+param externalDBPassword string = ''
+
+var imageReference = {
+    publisher: 'Canonical'
+    offer: '0001-com-ubuntu-server-focal'
+    sku: '20_04-lts-gen2'
+    version: 'latest'
+}
+
+var vmClarityNetName = 'vmclarity-server-net'
+var addressPrefix = '10.1.0.0/16'
+
+var vmClarityServerSubnetName = 'vmclarity-server-subnet'
+var vmClarityServerSecurityGroupName = 'vmclarity-server-security-group'
+var vmClarityServerSubnetAddressPrefix = '10.1.0.0/24'
+
+var vmClarityScannerSubnetName = 'vmclarity-scanner-subnet'
+var vmClarityScannerSecurityGroupName = 'vmclarity-scanner-security-group'
+var vmClarityScannerSubnetAddressPrefix = '10.1.1.0/24'
+
+var vmclarityServerVMName = 'vmclarity-server'
+var publicIPAddressName = '${vmclarityServerVMName}-public-ip'
+var networkInterfaceName = '${vmclarityServerVMName}-net-int'
+
+var params = {
+  BackendContainerImage: backendContainerImage
+  ScannerContainerImage: scannerContainerImage
+  TrivyServerContainerImage: trivyServerContainerImage
+  GrypeServerContainerImage: grypeServerContainerImage
+  ExploitDBServerContainerImage: exploitDBContainerImage
+  FreshclamMirrorContainerImage: freshclamMirrorContainerImage
+  PostgresqlContainerImage: postgresContainerImage
+  ScannerInstanceType: scannerVmSize
+  AssetScanDeletePolicy: assetScanDeletePolicy
+  DatabaseToUse: databaseToUse
+  PostgresDBPassword: postgresDBPassword
+  ExternalDBHost: externalDBHost
+  ExternalDBPort: string(externalDBPort)
+  ExternalDBName: externalDBName
+  ExternalDBUsername: externalDBUsername
+  ExternalDBPassword: externalDBPassword
+  AZURE_SUBSCRIPTION_ID: subscription().subscriptionId
+  AZURE_SCANNER_LOCATION: location
+  AZURE_SCANNER_RESOURCE_GROUP: resourceGroup().name
+  AZURE_SCANNER_SUBNET_ID: vmClarityNet::vmClarityScannerSubnet.id
+  AZURE_SCANNER_PUBLIC_KEY: base64(adminSSHKey)
+  AZURE_SCANNER_VM_SIZE: scannerVmSize
+  AZURE_SCANNER_IMAGE_PUBLISHER: imageReference.publisher
+  AZURE_SCANNER_IMAGE_OFFER: imageReference.offer
+  AZURE_SCANNER_IMAGE_SKU: imageReference.sku
+  AZURE_SCANNER_IMAGE_VERSION: imageReference.version
+  AZURE_SCANNER_SECURITY_GROUP: vmClarityScannerSecurityGroup.id
+  AZURE_SCANNER_STORAGE_ACCOUNT_NAME: storageAccountName
+  AZURE_SCANNER_STORAGE_CONTAINER_NAME: snapshotContainerName
+}
+
+var scriptTemplate = loadTextContent('vmclarity-install.sh')
+
+var renderedScript = reduce(
+  items(params),
+  {value: scriptTemplate},
+  (curr, next) => {value: replace(curr.value, '__${next.key}__', next.value)}
+).value
+
+var osDiskType = 'StandardSSD_LRS'
+var linuxConfiguration = {
+  disablePasswordAuthentication: true
+  ssh: {
+    publicKeys: [
+      {
+        path: '/home/${adminUsername}/.ssh/authorized_keys'
+        keyData: adminSSHKey
+      }
+    ]
+  }
+}
+var securityProfileJson = {
+  uefiSettings: {
+    secureBootEnabled: true
+    vTpmEnabled: true
+  }
+  securityType: securityType
+}
+
+var vmClarityGuestAttestationName = 'VmClarityServerGuestAttestation'
+var extensionName = 'GuestAttestation'
+var extensionPublisher = 'Microsoft.Azure.Security.LinuxAttestation'
+var extensionVersion = '1.0'
+var maaTenantName = 'GuestAttestation'
+var maaEndpoint = substring('emptystring', 0, 0)
+
+var vmClarityServerCustomScriptName = 'VmClarityServerCustomScript'
+
+resource networkInterface 'Microsoft.Network/networkInterfaces@2021-05-01' = {
+  name: networkInterfaceName
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          subnet: {
+            id: vmClarityNet::vmClarityServerSubnet.id
+          }
+          privateIPAllocationMethod: 'Dynamic'
+          publicIPAddress: {
+            id: publicIPAddress.id
+          }
+        }
+      }
+    ]
+    networkSecurityGroup: {
+      id: vmClarityServerSecurityGroup.id
+    }
+  }
+}
+
+resource vmClarityServerSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
+  name: vmClarityServerSecurityGroupName
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'SSH'
+        properties: {
+          priority: 1000
+          protocol: 'Tcp'
+          access: 'Allow'
+          direction: 'Inbound'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
+        }
+      }
+    ]
+  }
+}
+
+// Declare subnets inside of virtualNet so that they don't get deleted when
+// re-applying the template
+// https://github.com/Azure/bicep/issues/4653
+resource vmClarityNet 'Microsoft.Network/virtualNetworks@2021-05-01' = {
+  name: vmClarityNetName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        addressPrefix
+      ]
+    }
+    subnets:[
+      {
+        name: vmClarityServerSubnetName
+        properties: {
+          addressPrefix: vmClarityServerSubnetAddressPrefix
+          serviceEndpoints: [
+            {
+              service: 'Microsoft.Storage'
+            }
+          ]
+          privateEndpointNetworkPolicies: 'Enabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+      {
+        name: vmClarityScannerSubnetName
+        properties: {
+          addressPrefix: vmClarityScannerSubnetAddressPrefix
+          privateEndpointNetworkPolicies: 'Enabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+    ]
+  }
+
+  resource vmClarityServerSubnet 'subnets' existing = {
+    name: vmClarityServerSubnetName
+  }
+
+  resource vmClarityScannerSubnet 'subnets' existing = {
+    name: vmClarityScannerSubnetName
+  }
+}
+
+resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2021-05-01' = {
+  name: publicIPAddressName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Dynamic'
+    publicIPAddressVersion: 'IPv4'
+    dnsSettings: {
+      domainNameLabel: dnsLabelPrefix
+    }
+    idleTimeoutInMinutes: 4
+  }
+}
+
+resource vmClarityServer 'Microsoft.Compute/virtualMachines@2021-11-01' = {
+  name: vmclarityServerVMName
+  location: location
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities:{
+      '${vmClarityIdentityID}': {}
+    }
+  }
+  properties: {
+    hardwareProfile: {
+      vmSize: serverVmSize
+    }
+    storageProfile: {
+      osDisk: {
+        createOption: 'FromImage'
+        managedDisk: {
+          storageAccountType: osDiskType
+        }
+      }
+      imageReference: imageReference
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: networkInterface.id
+        }
+      ]
+    }
+    osProfile: {
+      computerName: vmclarityServerVMName
+      adminUsername: adminUsername
+      linuxConfiguration: linuxConfiguration
+    }
+    securityProfile: ((securityType == 'TrustedLaunch') ? securityProfileJson : null)
+  }
+}
+
+resource vmclarityServerGuestAttestation 'Microsoft.Compute/virtualMachines/extensions@2022-03-01' = if ((securityType == 'TrustedLaunch') && ((securityProfileJson.uefiSettings.secureBootEnabled == true) && (securityProfileJson.uefiSettings.vTpmEnabled == true))) {
+  parent: vmClarityServer
+  name: vmClarityGuestAttestationName
+  location: location
+  properties: {
+    publisher: extensionPublisher
+    type: extensionName
+    typeHandlerVersion: extensionVersion
+    autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
+    settings: {
+      AttestationConfig: {
+        MaaSettings: {
+          maaEndpoint: maaEndpoint
+          maaTenantName: maaTenantName
+        }
+      }
+    }
+  }
+}
+
+resource vmclarityServerCustomScript 'Microsoft.Compute/virtualMachines/extensions@2023-03-01' = {
+  parent: vmClarityServer
+  dependsOn: [
+    vmclarityServerGuestAttestation
+  ]
+  name: vmClarityServerCustomScriptName
+  location: location
+  properties: {
+    publisher: 'Microsoft.Azure.Extensions'
+    type: 'CustomScript'
+    typeHandlerVersion: '2.1'
+    autoUpgradeMinorVersion: true
+    protectedSettings: {
+      script: base64(renderedScript)
+    }
+  }
+}
+
+resource vmClarityScannerSecurityGroup 'Microsoft.Network/networkSecurityGroups@2021-05-01' = {
+  name: vmClarityScannerSecurityGroupName
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'SSH-From-VMClarity-Server'
+        properties: {
+          priority: 1000
+          protocol: 'Tcp'
+          access: 'Allow'
+          direction: 'Inbound'
+          sourceAddressPrefix: vmClarityServerSubnetAddressPrefix
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
+        }
+      }
+    ]
+  }
+}
+
+var storageAccountName = toLower('store${uniqueString(resourceGroup().id)}')
+var storageAccountType = 'Standard_LRS'
+// var subnetRef = '${vmClarityNet.id}/subnets/${vmClarityServerSubnet.name}'
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2022-09-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: storageAccountType
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    networkAcls: {
+      bypass: 'AzureServices'
+      virtualNetworkRules: [
+        {
+          id: vmClarityNet::vmClarityServerSubnet.id
+          action: 'Allow'
+        }
+      ]
+      defaultAction: 'Deny'
+    }
+  }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2021-02-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+var snapshotContainerName = 'snapshots'
+
+resource snapshotContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2022-09-01' = {
+  parent: blobService
+  name: snapshotContainerName
+}
+
+@description('This is the built-in Blob Contributor role. See https://learn.microsoft.com/en-gb/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor')
+resource blobContributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+}
+
+resource blocContributorRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount
+  name: guid(storageAccount.id, vmClarityIdentityID, blobContributorRoleDefinition.id)
+  properties: {
+    roleDefinitionId: blobContributorRoleDefinition.id
+    principalId: principalID
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output adminUsername string = adminUsername
+output hostname string = publicIPAddress.properties.dnsSettings.fqdn
+output sshCommand string = 'ssh ${adminUsername}@${publicIPAddress.properties.dnsSettings.fqdn}'

--- a/installation/azure/vmclarityDiscoverRole.bicep
+++ b/installation/azure/vmclarityDiscoverRole.bicep
@@ -1,0 +1,46 @@
+targetScope = 'subscription'
+
+@description('VMClarity Resource Group Name')
+param resourceGroupName string
+
+@description('VMClarity Managed Identity Principal ID')
+param principalID string
+
+var discoverRoleName = guid(subscription().id, resourceGroupName, 'vmclarity-discoverer-snapshotter')
+var discoverRoleDescription = 'IAM Role to allow VMClarity to discover and snapshot virtual machines.'
+
+resource vmClarityDiscoverRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: discoverRoleName
+  properties: {
+    roleName: discoverRoleName
+    description: discoverRoleDescription
+    type: 'customRole'
+    assignableScopes: [
+      subscription().id
+    ]
+    permissions: [
+      {
+        actions: [
+          'Microsoft.Resources/subscriptions/resourceGroups/read'
+          'Microsoft.Resources/subscriptions/resourceGroups/moveResources/action'
+          'Microsoft.Resources/subscriptions/resourceGroups/validateMoveResources/action'
+          'Microsoft.Compute/virtualMachines/read'
+          'Microsoft.Compute/disks/read'
+          'Microsoft.Compute/snapshots/read'
+          'Microsoft.Compute/snapshots/write'
+          'Microsoft.Compute/snapshots/delete'
+          'Microsoft.Compute/disks/beginGetAccess/action'
+        ]
+      }
+    ]
+  }
+}
+
+resource discoverRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(subscription().id, resourceGroupName, 'vmclarity-server', discoverRoleName)
+  properties: {
+    roleDefinitionId: vmClarityDiscoverRole.id
+    principalId: principalID
+    principalType: 'ServicePrincipal'
+  }
+}

--- a/installation/azure/vmclarityManagedIdentity.bicep
+++ b/installation/azure/vmclarityManagedIdentity.bicep
@@ -1,0 +1,13 @@
+targetScope = 'resourceGroup'
+
+@description('Location where to create the resources')
+param location string = resourceGroup().location
+
+var vmClarityIdentityName = 'vmclarity-discoverer-deployer-${uniqueString(resourceGroup().id)}'
+
+resource vmClarityServerIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: vmClarityIdentityName
+  location: location
+}
+output vmClarityIdentityId string = vmClarityServerIdentity.id
+output vmClarityIdentityPrincipalId string = vmClarityServerIdentity.properties.principalId

--- a/installation/azure/vmclarityScanRole.bicep
+++ b/installation/azure/vmclarityScanRole.bicep
@@ -1,0 +1,52 @@
+targetScope = 'resourceGroup'
+
+@description('VMClarity Managed Identity Principal ID')
+param principalID string
+
+var scanRoleName = guid(resourceGroup().id, 'vmclarity-scanner')
+var scanRoleDescription = 'IAM Role to allow VMClarity to deploy virtual machines that mount and scan snapshots.'
+
+resource vmClarityScanRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
+  name: scanRoleName
+  properties: {
+    roleName: scanRoleName
+    description: scanRoleDescription
+    type: 'customRole'
+    assignableScopes: [
+      resourceGroup().id
+    ]
+    permissions: [
+      {
+        actions: [
+          'Microsoft.Compute/virtualMachines/read'
+          'Microsoft.Compute/virtualMachines/write'
+          'Microsoft.Compute/virtualMachines/delete'
+          'Microsoft.Compute/snapshots/read'
+          'Microsoft.Compute/snapshots/write'
+          'Microsoft.Compute/snapshots/delete'
+          'Microsoft.Compute/disks/read'
+          'Microsoft.Compute/disks/write'
+          'Microsoft.Compute/disks/delete'
+          'Microsoft.Network/networkInterfaces/write'
+          'Microsoft.Network/networkInterfaces/read'
+          'Microsoft.Network/networkInterfaces/delete'
+          'Microsoft.Network/networkSecurityGroups/join/action'
+          'Microsoft.Network/virtualNetworks/subnets/join/action'
+          'Microsoft.Network/networkInterfaces/join/action'
+          'Microsoft.Compute/snapshots/beginGetAccess/action'
+          'Microsoft.Compute/snapshots/endGetAccess/action'
+          'Microsoft.Storage/storageAccounts/listkeys/action'
+        ]
+      }
+    ]
+  }
+}
+
+resource scanRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, 'vmclarity-server', vmClarityScanRole.id)
+  properties: {
+    roleDefinitionId: vmClarityScanRole.id
+    principalId: principalID
+    principalType: 'ServicePrincipal'
+  }
+}


### PR DESCRIPTION
## Description

Introduces an installer for VMClarity on Azure using Bicep / Azure Resource Manager. VMClarity will be installed into a new Resource Group with the control plane services running in a single VM. A dedicated VMClarity vNet will be created with 2 subnets, one for the control plane services which allows external access to the VMClarity server, and one for the Scanners which is only allows ingress from the control plane network so that it can be used as a bastion.

Two roles are added:
- One for discovery and snapshotting within a subscription.
- One for creating resources within the VMClarity resource group for scanning (VM, Disks, Network Interfaces)

To install on Azure you can either:
- use the az CLI to directly deploy the bicep (vmclarity.bicep)
- manually upload the ARM template (vmclarity.json) to the portal as a template spec
- Click the "Deploy to Azure" button in the README to deploy the ARM template with the custom UI wizard (this is the recommended method)

## Type of Change

[ ] Bug Fix  
[X] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
