### PR TITLE
fix: query for fetching ScanResults in Processor

### DIFF
--- a/runtime_scan/pkg/orchestrator/scanresultprocessor/processor.go
+++ b/runtime_scan/pkg/orchestrator/scanresultprocessor/processor.go
@@ -123,8 +123,10 @@ type ScanResultReconcileEvent struct {
 }
 
 func (srp *ScanResultProcessor) GetItems(ctx context.Context) ([]ScanResultReconcileEvent, error) {
+	filter := fmt.Sprintf("status/general/state eq '%s' and (findingsProcessed eq false or findingsProcessed eq null)",
+		models.TargetScanStateStateDone)
 	scanResults, err := srp.client.GetScanResults(ctx, models.GetScanResultsParams{
-		Filter: utils.PointerTo("status/general/state eq 'DONE' and (findingsProcessed eq false or findingsProcessed eq null)"),
+		Filter: utils.PointerTo(filter),
 		Select: utils.PointerTo("id"),
 	})
 	if err != nil {


### PR DESCRIPTION
## Description

Fix `ScanResult` status being hard-coded in the query used by `ScanResultProcessor` to fetch `ScanResult`(s) for findings processing.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
