### PR TITLE
refactor: use Google UUID library

### DIFF
--- a/backend/pkg/database/gorm/database.go
+++ b/backend/pkg/database/gorm/database.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -51,7 +51,7 @@ type Base struct {
 
 // BeforeCreate will set a UUID rather than numeric ID.
 func (base *Base) BeforeCreate(db *gorm.DB) error {
-	base.ID = uuid.NewV4()
+	base.ID = uuid.New()
 	return nil
 }
 

--- a/cli/pkg/cli/cli.go
+++ b/cli/pkg/cli/cli.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
+	"github.com/google/uuid"
 
 	"github.com/openclarity/vmclarity/cli/pkg/mount"
 	"github.com/openclarity/vmclarity/cli/pkg/presenter"
@@ -66,7 +66,7 @@ func (c *CLI) MountVolumes(ctx context.Context) ([]string, error) {
 		// if the device is not mounted and of a supported filesystem type,
 		// we assume it belongs to the attached volume, so we mount it.
 		if device.MountPoint == "" && isSupportedFS(device.FilesystemType) {
-			mountDir := "/mnt/snapshot" + uuid.NewV4().String()
+			mountDir := "/mnt/snapshot" + uuid.New().String()
 
 			if err := device.Mount(mountDir); err != nil {
 				return nil, fmt.Errorf("failed to mount device: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/openclarity/kubeclarity/shared v0.0.0
 	github.com/openclarity/vmclarity/api v0.0.0
 	github.com/parnurzeal/gorequest v0.2.16
-	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/viper v1.16.0
@@ -345,6 +344,7 @@ require (
 	github.com/samber/lo v1.37.0 // indirect
 	github.com/saracen/walker v0.1.3 // indirect
 	github.com/sassoftware/go-rpmutils v0.2.0 // indirect
+	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.6.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect


### PR DESCRIPTION
## Description

Use only the `github.com/google/uuid` instead of mixing the use of the `github.com/google/uuid` and `github.com/satori/go.uuid` libraries for generating and handling UUIDs.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
