### PR TITLE
fix: benchmark cache map by input instead of input type

### DIFF
--- a/pkg/shared/families/utils/utils.go
+++ b/pkg/shared/families/utils/utils.go
@@ -69,7 +69,7 @@ func GetInputSize(input types.Input) (int64, error) {
 		if err != nil {
 			return 0, fmt.Errorf("failed to get dir size: %v", err)
 		}
-		InputSizesCache[input.InputType] = size
+		InputSizesCache[input.Input] = size
 		return size, nil
 	default:
 		// currently other input types are not supported for size benchmarking.


### PR DESCRIPTION
## Description

Fix size cache to save by input instead of input type

## Type of Change

[* ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  
