### PR TITLE
fix: query for ScanResults to be reconciled

### DIFF
--- a/runtime_scan/pkg/orchestrator/scanresultwatcher/watcher.go
+++ b/runtime_scan/pkg/orchestrator/scanresultwatcher/watcher.go
@@ -80,7 +80,7 @@ func (w *Watcher) GetScanResults(ctx context.Context) ([]ScanResultReconcileEven
 	logger := log.GetLoggerFromContextOrDiscard(ctx)
 	logger.Debugf("Fetching ScanResults which need to be reconciled")
 
-	filter := fmt.Sprintf("status/general/state ne '%s' or status/general/state ne '%s' or resourceCleanup eq '%s'",
+	filter := fmt.Sprintf("(status/general/state ne '%s' and status/general/state ne '%s') or resourceCleanup eq '%s'",
 		models.TargetScanStateStateDone, models.TargetScanStateStateNotScanned, models.ResourceCleanupStatePending)
 	selector := "id,scan/id,target/id"
 	params := models.GetScanResultsParams{


### PR DESCRIPTION
## Description

Fix API query used for fetching `ScanResult`(s) which need to be reconciled by `ScanResultWatcher` controller.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
