### PR TITLE
fix: Volume mount scanner host fs into scanner container

### DIFF
--- a/runtime_scan/pkg/provider/cloudinit/cloud-init.tmpl.yaml
+++ b/runtime_scan/pkg/provider/cloudinit/cloud-init.tmpl.yaml
@@ -21,6 +21,7 @@ write_files:
       ExecStartPre=mkdir -p /var/opt/vmclarity
       ExecStartPre=docker pull {{ .ScannerImage }}
       ExecStart=docker run --rm --name %n --privileged \
+          -v /:/hostfs \
           -v /dev:/dev \
           -v /opt/vmclarity:/opt/vmclarity \
           -v /run:/run \

--- a/runtime_scan/pkg/provider/cloudinit/testdata/cloud-init.yaml
+++ b/runtime_scan/pkg/provider/cloudinit/testdata/cloud-init.yaml
@@ -31,6 +31,7 @@ write_files:
       ExecStartPre=mkdir -p /var/opt/vmclarity
       ExecStartPre=docker pull ghcr.io/openclarity/vmclarity-cli:latest
       ExecStart=docker run --rm --name %n --privileged \
+          -v /:/hostfs \
           -v /dev:/dev \
           -v /opt/vmclarity:/opt/vmclarity \
           -v /run:/run \


### PR DESCRIPTION
Containers can only be aware of device mount points which are within their containerized filesystem. This means that if a device is mounted somewhere on the host, and that location on the host is not exposed to the container, the container can not determine if its mount or not.

This commit resolves this issue by making the whole host filesystem available for the container to see by mounting it into a sub-directory called `/hostfs` within the containers filesystem.

Once the container can see the host filesystem, all volumes which are mounted by the host or by the scanner have a mount point defined in `lsblk`.

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
