### PR TITLE
fix(aws): incorrectly set AWS provider kind

### DIFF
--- a/runtime_scan/pkg/provider/aws/client.go
+++ b/runtime_scan/pkg/provider/aws/client.go
@@ -57,7 +57,7 @@ func New(ctx context.Context, config *Config) (*Client, error) {
 }
 
 func (c Client) Kind() models.CloudProvider {
-	return AWSProvider
+	return models.AWS
 }
 
 func (c *Client) DiscoverScopes(ctx context.Context) (*models.Scopes, error) {

--- a/runtime_scan/pkg/provider/aws/helpers.go
+++ b/runtime_scan/pkg/provider/aws/helpers.go
@@ -419,7 +419,7 @@ func getVMInfoFromInstance(i Instance) (models.TargetType, error) {
 	err := targetType.FromVMInfo(models.VMInfo{
 		Image:            i.Image,
 		InstanceID:       i.ID,
-		InstanceProvider: utils.PointerTo(AWSProvider),
+		InstanceProvider: utils.PointerTo(models.AWS),
 		InstanceType:     i.InstanceType,
 		LaunchTime:       i.LaunchTime,
 		Location:         i.Location(),

--- a/runtime_scan/pkg/provider/aws/types.go
+++ b/runtime_scan/pkg/provider/aws/types.go
@@ -20,8 +20,7 @@ import (
 )
 
 const (
-	maxResults                       = 500
-	AWSProvider models.CloudProvider = "aws"
+	maxResults = 500
 )
 
 const (


### PR DESCRIPTION
## Description

Fix AWS provider kind to use `models.AWS`.

Fixes: [#391](https://github.com/openclarity/vmclarity/issues/391), [#394](https://github.com/openclarity/vmclarity/issues/394)

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
