### PR TITLE
Clean up links in the docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ change, which may lead to your PR taking much longer to review, or result in it 
 
 ## Checklist
 
-- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
+- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
 - [ ] Existing issues have been referenced (where applicable)
 - [ ] I have verified this change is not present in other open pull requests
 - [ ] Functionality is documented

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ addressing your issue, assessing changes, and helping you finalize your pull req
 we endeavor to review incoming issues and pull requests within 10 days, and will close any lingering issues or pull
 requests after 60 days of inactivity.
 
-Please note that all of your interactions in the project are subject to our [Code of Conduct](/CODE_OF_CONDUCT.md). This
+Please note that all of your interactions in the project are subject to our [Code of Conduct](CODE_OF_CONDUCT.md). This
 includes creation of issues or pull requests, commenting on issues or pull requests, and extends to all interactions in
 any real-time space e.g., Slack, Discord, etc.
 
@@ -27,7 +27,7 @@ any real-time space e.g., Slack, Discord, etc.
 
 ## Troubleshooting and Debugging
 
-Please see the troubleshooting and debugging guide [here](/docs/troubleshooting.md).
+Please see the troubleshooting and debugging guide [here](docs/troubleshooting.md).
 
 ## Reporting Issues
 
@@ -38,7 +38,7 @@ When creating a new issue, please be sure to include a **title and clear descrip
 possible, and, if possible, a test case.
 
 **If you discover a security bug, please do not report it through GitHub. Instead, please see security procedures in
-[SECURITY.md](/SECURITY.md).**
+[SECURITY.md](SECURITY.md).**
 
 ## Development
 
@@ -98,7 +98,7 @@ api` to regenerate the model, client and server code.
 ### Testing End to End
 
 For details on how to test VMClarity end to end please see the End to End
-testing guide [here](/docs/test_e2e.md).
+testing guide [here](docs/test_e2e.md).
 
 ## Sending Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For a detailed installation guide, please see [AWS](installation/aws/README.md).
     ```
 
 2. Access VMClarity UI in the browser: http://localhost:8080/
-3. Access the [API](/api/openapi.yaml) via http://localhost:8080/api
+3. Access the [API](api/openapi.yaml) via http://localhost:8080/api
 
 For a detailed UI tour, please see [tour](TOUR.md).
 
@@ -126,13 +126,13 @@ VMClarity project roadmap is available [here](https://github.com/orgs/openclarit
 # Contributing
 
 If you are ready to jump in and test, add code, or help with documentation,
-please follow the instructions on our [contributing guide](/CONTRIBUTING.md)
+please follow the instructions on our [contributing guide](CONTRIBUTING.md)
 for details on how to open issues, setup VMClarity for development and test.
 
 # Code of Conduct
 
-You can view our code of conduct [here](/CODE_OF_CONDUCT.md).
+You can view our code of conduct [here](CODE_OF_CONDUCT.md).
 
 # License
 
-[Apache License, Version 2.0](/LICENSE)
+[Apache License, Version 2.0](LICENSE)

--- a/docs/test_e2e.md
+++ b/docs/test_e2e.md
@@ -39,7 +39,7 @@ DOCKER_REGISTRY=<your docker registry> make push-docker
 
 ## Performing an end to end test
 
-1. Copy the example [scanConfig.json](/docs/scanConfig.json) into the ubuntu user's home directory
+1. Copy the example [scanConfig.json](scanConfig.json) into the ubuntu user's home directory
 
    ```
    scp scanConfig.json ubuntu@<ip address>:~/scanConfig.json


### PR DESCRIPTION
## Description

The contributing link is broken in the PR template as mentioned here: https://github.com/openclarity/vmclarity/issues/546

This PR is fixing this link to the correct one and remove some unnecessary slash from other docs.

## Type of Change

[ X ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ X ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ X ] Existing issues have been referenced (where applicable)
- [ X ] I have verified this change is not present in other open pull requests
- [ X ] Functionality is documented
- [ X ] All code style checks pass
- [ X ] New code contribution is covered by automated tests
- [ X ] All new and existing tests pass
