### PR TITLE
feat(dockerfile): add mount type cache to go build command

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -32,7 +32,9 @@ ARG COMMIT_HASH
 
 ENV CGO_ENABLED=1
 
-RUN go build -ldflags="-s -w -extldflags -static \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -ldflags="-s -w -extldflags -static \
      -X 'github.com/openclarity/vmclarity/backend/pkg/version.Version=${VERSION}' \
      -X 'github.com/openclarity/vmclarity/backend/pkg/version.CommitHash=${COMMIT_HASH}' \
      -X 'github.com/openclarity/vmclarity/backend/pkg/version.BuildTimestamp=${BUILD_TIMESTAMP}'" -o backend ./cmd/backend/main.go


### PR DESCRIPTION
## Description

Add mount type cache to go build command in Dockerfile.backend.

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
