### PR TITLE
fix: ScanResults stuck in aborted state

### DIFF
--- a/runtime_scan/pkg/orchestrator/config.go
+++ b/runtime_scan/pkg/orchestrator/config.go
@@ -57,6 +57,7 @@ const (
 
 	ScanResultPollingInterval  = "SCAN_RESULT_POLLING_INTERVAL"
 	ScanResultReconcileTimeout = "SCAN_RESULT_RECONCILE_TIMEOUT"
+	ScanResultAbortTimeout     = "SCAN_RESULT_ABORT_TIMEOUT"
 
 	ScanResultProcessorPollingInterval  = "SCAN_RESULT_PROCESSOR_POLLING_INTERVAL"
 	ScanResultProcessorReconcileTimeout = "SCAN_RESULT_PROCESSOR_RECONCILE_TIMEOUT"
@@ -119,6 +120,7 @@ func setConfigDefaults(backendHost string, backendPort int, backendBaseURL strin
 	viper.SetDefault(DiscoveryInterval, discovery.DefaultInterval.String())
 	viper.SetDefault(ControllerStartupDelay, DefaultControllerStartupDelay.String())
 	viper.SetDefault(ProviderKind, DefaultProviderKind)
+	viper.SetDefault(ScanResultAbortTimeout, scanresultwatcher.DefaultAbortTimeout)
 
 	viper.AutomaticEnv()
 }
@@ -155,6 +157,7 @@ func LoadConfig(backendHost string, backendPort int, baseURL string) (*Config, e
 		ScanResultWatcherConfig: scanresultwatcher.Config{
 			PollPeriod:       viper.GetDuration(ScanResultPollingInterval),
 			ReconcileTimeout: viper.GetDuration(ScanResultReconcileTimeout),
+			AbortTimeout:     viper.GetDuration(ScanResultAbortTimeout),
 			ScannerConfig: scanresultwatcher.ScannerConfig{
 				DeleteJobPolicy:               scanresultwatcher.GetDeleteJobPolicyType(viper.GetString(DeleteJobPolicy)),
 				ScannerImage:                  viper.GetString(ScannerContainerImage),

--- a/runtime_scan/pkg/orchestrator/scanresultwatcher/config.go
+++ b/runtime_scan/pkg/orchestrator/scanresultwatcher/config.go
@@ -25,6 +25,7 @@ import (
 const (
 	DefaultPollInterval     = time.Minute
 	DefaultReconcileTimeout = 5 * time.Minute
+	DefaultAbortTimeout     = 10 * time.Minute
 )
 
 type Config struct {
@@ -33,6 +34,7 @@ type Config struct {
 	PollPeriod       time.Duration
 	ReconcileTimeout time.Duration
 	ScannerConfig    ScannerConfig
+	AbortTimeout     time.Duration
 }
 
 func (c Config) WithBackendClient(b *backendclient.BackendClient) Config {


### PR DESCRIPTION
## Description

The `vmclarity-cli` running on the `Scanner` instance is responsible for handling the `aborted` event for the corresponding `ScanResult`. The `ScanResultWatcher` controller will periodically check whether the `vmclarity-cli` managed to gracefully shutdown the running scan and set the` ScanResult `to `done` indicating that thr scan is finished and the Scanner instance could be removed. However moving the `ScanResults` state to `done` will not happen in case the `vmclarity-cli` process is not running on the Scanner instance making the `ScanResultWatcher` controller waiting indefinitely.

The `ScanResultWatcher` will now monitor the `ScanResults` in `aborted` state and will move their state to `done` after a predefined period of time.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
