### PR TITLE
feat: add creation of vmclarity cli docker image on arm64 architecture

### DIFF
--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -114,6 +114,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/openclarity/vmclarity-cli:${{ inputs.image_tag }}
           file: Dockerfile.cli
           push: ${{ inputs.push }}
@@ -121,8 +122,6 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           build-args: |
-            VERSION=${{ inputs.image_tag }}
-            BUILD_TIMESTAMP=${{ needs.timestamp.outputs.timestamp }}
             COMMIT_HASH=${{ github.sha }}
 
       - name: Upload artifact

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.2
-ARG VMCLARITY_TOOLS_BASE=ghcr.io/openclarity/vmclarity-tools-base@sha256:e18d4fdc0d5585c28439eb766828090a6c55aeca4fb4d507f348393f5b7922da # v0.1.0
-FROM golang:1.20.4-alpine AS builder
+ARG VMCLARITY_TOOLS_BASE=ghcr.io/openclarity/vmclarity-tools-base:v0.2.0
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.20.4-alpine AS builder
 
 RUN apk add --update --no-cache ca-certificates git
 RUN apk add build-base
@@ -12,13 +12,20 @@ COPY . /build
 WORKDIR /build/cli
 
 ARG COMMIT_HASH
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -ldflags="-s -w \
-     -X 'github.com/openclarity/vmclarity/cli/pkg.GitRevision=${COMMIT_HASH}'" -o cli ./main.go
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
+    go build \
+    -ldflags="-s -w -X 'github.com/openclarity/vmclarity/cli/pkg.GitRevision=${COMMIT_HASH}'" \
+    -o cli \
+    ./main.go
 
-FROM ${VMCLARITY_TOOLS_BASE}
+FROM --platform=${TARGETPLATFORM:-linux/amd64} ${VMCLARITY_TOOLS_BASE}
 
 RUN apk upgrade
 RUN apk add util-linux

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ cli: ## Build CLI
 docker: docker-backend docker-cli ## Build All Docker images
 
 .PHONY: push-docker
-push-docker: push-docker-backend push-docker-cli ## Build and Push All Docker images
+push-docker: push-docker-backend build-and-push-docker-cli ## Build and Push All Docker images
 
 ifneq ($(strip $(VMCLARITY_TOOLS_BASE)),)
 VMCLARITY_TOOLS_CLI_DOCKER_ARG=--build-arg VMCLARITY_TOOLS_BASE=${VMCLARITY_TOOLS_BASE}
@@ -56,15 +56,24 @@ endif
 .PHONY: docker-cli
 docker-cli: ## Build CLI Docker image
 	@(echo "Building cli docker image ..." )
-	docker build --file ./Dockerfile.cli --build-arg VERSION=${VERSION} \
-		--build-arg BUILD_TIMESTAMP=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
-		--build-arg COMMIT_HASH=$(shell git rev-parse HEAD) ${VMCLARITY_TOOLS_CLI_DOCKER_ARG} \
-		-t ${DOCKER_IMAGE}-cli:${DOCKER_TAG} .
+	docker build \
+		--file ./Dockerfile.cli \
+		--build-arg COMMIT_HASH=$(shell git rev-parse HEAD) \
+		${VMCLARITY_TOOLS_CLI_DOCKER_ARG} \
+		-t ${DOCKER_IMAGE}-cli:${DOCKER_TAG} \
+		.
 
-.PHONY: push-docker-cli
-push-docker-cli: docker-cli ## Build and Push CLI Docker image
+.PHONY: build-and-push-docker-cli
+build-and-push-docker-cli: ## Build and Push CLI Docker image
 	@echo "Publishing cli docker image ..."
-	docker push ${DOCKER_IMAGE}-cli:${DOCKER_TAG}
+	docker buildx build \
+		--push \
+		--platform linux/amd64,linux/arm64 \
+		--file ./Dockerfile.cli \
+		--build-arg COMMIT_HASH=$(shell git rev-parse HEAD) \
+		${VMCLARITY_TOOLS_CLI_DOCKER_ARG} \
+		-t ${DOCKER_IMAGE}-cli:${DOCKER_TAG} \
+		.
 
 .PHONY: docker-backend
 docker-backend: ## Build Backend Docker image


### PR DESCRIPTION
## Description

In this PR I added multi-arch build to the Dockerfile.cli.
With this PR merged in, we will be able to run the scanner on amd64 and arm64 architectures.

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
