### PR TITLE
fix: Fix summaries in the asset table and asset details

### DIFF
--- a/ui/src/layout/Assets/AssetsTable.js
+++ b/ui/src/layout/Assets/AssetsTable.js
@@ -51,7 +51,7 @@ const AssetsTable = () => {
         <TablePage
             columns={columns}
             url={APIS.ASSETS}
-            select="id,targetInfo"
+            select="id,targetInfo,summary"
             tableTitle={TABLE_TITLE}
             filterType={FILTER_TYPES.ASSETS}
             filtersConfig={[

--- a/ui/src/layout/detail-displays/Findings/index.js
+++ b/ui/src/layout/detail-displays/Findings/index.js
@@ -11,7 +11,8 @@ import FindingsCounterDisplay from './FindingsCounterDisplay';
 import FindingsSystemFilterLinks from './FindingsSystemFilterLinks';
 
 const Findings = ({findingsSummary, findingsFilter, findingsFilterTitle, findingsFilterSuffix=""}) => {
-    const {totalVulnerabilities} = findingsSummary || {};
+    findingsSummary = findingsSummary || {};
+    const {totalVulnerabilities} = findingsSummary;
 
     const {pathname} = useLocation();
     const filtersDispatch = useFilterDispatch();
@@ -26,7 +27,7 @@ const Findings = ({findingsSummary, findingsFilter, findingsFilterTitle, finding
                 backPath: pathname,
                 customDisplay: () => (
                     <FindingsSystemFilterLinks
-                        findingsSummary={findingsSummary || {}}
+                        findingsSummary={findingsSummary}
                         totalVulnerabilitiesCount={getTotlalVulnerabilitiesFromCounters(totalVulnerabilities)}
                     />
                 )


### PR DESCRIPTION
## Description

Ensures the data is pulled from the API for the summaries to be displayed in the assets table.

Ensures that assets with missing summary data don't crash the UI when in the assets drill down, without this change it just displays a blank screen.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
