### PR TITLE
Ensure we cast to JSON while build JSON objects

### DIFF
--- a/backend/pkg/database/odatasql/jsonsql/postgres.go
+++ b/backend/pkg/database/odatasql/jsonsql/postgres.go
@@ -65,3 +65,11 @@ func (postgres) JSONExtractText(source, path string) string {
 	path = convertJSONPathToPostgresPath(path)
 	return fmt.Sprintf("%s#>>'%s'", source, path)
 }
+
+func (postgres) JSONQuote(value string) string {
+	return fmt.Sprintf("TO_JSONB(%s::text)", value)
+}
+
+func (postgres) JSONCast(value string) string {
+	return fmt.Sprintf("TO_JSONB(%s)", value)
+}

--- a/backend/pkg/database/odatasql/jsonsql/sqlite.go
+++ b/backend/pkg/database/odatasql/jsonsql/sqlite.go
@@ -51,3 +51,11 @@ func (sqlite) JSONExtract(source, path string) string {
 func (sqlite) JSONExtractText(source, path string) string {
 	return fmt.Sprintf("%s->>'%s'", source, path)
 }
+
+func (sqlite) JSONQuote(value string) string {
+	return fmt.Sprintf("JSON_QUOTE(%s)", value)
+}
+
+func (sqlite) JSONCast(value string) string {
+	return fmt.Sprintf("JSON(%s)", value)
+}

--- a/backend/pkg/database/odatasql/jsonsql/variant.go
+++ b/backend/pkg/database/odatasql/jsonsql/variant.go
@@ -23,4 +23,6 @@ type Variant interface {
 	JSONArray(items []string) string
 	JSONExtract(source string, path string) string
 	JSONExtractText(source string, path string) string
+	JSONQuote(value string) string
+	JSONCast(value string) string
 }

--- a/backend/pkg/database/odatasql/query.go
+++ b/backend/pkg/database/odatasql/query.go
@@ -237,7 +237,7 @@ func buildSelectFieldsForRelationshipCollectionFieldType(sqlVariant jsonsql.Vari
 		sel := st.children[key]
 
 		extract := buildSelectFields(sqlVariant, schemaMetas, fm, fmt.Sprintf("%s%s", identifier, key), newSource, fmt.Sprintf("$.%s", key), sel)
-		part := fmt.Sprintf("'%s', %s", key, extract)
+		part := fmt.Sprintf("'%s', %s", key, sqlVariant.JSONCast(extract))
 		parts = append(parts, part)
 	}
 	subQuery := sqlVariant.JSONObject(parts)
@@ -269,7 +269,7 @@ func buildSelectFieldsForRelationshipFieldType(sqlVariant jsonsql.Variant, schem
 		sel := st.children[key]
 
 		extract := buildSelectFields(sqlVariant, schemaMetas, fm, fmt.Sprintf("%s%s", identifier, key), newsource, fmt.Sprintf("$.%s", key), sel)
-		part := fmt.Sprintf("'%s', %s", key, extract)
+		part := fmt.Sprintf("'%s', %s", key, sqlVariant.JSONCast(extract))
 		parts = append(parts, part)
 	}
 	object := sqlVariant.JSONObject(parts)
@@ -328,7 +328,7 @@ func buildSelectFieldsForComplexFieldType(sqlVariant jsonsql.Variant, schemaMeta
 			}
 
 			extract := buildSelectFields(sqlVariant, schemaMetas, fm, fmt.Sprintf("%s%s", identifier, key), source, fmt.Sprintf("%s.%s", path, key), sel)
-			part := fmt.Sprintf("'%s', %s", key, extract)
+			part := fmt.Sprintf("'%s', %s", key, sqlVariant.JSONCast(extract))
 			parts = append(parts, part)
 		}
 		objects = append(objects, sqlVariant.JSONObject(parts))
@@ -523,7 +523,10 @@ func buildWhereFromFilter(sqlVariant jsonsql.Variant, schemaMetas map[string]Sch
 		var value string
 		switch rhs.Token.Type { // TODO: implement all the relevant cases as ExpressionTokenDate and ExpressionTokenDateTime
 		case godata.ExpressionTokenString:
-			value = singleQuote(strings.ReplaceAll(rhs.Token.Value, "'", "\""))
+			// rhs.Token.Value is already enforced to be single
+			// quoted by the odata validation so we can pass it
+			// straight in to json quote.
+			value = sqlVariant.JSONQuote(rhs.Token.Value)
 		case godata.ExpressionTokenBoolean:
 			value = singleQuote(rhs.Token.Value)
 		case godata.ExpressionTokenInteger, godata.ExpressionTokenFloat:


### PR DESCRIPTION
## Description

This commit ensures that while building the json objects for select and expand, we cast the extracted data to json to avoid issues where the DB gets confused between JSON encoded strings and JSON data.

Without this change we sometimes get unexpected escaped quotes in the returned data as the DB thinks its been given a string, but its actually a json encoded string.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
