### PR TITLE
fix(ui): ScanResult status mapping

### DIFF
--- a/ui/src/layout/AssetScans/StatusIndicator/index.js
+++ b/ui/src/layout/AssetScans/StatusIndicator/index.js
@@ -7,12 +7,13 @@ import COLORS from 'utils/scss_variables.module.scss';
 import './status-indicator.scss';
 
 export const STATUS_MAPPING = {
-    NOT_SCANNED: {title: "Not Scanned", color: COLORS["color-grey"]},
-    INIT: {title: "Initialized", color: COLORS["color-main"]},
-    ATTACHED: {title: "Volume Snapshot Attached", color: COLORS["color-main"]},
-    IN_PROGRESS: {title: "In Progress", color: COLORS["color-main"]},
-    DONE: {title: "Done", color: COLORS["color-success"]},
-    ABORTED: {title: "Aborted", color: COLORS["color-grey"]}
+    NotScanned: {title: "Not Scanned", color: COLORS["color-grey"]},
+    Pending: {title: "Pending", color: COLORS["color-main"]},
+    Scheduled: {title: "Scheduled", color: COLORS["color-main"]},
+    ReadyToScan: {title: "Ready To Scan", color: COLORS["color-main"]},
+    InProgress: {title: "In Progress", color: COLORS["color-main"]},
+    Done: {title: "Done", color: COLORS["color-success"]},
+    Aborted: {title: "Aborted", color: COLORS["color-grey"]}
 }
 
 const StatusIndicator = ({state, isError=false}) => {


### PR DESCRIPTION
## Description

Fix `StatusMapping` for `ScanResults` in the UI which broken due to #379.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
