### PR TITLE
fix: patching aborted scan

### DIFF
--- a/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
+++ b/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
@@ -537,11 +537,15 @@ func (w *Watcher) reconcileAborted(ctx context.Context, scan *models.Scan) error
 
 	scan.EndTime = utils.PointerTo(time.Now())
 	scan.State = utils.PointerTo(models.ScanStateFailed)
+	scan.StateReason = utils.PointerTo(models.ScanStateReasonAborted)
+	scan.StateMessage = utils.PointerTo("Scan has been aborted")
 
 	scanPatch := &models.Scan{
-		State:     scan.State,
-		EndTime:   scan.EndTime,
-		TargetIDs: scan.TargetIDs,
+		State:        scan.State,
+		EndTime:      scan.EndTime,
+		StateReason:  scan.StateReason,
+		StateMessage: scan.StateMessage,
+		TargetIDs:    scan.TargetIDs,
 	}
 	err = w.backend.PatchScan(ctx, scanID, scanPatch)
 	if err != nil {

--- a/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
+++ b/runtime_scan/pkg/orchestrator/scanwatcher/watcher.go
@@ -538,9 +538,14 @@ func (w *Watcher) reconcileAborted(ctx context.Context, scan *models.Scan) error
 	scan.EndTime = utils.PointerTo(time.Now())
 	scan.State = utils.PointerTo(models.ScanStateFailed)
 
-	err = w.backend.PatchScan(ctx, scanID, scan)
+	scanPatch := &models.Scan{
+		State:     scan.State,
+		EndTime:   scan.EndTime,
+		TargetIDs: scan.TargetIDs,
+	}
+	err = w.backend.PatchScan(ctx, scanID, scanPatch)
 	if err != nil {
-		return fmt.Errorf("failed to patch Scan with %s id: %w", scanID, err)
+		return fmt.Errorf("failed to patch Scan. ScanID=%s: %w", scanID, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

Fix patching aborted scans by adding only the updated fields to the `PATCH` request.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
