### PR TITLE
docs: update api url and scan config example

### DIFF
--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -10,12 +10,12 @@ If we want to report results to the VMClarity backend, we need to create asset a
 ## Reporting results to VMClarity backend:
 
 ```
-ASSET_ID=$(./cli/bin/vmclarity-cli asset-create --file assets/dir-asset.json --server http://localhost:8888/api) --jsonpath {.id}
-ASSET_SCAN_ID=$(./cli/bin/vmclarity-cli asset-scan-create --asset-id $ASSET_ID --server http://localhost:8888/api) --jsonpath {.id}
-./cli/bin/vmclarity-cli scan --config ~/testConf.yaml --server http://localhost:8888/api --asset-scan-id $ASSET_SCAN_ID
+ASSET_ID=$(./cli/bin/vmclarity-cli asset-create --file assets/dir-asset.json --server http://localhost:8080/api) --jsonpath {.id}
+ASSET_SCAN_ID=$(./cli/bin/vmclarity-cli asset-scan-create --asset-id $ASSET_ID --server http://localhost:8080/api) --jsonpath {.id}
+./cli/bin/vmclarity-cli scan --config ~/testConf.yaml --server http://localhost:8080/api --asset-scan-id $ASSET_SCAN_ID
 ```
 
 Using one-liner:
 ```
-./cli/bin/vmclarity-cli asset-create --file docs/assets/dir-asset.json --server http://localhost:8888/api --update-if-exists --jsonpath {.id} | xargs -I{} ./cli/bin/vmclarity-cli asset-scan-create --asset-id {} --server http://localhost:8888/api --jsonpath {.id} | xargs -I{} ./cli/bin/vmclarity-cli scan --config ~/testConf.yaml --server http://localhost:8888/api --asset-scan-id {}
+./cli/bin/vmclarity-cli asset-create --file docs/assets/dir-asset.json --server http://localhost:8080/api --update-if-exists --jsonpath {.id} | xargs -I{} ./cli/bin/vmclarity-cli asset-scan-create --asset-id {} --server http://localhost:8080/api --jsonpath {.id} | xargs -I{} ./cli/bin/vmclarity-cli scan --config ~/testConf.yaml --server http://localhost:8080/api --asset-scan-id {}
 ```

--- a/docs/scanConfig.json
+++ b/docs/scanConfig.json
@@ -1,19 +1,23 @@
 {
-        "name": "test",
-        "scanFamiliesConfig": {
-           "sbom": {
-             "enabled": true
-           },
-           "vulnerabilities": {
-             "enabled": true
-           },
-           "exploits": {
-             "enabled": true
-           }
+  "name": "test",
+  "scanTemplate": {
+    "scope": "contains(assetInfo.tags, '{\"key\":\"scanconfig\",\"value\":\"test\"}')",
+    "assetScanTemplate": {
+      "scanFamiliesConfig": {
+        "sbom": {
+          "enabled": true
         },
-        "scheduled": {
-           "cronLine": "0 */4 * * *",
-           "operationTime": "2023-01-20T15:46:18+00:00"
+        "vulnerabilities": {
+          "enabled": true
         },
-        "scope": ""
+        "exploits": {
+          "enabled": true
+        }
+      }
+    }
+  },
+  "scheduled": {
+    "cronLine": "0 */4 * * *",
+    "operationTime": "2023-01-20T15:46:18+00:00"
+  }
 }

--- a/docs/test_e2e.md
+++ b/docs/test_e2e.md
@@ -91,7 +91,7 @@ DOCKER_REGISTRY=<your docker registry> make push-docker
 3. While ssh'd into the VMClarity server run
 
    ```
-   curl -X POST http://localhost:8888/api/scanConfigs -H 'Content-Type: application/json' -d @scanConfig.json
+   curl -X POST http://localhost:8080/api/scanConfigs -H 'Content-Type: application/json' -d @scanConfig.json
    ```
 
 4. Check VMClarity logs to ensure that everything is performing as expected
@@ -105,7 +105,7 @@ DOCKER_REGISTRY=<your docker registry> make push-docker
    * Get scans:
 
      ```
-     curl -X GET http://localhost:8888/api/scans
+     curl -X GET http://localhost:8080/api/scans
      ```
 
      After the operationTime in the scan config created above there should be a new
@@ -121,5 +121,5 @@ DOCKER_REGISTRY=<your docker registry> make push-docker
    * Get asset scans:
 
      ```
-     curl -X GET http://localhost:8888/api/assetScans
+     curl -X GET http://localhost:8080/api/assetScans
      ```


### PR DESCRIPTION
## Description

Update documentation to reflect the latest changes:
* Change api url from `http://localhost:8888/api` to `http://localhost:8080/api`
* Change scan config example to match new `ScanConfig` struct

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[x] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
