### PR TITLE
Postgres DB driver has issues so removing the option to configure it

### DIFF
--- a/installation/aws/VmClarity.cfn
+++ b/installation/aws/VmClarity.cfn
@@ -949,10 +949,10 @@ Parameters:
   DatabaseToUse:
     Description: Database VMClarity should use to store its objects.
     Type: String
-    Default: Postgresql
+    Default: SQLite
     AllowedValues:
-      - Postgresql
-      - External Postgresql
+      #- Postgresql
+      #- External Postgresql
       - SQLite
   PostgresDBPassword:
     Description: >


### PR DESCRIPTION
## Description

This leaves the well tested and working SQLite DB driver as the default and only option to install VMClarity with.
Postgres options will be re-enabled once the Postgres driver issues are resolved.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[X] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
