### PR TITLE
Optimize Trends widget load time

### DIFF
--- a/ui_backend/api/models/findingType.go
+++ b/ui_backend/api/models/findingType.go
@@ -1,0 +1,13 @@
+package models
+
+func GetFindingTypes() []FindingType {
+	return []FindingType{
+		EXPLOIT,
+		MALWARE,
+		MISCONFIGURATION,
+		PACKAGE,
+		ROOTKIT,
+		SECRET,
+		VULNERABILITY,
+	}
+}


### PR DESCRIPTION
## Description

There was a need to improve the load time of the trends widget.
This PR improve it by
1. Adding an index for Trends widget query
2. Run the findings type queries in parallel

After testing, the full call for `/ui/api/dashboard/findingsTrends` improved from 6.5s to 300ms

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[X] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
