### PR TITLE
feat: Reduce default orchestrator poller interval to 15 seconds

### DIFF
--- a/runtime_scan/pkg/orchestrator/assetscanwatcher/config.go
+++ b/runtime_scan/pkg/orchestrator/assetscanwatcher/config.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	DefaultPollInterval     = time.Minute
+	DefaultPollInterval     = 15 * time.Second
 	DefaultReconcileTimeout = 5 * time.Minute
 	DefaultAbortTimeout     = 10 * time.Minute
 )

--- a/runtime_scan/pkg/orchestrator/config.go
+++ b/runtime_scan/pkg/orchestrator/config.go
@@ -73,7 +73,11 @@ const (
 	DefaultTrivyServerTimeout = 5 * time.Minute
 	DefaultGrypeServerTimeout = 2 * time.Minute
 
-	DefaultControllerStartupDelay = 15 * time.Second
+	// Approximately half the polling delay to allow for more efficient
+	// reconcile cascading e.g. reconciling scan config creates a scan, the
+	// poller for scan is offset by 7 seconds so should pick up the new
+	// scan after 7 seconds instead of the full poller time.
+	DefaultControllerStartupDelay = 7 * time.Second
 	DefaultProviderKind           = models.AWS
 )
 

--- a/runtime_scan/pkg/orchestrator/scanconfigwatcher/config.go
+++ b/runtime_scan/pkg/orchestrator/scanconfigwatcher/config.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	DefaultPollInterval     = time.Minute
+	DefaultPollInterval     = 15 * time.Second
 	DefaultReconcileTimeout = 5 * time.Minute
 )
 

--- a/runtime_scan/pkg/orchestrator/scanwatcher/config.go
+++ b/runtime_scan/pkg/orchestrator/scanwatcher/config.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	DefaultPollInterval     = time.Minute
+	DefaultPollInterval     = 15 * time.Second
 	DefaultReconcileTimeout = 5 * time.Minute
 	DefaultScanTimeout      = 48 * time.Hour
 )


### PR DESCRIPTION
## Description

The current 1 minute results in multi-minute start up times for a scan because it has to reconcile multiple times to step through Pending -> Discovered -> InProgress.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[X] Other (please describe)  optimisation

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
