### PR TITLE
Downgrade the QueryPath log to debug level

### DIFF
--- a/pkg/apiserver/database/odatasql/query.go
+++ b/pkg/apiserver/database/odatasql/query.go
@@ -710,7 +710,7 @@ func buildWhereFromLambda(sqlVariant jsonsql.Variant, schemaMetas map[string]Sch
 }
 
 func sourceFromQueryPath(sqlVariant jsonsql.Variant, schemaMetas map[string]SchemaMeta, field FieldMeta, identifier string, source string, queryPath string) (string, error) {
-	log.Infof("QueryPath: %s", queryPath)
+	log.Debugf("QueryPath: %s", queryPath)
 
 	// ODATA path that would be present if we were to $select the
 	// field being filtered


### PR DESCRIPTION
## Description

This PR downgrade the log level to debug in sourceFromQueryPath because it is too noisy in production enviroment as mentioned here: https://github.com/openclarity/vmclarity/issues/521
Otherwise for debugging this log can be useful and easier to search for the queryPath with cli tools like grep.

## Type of Change

[ X ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ X ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ X ] Existing issues have been referenced (where applicable)
- [ X ] I have verified this change is not present in other open pull requests
- [ X ] Functionality is documented
- [ X ] All code style checks pass
- [ X ] New code contribution is covered by automated tests
- [ X ] All new and existing tests pass
