### PR TITLE
Re-enable dupword and wastedassign linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,6 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - wastedassign
     - musttag
     - revive
     - maligned

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,6 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - dupword
     - wastedassign
     - musttag
     - revive

--- a/pkg/orchestrator/assetscanwatcher/watcher.go
+++ b/pkg/orchestrator/assetscanwatcher/watcher.go
@@ -358,7 +358,7 @@ func (w *Watcher) cleanupResources(ctx context.Context, assetScan *models.AssetS
 			asset:     &asset,
 		})
 		if err != nil {
-			return fmt.Errorf("failed to to create ScanJobConfigg for AssetScan. AssetScanID=%s: %w", assetScanID, err)
+			return fmt.Errorf("failed to create ScanJobConfig for AssetScan. AssetScanID=%s: %w", assetScanID, err)
 		}
 
 		err = w.provider.RemoveAssetScan(ctx, jobConfig)

--- a/pkg/shared/families/exploits/family.go
+++ b/pkg/shared/families/exploits/family.go
@@ -90,7 +90,6 @@ func (e Exploits) Run(ctx context.Context, res *results.Results) (interfaces.IsR
 
 // create a comma separated representation of cveIDs array, as an input for the exploits scanners.
 func getCVEIDsFromVulnerabilitiesResults(vulnResults *vulnerabilities.Results) string {
-	cves := ""
 	if vulnResults == nil || vulnResults.MergedResults == nil {
 		return ""
 	}
@@ -103,7 +102,7 @@ func getCVEIDsFromVulnerabilitiesResults(vulnResults *vulnerabilities.Results) s
 		}
 	}
 
-	cves = strings.Join(maps.Keys(cvesMap), ",")
+	cves := strings.Join(maps.Keys(cvesMap), ",")
 
 	return cves
 }

--- a/pkg/shared/families/sbom/family.go
+++ b/pkg/shared/families/sbom/family.go
@@ -50,7 +50,7 @@ func (s SBOM) Run(ctx context.Context, _ *familiesresults.Results) (interfaces.I
 
 	// TODO: move the logic from cli utils to shared utils
 	// TODO: now that we support multiple inputs,
-	//  we need to change the fact the the MergedResults assumes it is only for 1 input?
+	//  we need to change the fact the MergedResults assumes it is only for 1 input?
 	hash, err := cliutils.GenerateHash(utils.SourceType(s.conf.Inputs[0].InputType), s.conf.Inputs[0].Input)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate hash for source %s: %v", s.conf.Inputs[0].Input, err)

--- a/pkg/shared/fsutils/lsblk/internal/scan.go
+++ b/pkg/shared/fsutils/lsblk/internal/scan.go
@@ -29,7 +29,8 @@ func isDoubleQuote(r rune) bool {
 func ScanPairs(data []byte, atEOF bool) (int, []byte, error) {
 	// Skip leading spaces.
 	start := 0
-	for width := 0; start < len(data); start += width {
+	var width int
+	for ; start < len(data); start += width {
 		var r rune
 		r, width = utf8.DecodeRune(data[start:])
 		if !unicode.IsSpace(r) {
@@ -38,7 +39,7 @@ func ScanPairs(data []byte, atEOF bool) (int, []byte, error) {
 	}
 	// Scan until space or closing double quote
 	var qouted bool
-	for width, i := 0, start; i < len(data); i += width {
+	for i := start; i < len(data); i += width {
 		var r rune
 		r, width = utf8.DecodeRune(data[i:])
 

--- a/pkg/uibackend/rest/dashboard_findings_impact.go
+++ b/pkg/uibackend/rest/dashboard_findings_impact.go
@@ -523,7 +523,7 @@ func processFindings(findings []backendmodels.Finding, findingAssetMap map[findi
 				}
 			}
 		} else {
-			log.Debugf("Already count asset %q for finding finding (%+v).", item.Asset.Id, fKey)
+			log.Debugf("Already count asset %q for finding (%+v).", item.Asset.Id, fKey)
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR enable 2 linter and fix the related warnings for this issue:
https://github.com/openclarity/vmclarity/issues/364

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ X ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ X ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ X ] Existing issues have been referenced (where applicable)
- [ X ] I have verified this change is not present in other open pull requests
- [ X ] Functionality is documented
- [ X ] All code style checks pass
- [ X ] New code contribution is covered by automated tests
- [ X ] All new and existing tests pass
