### PR TITLE
fix: vmclarity-ui-backend references

### DIFF
--- a/installation/azure/vmclarity.bicep
+++ b/installation/azure/vmclarity.bicep
@@ -33,7 +33,7 @@ param orchestratorContainerImage string = 'ghcr.io/openclarity/vmclarity-orchest
 param uiContainerImage string = 'ghcr.io/openclarity/vmclarity-ui:latest'
 
 @description ('VMClarity UIBackend Container Image')
-param uibackendContainerImage string = 'ghcr.io/openclarity/vmclarity-uibackend:latest'
+param uibackendContainerImage string = 'ghcr.io/openclarity/vmclarity-ui-backend:latest'
 
 @description ('VMClarity Scanner Container Image')
 param scannerContainerImage string = 'ghcr.io/openclarity/vmclarity-cli:latest'

--- a/installation/azure/vmclarity.json
+++ b/installation/azure/vmclarity.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.19.5.34762",
-      "templateHash": "11101766410951708815"
+      "templateHash": "2645412564224659674"
     }
   },
   "parameters": {
@@ -76,7 +76,7 @@
     },
     "uibackendContainerImage": {
       "type": "string",
-      "defaultValue": "ghcr.io/openclarity/vmclarity-uibackend:latest",
+      "defaultValue": "ghcr.io/openclarity/vmclarity-ui-backend:latest",
       "metadata": {
         "description": "VMClarity UIBackend Container Image"
       }
@@ -556,7 +556,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.19.5.34762",
-              "templateHash": "587257319525751437"
+              "templateHash": "14736449405121414571"
             }
           },
           "parameters": {
@@ -646,7 +646,7 @@
             },
             "uibackendContainerImage": {
               "type": "string",
-              "defaultValue": "ghcr.io/openclarity/vmclarity-uibackend:latest",
+              "defaultValue": "ghcr.io/openclarity/vmclarity-ui-backend:latest",
               "metadata": {
                 "description": "VMClarity UIBackend Container Image"
               }

--- a/installation/azure/vmclarityDeployModule.bicep
+++ b/installation/azure/vmclarityDeployModule.bicep
@@ -40,7 +40,7 @@ param orchestratorContainerImage string = 'ghcr.io/openclarity/vmclarity-orchest
 param uiContainerImage string = 'ghcr.io/openclarity/vmclarity-ui:latest'
 
 @description ('VMClarity UIBackend Container Image')
-param uibackendContainerImage string = 'ghcr.io/openclarity/vmclarity-uibackend:latest'
+param uibackendContainerImage string = 'ghcr.io/openclarity/vmclarity-ui-backend:latest'
 
 @description ('VMClarity Scanner Container Image')
 param scannerContainerImage string = 'ghcr.io/openclarity/vmclarity-cli:latest'

--- a/installation/docker/dockercompose.yml
+++ b/installation/docker/dockercompose.yml
@@ -42,7 +42,7 @@ services:
         condition: on-failure
 
   uibackend:
-    image: ${UIBackendContainerImage:-ghcr.io/openclarity/vmclarity-uibackend:latest}
+    image: ${UIBackendContainerImage:-ghcr.io/openclarity/vmclarity-ui-backend:latest}
     command:
       - run
       - --log-level

--- a/installation/docker/image_override.env
+++ b/installation/docker/image_override.env
@@ -3,5 +3,5 @@
 APIServerContainerImage=docker.io/tehsmash/vmclarity-apiserver:swaggerui
 OrchestratorContainerImage=docker.io/tehsmash/vmclarity-orchestrator:swaggerui
 UIContainerImage=docker.io/tehsmash/vmclarity-ui:swaggerui
-UIBackendContainerImage=docker.io/tehsmash/vmclarity-uibackend:swaggerui
+UIBackendContainerImage=docker.io/tehsmash/vmclarity-ui-backend:swaggerui
 ScannerContainerImage=docker.io/tehsmash/vmclarity-cli:swaggerui

--- a/installation/gcp/dm/components/vmclarity-server.py.schema
+++ b/installation/gcp/dm/components/vmclarity-server.py.schema
@@ -65,7 +65,7 @@ properties:
     description: The container image to use for the ui
   uibackendContainerImage:
     type: string
-    default: ghcr.io/openclarity/vmclarity-uibackend:latest
+    default: ghcr.io/openclarity/vmclarity-ui-backend:latest
     description: The container image to use for the uibackend
   scannerContainerImage:
     type: string

--- a/installation/gcp/dm/vmclarity.py.schema
+++ b/installation/gcp/dm/vmclarity.py.schema
@@ -57,7 +57,7 @@ properties:
     description: The container image to use for the ui
   uibackendContainerImage:
     type: string
-    default: ghcr.io/openclarity/vmclarity-uibackend:latest
+    default: ghcr.io/openclarity/vmclarity-ui-backend:latest
     description: The container image to use for the uibackend
   scannerContainerImage:
     type: string


### PR DESCRIPTION
## Description

VMClarity UI backend is built and published as vmclarity-ui-backend, there are a few places refering to it as vmclarity-uibackend. This commit fixes these references to use the dashed version.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
