### PR TITLE
refactor: provider configuration

### DIFF
--- a/backend/pkg/backend/backend.go
+++ b/backend/pkg/backend/backend.go
@@ -31,7 +31,6 @@ import (
 	databaseTypes "github.com/openclarity/vmclarity/backend/pkg/database/types"
 	"github.com/openclarity/vmclarity/backend/pkg/rest"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator"
-	"github.com/openclarity/vmclarity/runtime_scan/pkg/provider/aws"
 	"github.com/openclarity/vmclarity/shared/pkg/backendclient"
 	"github.com/openclarity/vmclarity/shared/pkg/log"
 	uibackend "github.com/openclarity/vmclarity/ui_backend/pkg/rest"
@@ -129,15 +128,15 @@ func Run(ctx context.Context) {
 func startOrchestrator(ctx context.Context, config *_config.Config, client *backendclient.BackendClient) error {
 	orchestratorConfig, err := orchestrator.LoadConfig(config.BackendRestHost, config.BackendRestPort, rest.BaseURL)
 	if err != nil {
-		return fmt.Errorf("failed to load runtime scan orchestrator config: %w", err)
+		return fmt.Errorf("failed to load Orchestrator config: %w", err)
 	}
 
-	p, err := aws.New(ctx, orchestratorConfig.AWSConfig)
+	o, err := orchestrator.New(ctx, orchestratorConfig, client)
 	if err != nil {
-		return fmt.Errorf("failed to create provider client: %w", err)
+		return fmt.Errorf("failed to initialize Orchestrator: %w", err)
 	}
 
-	orchestrator.New(orchestratorConfig, p, client).Start(ctx)
+	o.Start(ctx)
 
 	return nil
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,46 @@
+# Configuration
+
+## Orchestrator
+
+| Environment Variable                      | Required  | Default | Description                                  |
+|-------------------------------------------|-----------|---------|----------------------------------------------|
+| `DELETE_JOB_POLICY`                       |           |         |                                              |
+| `SCANNER_CONTAINER_IMAGE`                 |           |         |                                              |
+| `GITLEAKS_BINARY_PATH`                    |           |         |                                              |
+| `CLAM_BINARY_PATHCLAM_BINARY_PATH`        |           |         |                                              |
+| `FRESHCLAM_BINARY_PATH`                   |           |         |                                              |
+| `ALTERNATIVE_FRESHCLAM_MIRROR_URL`        |           |         |                                              |
+| `LYNIS_INSTALL_PATH`                      |           |         |                                              |
+| `SCANNER_VMCLARITY_BACKEND_ADDRESS`       |           |         |                                              |
+| `EXPLOIT_DB_ADDRESS`                      |           |         |                                              |
+| `TRIVY_SERVER_ADDRESS`                    |           |         |                                              |
+| `TRIVY_SERVER_TIMEOUT`                    |           |         |                                              |
+| `GRYPE_SERVER_ADDRESS`                    |           |         |                                              |
+| `GRYPE_SERVER_TIMEOUT`                    |           |         |                                              |
+| `CHKROOTKIT_BINARY_PATH`                  |           |         |                                              |
+| `SCAN_CONFIG_POLLING_INTERVAL`            |           |         |                                              |
+| `SCAN_CONFIG_RECONCILE_TIMEOUT`           |           |         |                                              |
+| `SCAN_POLLING_INTERVAL`                   |           |         |                                              |
+| `SCAN_RECONCILE_TIMEOUT`                  |           |         |                                              |
+| `SCAN_TIMEOUT`                            |           |         |                                              |
+| `SCAN_RESULT_POLLING_INTERVAL`            |           |         |                                              |
+| `SCAN_RESULT_RECONCILE_TIMEOUT`           |           |         |                                              |
+| `SCAN_RESULT_PROCESSOR_POLLING_INTERVAL`  |           |         |                                              |
+| `SCAN_RESULT_PROCESSOR_RECONCILE_TIMEOUT` |           |         |                                              |
+| `DISCOVERY_INTERVAL`                      |           |         |                                              |
+| `CONTROLLER_STARTUP_DELAY`                |           |         |                                              |
+| `PROVIDER`                                | **yes**   | `aws`   | Provider used for Target discovery and scans |
+
+## Provider
+
+### AWS
+
+| Environment Variable                   | Required | Default      | Description                                                                   |
+|----------------------------------------|----------|--------------|-------------------------------------------------------------------------------|
+| `VMCLARITY_AWS_REGION`                 | **yes**  |              | Region where the Scanner instance needs to be created                         |
+| `VMCLARITY_AWS_SUBNET_ID`              | **yes**  |              | SubnetID where the Scanner instance needs to be created                       |
+| `VMCLARITY_AWS_SECURITY_GROUP_ID`      | **yes**  |              | SecurityGroupId which needs to be attached to the Scanner instance            |
+| `VMCLARITY_AWS_KEYPAIR_NAME`           |          |              | Name of the SSH KeyPair to use for Scanner instance launch                    |
+| `VMCLARITY_AWS_SCANNER_AMI_ID`         | **yes**  |              | The AMI image used for creating Scanner instance                              |
+| `VMCLARITY_AWS_SCANNER_INSTANCE_TYPE`  |          | `t2.large`   | The instance type used for Scanner instance                                   |
+| `VMCLARITY_AWS_BLOCK_DEVICE_NAME`      |          | `xvdh`       | Block device name used for attaching Scanner volume to the Scanner instance   |

--- a/installation/aws/VmClarity.cfn
+++ b/installation/aws/VmClarity.cfn
@@ -229,21 +229,46 @@ Resources:
               content:
                 Fn::Sub:
                   - |
-                    AWS_REGION=${AWS::Region}
-                    SCANNER_AWS_REGION=${AWS::Region}
-                    AWS_SUBNET_ID=${VmClarityScannerSubnet}
-                    AWS_SECURITY_GROUP_ID=${VmClarityScannerSecurityGroup}
-                    AWS_INSTANCE_TYPE=${ScannerInstanceType}
-                    SCANNER_KEY_PAIR_NAME=${KeyName}
-                    AWS_JOB_IMAGE_ID=${JobImageID}
+                    ##
+                    ## Orchestrator configuration
+                    ##
+                    # Host for the VMClarity backend server
                     BACKEND_REST_HOST=__BACKEND_REST_HOST__
+                    # Port number for the VMClarity backend server
                     BACKEND_REST_PORT=8888
+                    # Container image for Scanner instance
                     SCANNER_CONTAINER_IMAGE=${ScannerContainerImage}
+                    # Trivy server address
                     TRIVY_SERVER_ADDRESS=http://__BACKEND_REST_HOST__:9992
+                    # Grype server address
                     GRYPE_SERVER_ADDRESS=__BACKEND_REST_HOST__:9991
-                    DELETE_JOB_POLICY=${AssetScanDeletePolicy}
+                    # FreshClam mirror URL
                     ALTERNATIVE_FRESHCLAM_MIRROR_URL=http://__BACKEND_REST_HOST__:1000/clamav
-                  - JobImageID: !FindInMap
+                    # Resource cleanup policy
+                    DELETE_JOB_POLICY=${AssetScanDeletePolicy}
+                    # Provider to use
+                    PROVIDER=aws
+
+                    ##
+                    ## Provider configuration
+                    ##
+                    # The AWS region where the provider is deployed
+                    AWS_REGION=${AWS::Region}
+                    # Region where the Scanner instance needs to be created
+                    VMCLARITY_AWS_SCANNER_REGION=${AWS::Region}
+                    # SubnetID where the Scanner instance needs to be created
+                    VMCLARITY_AWS_SUBNET_ID=${VmClarityScannerSubnet}
+                    # SecurityGroupId which needs to be attached to the Scanner instance
+                    VMCLARITY_AWS_SECURITY_GROUP_ID=${VmClarityScannerSecurityGroup}
+                    # Name of the SSH KeyPair to use for Scanner instance launch
+                    VMCLARITY_AWS_KEYPAIR_NAME=${KeyName}
+                    # The AMI image used for creating Scanner instance
+                    VMCLARITY_AWS_SCANNER_AMI_ID=${ScannerImageID}
+                    # The instance type used for Scanner instance
+                    VMCLARITY_AWS_SCANNER_INSTANCE_TYPE=${ScannerInstanceType}
+                    # Block device name used for attaching Scanner volume to the Scanner instance
+                    #VMCLARITY_AWS_BLOCK_DEVICE_NAME=xvhd
+                  - ScannerImageID: !FindInMap
                       - AWSRegionArch2AMI
                       - !Ref "AWS::Region"
                       - !FindInMap

--- a/runtime_scan/pkg/orchestrator/config.go
+++ b/runtime_scan/pkg/orchestrator/config.go
@@ -19,31 +19,28 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/viper"
 
+	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/discovery"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/scanconfigwatcher"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/scanresultprocessor"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/scanresultwatcher"
 	"github.com/openclarity/vmclarity/runtime_scan/pkg/orchestrator/scanwatcher"
-	"github.com/openclarity/vmclarity/runtime_scan/pkg/provider/aws"
 )
 
 const (
-	ScannerAWSRegion              = "SCANNER_AWS_REGION"
 	DeleteJobPolicy               = "DELETE_JOB_POLICY"
 	ScannerContainerImage         = "SCANNER_CONTAINER_IMAGE"
-	ScannerKeyPairName            = "SCANNER_KEY_PAIR_NAME"
 	GitleaksBinaryPath            = "GITLEAKS_BINARY_PATH"
 	ClamBinaryPath                = "CLAM_BINARY_PATH"
 	FreshclamBinaryPath           = "FRESHCLAM_BINARY_PATH"
 	AlternativeFreshclamMirrorURL = "ALTERNATIVE_FRESHCLAM_MIRROR_URL"
 	LynisInstallPath              = "LYNIS_INSTALL_PATH"
-	AttachedVolumeDeviceName      = "ATTACHED_VOLUME_DEVICE_NAME"
 	ScannerBackendAddress         = "SCANNER_VMCLARITY_BACKEND_ADDRESS"
-	ScanConfigWatchInterval       = "SCAN_CONFIG_WATCH_INTERVAL"
 	ExploitDBAddress              = "EXPLOIT_DB_ADDRESS"
 	TrivyServerAddress            = "TRIVY_SERVER_ADDRESS"
 	TrivyServerTimeout            = "TRIVY_SERVER_TIMEOUT"
@@ -67,20 +64,21 @@ const (
 	DiscoveryInterval = "DISCOVERY_INTERVAL"
 
 	ControllerStartupDelay = "CONTROLLER_STARTUP_DELAY"
+
+	ProviderKind = "PROVIDER"
 )
 
 const (
-	DefaultScannerAWSRegion         = "us-east-1"
-	DefaultAttachedVolumeDeviceName = "xvdh"
-
 	DefaultTrivyServerTimeout = 5 * time.Minute
 	DefaultGrypeServerTimeout = 2 * time.Minute
 
 	DefaultControllerStartupDelay = 15 * time.Second
+	DefaultProviderKind           = "aws"
 )
 
 type Config struct {
-	AWSConfig             *aws.Config
+	ProviderKind models.CloudProvider
+
 	ScannerBackendAddress string
 
 	// The Orchestrator starts the Controller(s) in a sequence and the ControllerStartupDelay is used for waiting
@@ -96,8 +94,6 @@ type Config struct {
 }
 
 func setConfigDefaults(backendHost string, backendPort int, backendBaseURL string) {
-	viper.SetDefault(ScannerAWSRegion, DefaultScannerAWSRegion)
-	viper.SetDefault(ScanConfigWatchInterval, "30s")
 	viper.SetDefault(DeleteJobPolicy, string(scanresultwatcher.DeleteJobPolicyAlways))
 	viper.SetDefault(ScannerBackendAddress, fmt.Sprintf("http://%s%s", net.JoinHostPort(backendHost, strconv.Itoa(backendPort)), backendBaseURL))
 	// https://github.com/openclarity/vmclarity-tools-base/blob/main/Dockerfile#L33
@@ -107,7 +103,6 @@ func setConfigDefaults(backendHost string, backendPort int, backendBaseURL strin
 	// https://github.com/openclarity/vmclarity-tools-base/blob/main/Dockerfile
 	viper.SetDefault(ChkrootkitBinaryPath, "/artifacts/chkrootkit")
 	viper.SetDefault(ExploitDBAddress, fmt.Sprintf("http://%s", net.JoinHostPort(backendHost, "1326")))
-	viper.SetDefault(AttachedVolumeDeviceName, DefaultAttachedVolumeDeviceName)
 	viper.SetDefault(ClamBinaryPath, "clamscan")
 	viper.SetDefault(FreshclamBinaryPath, "freshclam")
 	viper.SetDefault(TrivyServerTimeout, DefaultTrivyServerTimeout)
@@ -123,6 +118,7 @@ func setConfigDefaults(backendHost string, backendPort int, backendBaseURL strin
 	viper.SetDefault(ScanResultProcessorReconcileTimeout, scanresultprocessor.DefaultReconcileTimeout.String())
 	viper.SetDefault(DiscoveryInterval, discovery.DefaultInterval.String())
 	viper.SetDefault(ControllerStartupDelay, DefaultControllerStartupDelay.String())
+	viper.SetDefault(ProviderKind, DefaultProviderKind)
 
 	viper.AutomaticEnv()
 }
@@ -130,11 +126,17 @@ func setConfigDefaults(backendHost string, backendPort int, backendBaseURL strin
 func LoadConfig(backendHost string, backendPort int, baseURL string) (*Config, error) {
 	setConfigDefaults(backendHost, backendPort, baseURL)
 
+	var providerKind models.CloudProvider
+	switch strings.ToLower(viper.GetString(ProviderKind)) {
+	case "aws":
+		fallthrough
+	default:
+		providerKind = models.AWS
+	}
+
 	c := &Config{
-		AWSConfig: aws.LoadConfig(),
-
+		ProviderKind:           providerKind,
 		ControllerStartupDelay: viper.GetDuration(ControllerStartupDelay),
-
 		DiscoveryConfig: discovery.Config{
 			DiscoveryInterval: viper.GetDuration(DiscoveryInterval),
 		},
@@ -152,14 +154,11 @@ func LoadConfig(backendHost string, backendPort int, baseURL string) (*Config, e
 			PollPeriod:       viper.GetDuration(ScanResultPollingInterval),
 			ReconcileTimeout: viper.GetDuration(ScanResultReconcileTimeout),
 			ScannerConfig: scanresultwatcher.ScannerConfig{
-				Region:                        viper.GetString(ScannerAWSRegion),
 				DeleteJobPolicy:               scanresultwatcher.GetDeleteJobPolicyType(viper.GetString(DeleteJobPolicy)),
 				ScannerImage:                  viper.GetString(ScannerContainerImage),
 				ScannerBackendAddress:         viper.GetString(ScannerBackendAddress),
-				ScannerKeyPairName:            viper.GetString(ScannerKeyPairName),
 				GitleaksBinaryPath:            viper.GetString(GitleaksBinaryPath),
 				LynisInstallPath:              viper.GetString(LynisInstallPath),
-				DeviceName:                    viper.GetString(AttachedVolumeDeviceName),
 				ExploitsDBAddress:             viper.GetString(ExploitDBAddress),
 				ClamBinaryPath:                viper.GetString(ClamBinaryPath),
 				FreshclamBinaryPath:           viper.GetString(FreshclamBinaryPath),

--- a/runtime_scan/pkg/orchestrator/config.go
+++ b/runtime_scan/pkg/orchestrator/config.go
@@ -73,7 +73,7 @@ const (
 	DefaultGrypeServerTimeout = 2 * time.Minute
 
 	DefaultControllerStartupDelay = 15 * time.Second
-	DefaultProviderKind           = "aws"
+	DefaultProviderKind           = models.AWS
 )
 
 type Config struct {
@@ -128,7 +128,7 @@ func LoadConfig(backendHost string, backendPort int, baseURL string) (*Config, e
 
 	var providerKind models.CloudProvider
 	switch strings.ToLower(viper.GetString(ProviderKind)) {
-	case "aws":
+	case strings.ToLower(string(models.AWS)):
 		fallthrough
 	default:
 		providerKind = models.AWS

--- a/runtime_scan/pkg/orchestrator/scanresultwatcher/config.go
+++ b/runtime_scan/pkg/orchestrator/scanresultwatcher/config.go
@@ -61,12 +61,6 @@ func (c Config) WithScannerConfig(s ScannerConfig) Config {
 }
 
 type ScannerConfig struct {
-	// We need to know where the VMClarity scanner is running so that we
-	// can boot the scanner jobs in the same region, there isn't a
-	// mechanism to discover this right now so its passed in as a config
-	// value.
-	Region string
-
 	// Address that the Scanner should use to talk to the VMClarity backend
 	// We use a configuration variable for this instead of discovering it
 	// automatically in case VMClarity backend has multiple IPs (internal
@@ -89,10 +83,6 @@ type ScannerConfig struct {
 	// tools.
 	ScannerImage string
 
-	// The key pair name that should be attached to the scanner VM instance.
-	// Mainly used for debugging.
-	ScannerKeyPairName string
-
 	// The gitleaks binary path in the scanner image container.
 	GitleaksBinaryPath string
 
@@ -110,7 +100,4 @@ type ScannerConfig struct {
 
 	// The chkrootkit binary path in the scanner image container.
 	ChkrootkitBinaryPath string
-
-	// the name of the block device to attach to the scanner job
-	DeviceName string
 }

--- a/runtime_scan/pkg/orchestrator/scanresultwatcher/helpers.go
+++ b/runtime_scan/pkg/orchestrator/scanresultwatcher/helpers.go
@@ -78,9 +78,6 @@ func newJobConfig(i *jobConfigInput) (*provider.ScanJobConfig, error) {
 		ScannerImage:     i.config.ScannerImage,
 		ScannerCLIConfig: string(scannerConfigYAML),
 		VMClarityAddress: i.config.ScannerBackendAddress,
-		KeyPairName:      i.config.ScannerKeyPairName,
-		ScannerRegion:    i.config.Region,
-		BlockDeviceName:  i.config.DeviceName,
 		ScanMetadata: provider.ScanMetadata{
 			ScanID:       i.scanResult.Scan.Id,
 			ScanResultID: *i.scanResult.Id,

--- a/runtime_scan/pkg/provider/aws/config.go
+++ b/runtime_scan/pkg/provider/aws/config.go
@@ -46,23 +46,23 @@ type Config struct {
 
 func (c *Config) Validate() error {
 	if c.ScannerRegion == "" {
-		return fmt.Errorf("parameter Region must not be nil")
+		return fmt.Errorf("parameter Region must be provided")
 	}
 
 	if c.SubnetID == "" {
-		return fmt.Errorf("parameter SubnetID must not be nil")
+		return fmt.Errorf("parameter SubnetID must be provided")
 	}
 
 	if c.SecurityGroupID == "" {
-		return fmt.Errorf("parameter SecurityGroupID must not be nil")
+		return fmt.Errorf("parameter SecurityGroupID must be provided")
 	}
 
 	if c.ScannerImage == "" {
-		return fmt.Errorf("parameter ScannerImage must not be nil")
+		return fmt.Errorf("parameter ScannerImage must be provided")
 	}
 
 	if c.ScannerInstanceType == "" {
-		return fmt.Errorf("parameter ScannerInstanceType must not be nil")
+		return fmt.Errorf("parameter ScannerInstanceType must be provided")
 	}
 
 	return nil

--- a/runtime_scan/pkg/provider/aws/config.go
+++ b/runtime_scan/pkg/provider/aws/config.go
@@ -22,33 +22,26 @@ import (
 )
 
 const (
-	EnvScannerRegion       = "VMCLARITY_AWS_SCANNER_REGION"
-	EnvSubnetID            = "VMCLARITY_AWS_SUBNET_ID"
-	EnvSecurityGroupID     = "VMCLARITY_AWS_SECURITY_GROUP_ID"
-	EnvKeyPairName         = "VMCLARITY_AWS_KEYPAIR_NAME"
-	EnvScannerImage        = "VMCLARITY_AWS_SCANNER_AMI_ID"
-	EnvScannerInstanceType = "VMCLARITY_AWS_SCANNER_INSTANCE_TYPE"
-	EnvBlockDeviceName     = "VMCLARITY_AWS_BLOCK_DEVICE_NAME"
-
+	DefaultEnvPrefix           = "VMCLARITY_AWS"
 	DefaultScannerInstanceType = "t2.large"
 	DefaultBlockDeviceName     = "xvdh"
 )
 
 type Config struct {
 	// Region where the Scanner instance needs to be created
-	ScannerRegion string
+	ScannerRegion string `mapstructure:"scanner_region"`
 	// SubnetID where the Scanner instance needs to be created
-	SubnetID string
+	SubnetID string `mapstructure:"subnet_id"`
 	// SecurityGroupID which needs to be attached to the Scanner instance
-	SecurityGroupID string
+	SecurityGroupID string `mapstructure:"security_group_id"`
 	// KeyPairName is the name of the SSH KeyPair to use for Scanner instance launch
-	KeyPairName string
+	KeyPairName string `mapstructure:"keypair_name"`
 	// ScannerImage is the AMI image used for creating Scanner instance
-	ScannerImage string
+	ScannerImage string `mapstructure:"scanner_ami_id"`
 	// ScannerInstanceType is the instance type used for Scanner instance
-	ScannerInstanceType string
+	ScannerInstanceType string `mapstructure:"scanner_instance_type"`
 	// BlockDeviceName contains the block device name used for attaching Scanner volume to the Scanner instance
-	BlockDeviceName string
+	BlockDeviceName string `mapstructure:"block_device_name"`
 }
 
 func (c *Config) Validate() error {
@@ -79,20 +72,21 @@ func NewConfig() (*Config, error) {
 	// Avoid modifying the global instance
 	v := viper.New()
 
+	v.SetEnvPrefix(DefaultEnvPrefix)
 	v.AllowEmptyEnv(true)
 	v.AutomaticEnv()
 
-	_ = v.BindEnv("ScannerRegion", EnvScannerRegion)
-	_ = v.BindEnv("SubnetID", EnvSubnetID)
-	_ = v.BindEnv("SecurityGroupID", EnvSecurityGroupID)
-	_ = v.BindEnv("KeyPairName", EnvKeyPairName)
-	_ = v.BindEnv("ScannerImage", EnvScannerImage)
+	_ = v.BindEnv("scanner_region")
+	_ = v.BindEnv("subnet_id")
+	_ = v.BindEnv("security_group_id")
+	_ = v.BindEnv("keypair_name")
+	_ = v.BindEnv("scanner_ami_id")
 
-	_ = v.BindEnv("ScannerInstanceType", EnvScannerInstanceType)
-	v.SetDefault("ScannerInstanceType", DefaultScannerInstanceType)
+	_ = v.BindEnv("scanner_instance_type")
+	v.SetDefault("scanner_instance_type", DefaultScannerInstanceType)
 
-	_ = v.BindEnv("BlockDeviceName", EnvBlockDeviceName)
-	v.SetDefault("BlockDeviceName", DefaultBlockDeviceName)
+	_ = v.BindEnv("block_device_name")
+	v.SetDefault("block_device_name", DefaultBlockDeviceName)
 
 	config := &Config{}
 	if err := v.Unmarshal(config); err != nil {

--- a/runtime_scan/pkg/provider/aws/config.go
+++ b/runtime_scan/pkg/provider/aws/config.go
@@ -15,40 +15,89 @@
 
 package aws
 
-import "github.com/spf13/viper"
+import (
+	"fmt"
+
+	"github.com/spf13/viper"
+)
 
 const (
-	AWSSubnetID            = "AWS_SUBNET_ID"
-	AWSJobImageID          = "AWS_JOB_IMAGE_ID"
-	AWSSecurityGroupID     = "AWS_SECURITY_GROUP_ID"
-	AWSInstanceType        = "AWS_INSTANCE_TYPE"
-	defaultAWSJobImageID   = "ami-0568773882d492fc8" // ubuntu server 22.04 LTS (HVM), SSD volume type
-	defaultAWSInstanceType = "t2.large"
+	EnvScannerRegion       = "VMCLARITY_AWS_SCANNER_REGION"
+	EnvSubnetID            = "VMCLARITY_AWS_SUBNET_ID"
+	EnvSecurityGroupID     = "VMCLARITY_AWS_SECURITY_GROUP_ID"
+	EnvKeyPairName         = "VMCLARITY_AWS_KEYPAIR_NAME"
+	EnvScannerImage        = "VMCLARITY_AWS_SCANNER_AMI_ID"
+	EnvScannerInstanceType = "VMCLARITY_AWS_SCANNER_INSTANCE_TYPE"
+	EnvBlockDeviceName     = "VMCLARITY_AWS_BLOCK_DEVICE_NAME"
+
+	DefaultScannerInstanceType = "t2.large"
+	DefaultBlockDeviceName     = "xvdh"
 )
 
 type Config struct {
-	AmiID           string // image id of a scanner job
-	SubnetID        string // the scanner's subnet ID
-	SecurityGroupID string // the scanner's security group
-	InstanceType    string // the scanner's instance type
+	// Region where the Scanner instance needs to be created
+	ScannerRegion string
+	// SubnetID where the Scanner instance needs to be created
+	SubnetID string
+	// SecurityGroupID which needs to be attached to the Scanner instance
+	SecurityGroupID string
+	// KeyPairName is the name of the SSH KeyPair to use for Scanner instance launch
+	KeyPairName string
+	// ScannerImage is the AMI image used for creating Scanner instance
+	ScannerImage string
+	// ScannerInstanceType is the instance type used for Scanner instance
+	ScannerInstanceType string
+	// BlockDeviceName contains the block device name used for attaching Scanner volume to the Scanner instance
+	BlockDeviceName string
 }
 
-func setConfigDefaults() {
-	viper.SetDefault(AWSJobImageID, defaultAWSJobImageID)
-	viper.SetDefault(AWSInstanceType, defaultAWSInstanceType)
-
-	viper.AutomaticEnv()
-}
-
-func LoadConfig() *Config {
-	setConfigDefaults()
-
-	config := &Config{
-		AmiID:           viper.GetString(AWSJobImageID),
-		SubnetID:        viper.GetString(AWSSubnetID),
-		SecurityGroupID: viper.GetString(AWSSecurityGroupID),
-		InstanceType:    viper.GetString(AWSInstanceType),
+func (c *Config) Validate() error {
+	if c.ScannerRegion == "" {
+		return fmt.Errorf("parameter Region must not be nil")
 	}
 
-	return config
+	if c.SubnetID == "" {
+		return fmt.Errorf("parameter SubnetID must not be nil")
+	}
+
+	if c.SecurityGroupID == "" {
+		return fmt.Errorf("parameter SecurityGroupID must not be nil")
+	}
+
+	if c.ScannerImage == "" {
+		return fmt.Errorf("parameter ScannerImage must not be nil")
+	}
+
+	if c.ScannerInstanceType == "" {
+		return fmt.Errorf("parameter ScannerInstanceType must not be nil")
+	}
+
+	return nil
+}
+
+func NewConfig() (*Config, error) {
+	// Avoid modifying the global instance
+	v := viper.New()
+
+	v.AllowEmptyEnv(true)
+	v.AutomaticEnv()
+
+	_ = v.BindEnv("ScannerRegion", EnvScannerRegion)
+	_ = v.BindEnv("SubnetID", EnvSubnetID)
+	_ = v.BindEnv("SecurityGroupID", EnvSecurityGroupID)
+	_ = v.BindEnv("KeyPairName", EnvKeyPairName)
+	_ = v.BindEnv("ScannerImage", EnvScannerImage)
+
+	_ = v.BindEnv("ScannerInstanceType", EnvScannerInstanceType)
+	v.SetDefault("ScannerInstanceType", DefaultScannerInstanceType)
+
+	_ = v.BindEnv("BlockDeviceName", EnvBlockDeviceName)
+	v.SetDefault("BlockDeviceName", DefaultBlockDeviceName)
+
+	config := &Config{}
+	if err := v.Unmarshal(config); err != nil {
+		return nil, fmt.Errorf("failed to parse provider configuration. Provider=AWS: %w", err)
+	}
+
+	return config, nil
 }

--- a/runtime_scan/pkg/provider/aws/config_test.go
+++ b/runtime_scan/pkg/provider/aws/config_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aws
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+func TestConfig(t *testing.T) {
+	tests := []struct {
+		Name    string
+		EnvVars map[string]string
+
+		ExpectedNewErrorMatcher      types.GomegaMatcher
+		ExpectedConfig               *Config
+		ExpectedValidateErrorMatcher types.GomegaMatcher
+	}{
+		{
+			Name: "Valid config",
+			EnvVars: map[string]string{
+				"VMCLARITY_AWS_SCANNER_REGION":        "eu-west-1",
+				"VMCLARITY_AWS_SUBNET_ID":             "subnet-038f85dc621fd5b5d",
+				"VMCLARITY_AWS_SECURITY_GROUP_ID":     "sg-02cfdc854e18664d4",
+				"VMCLARITY_AWS_KEYPAIR_NAME":          "vmclarity-ssh-key",
+				"VMCLARITY_AWS_SCANNER_AMI_ID":        "ami-0568773882d492fc8",
+				"VMCLARITY_AWS_SCANNER_INSTANCE_TYPE": "t3.large",
+				"VMCLARITY_AWS_BLOCK_DEVICE_NAME":     "xvdh",
+			},
+			ExpectedNewErrorMatcher: Not(HaveOccurred()),
+			ExpectedConfig: &Config{
+				ScannerRegion:       "eu-west-1",
+				SubnetID:            "subnet-038f85dc621fd5b5d",
+				SecurityGroupID:     "sg-02cfdc854e18664d4",
+				KeyPairName:         "vmclarity-ssh-key",
+				ScannerImage:        "ami-0568773882d492fc8",
+				ScannerInstanceType: "t3.large",
+				BlockDeviceName:     "xvdh",
+			},
+			ExpectedValidateErrorMatcher: Not(HaveOccurred()),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			os.Clearenv()
+			for k, v := range test.EnvVars {
+				err := os.Setenv(k, v)
+				g.Expect(err).Should(Not(HaveOccurred()))
+			}
+
+			config, err := NewConfig()
+
+			g.Expect(err).Should(test.ExpectedNewErrorMatcher)
+			g.Expect(config).Should(BeEquivalentTo(test.ExpectedConfig))
+
+			err = config.Validate()
+			g.Expect(err).Should(test.ExpectedValidateErrorMatcher)
+		})
+	}
+}

--- a/runtime_scan/pkg/provider/types.go
+++ b/runtime_scan/pkg/provider/types.go
@@ -61,9 +61,6 @@ type ScanJobConfig struct {
 	ScannerImage     string // Scanner Container Image to use containing the vmclarity-cli and tools
 	ScannerCLIConfig string // Scanner CLI config yaml (families config yaml)
 	VMClarityAddress string // The backend address for the scanner CLI to export too
-	KeyPairName      string // The name of the key pair to set on the instance, ignored if not set, used mainly for debugging.
-	ScannerRegion    string // The region where the VMClarity Scanner instance needs to be deployed
-	BlockDeviceName  string // The block device name used for attaching target volume to the scanner vm
 
 	ScanMetadata
 	models.ScannerInstanceCreationConfig


### PR DESCRIPTION
## Description

### Refactor

* removed `Provider` specific configuration form `orchestrator.Config`
* added `VMCLARITY_AWS` prefix to environment variables related to `aws` package
* switch from using `viper.Get*` getters to `viper.Unmarshal` to initialize `aws.Config`

### Documentation

* extended documentation with the configuration options for `Orchestrator` and `Provider` components.


## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[x] Breaking Change  
[x] Refactor  
[x] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
