### PR TITLE
scan estimation apiserver

### DIFF
--- a/api/client/client.gen.go
+++ b/api/client/client.gen.go
@@ -90,6 +90,27 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// GetAssetScanEstimations request
+	GetAssetScanEstimations(ctx context.Context, params *GetAssetScanEstimationsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostAssetScanEstimations request with any body
+	PostAssetScanEstimationsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostAssetScanEstimations(ctx context.Context, body PostAssetScanEstimationsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetAssetScanEstimationsAssetScanEstimationID request
+	GetAssetScanEstimationsAssetScanEstimationID(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *GetAssetScanEstimationsAssetScanEstimationIDParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PatchAssetScanEstimationsAssetScanEstimationID request with any body
+	PatchAssetScanEstimationsAssetScanEstimationIDWithBody(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PatchAssetScanEstimationsAssetScanEstimationID(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, body PatchAssetScanEstimationsAssetScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PutAssetScanEstimationsAssetScanEstimationID request with any body
+	PutAssetScanEstimationsAssetScanEstimationIDWithBody(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PutAssetScanEstimationsAssetScanEstimationID(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, body PutAssetScanEstimationsAssetScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetAssetScans request
 	GetAssetScans(ctx context.Context, params *GetAssetScansParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -186,6 +207,30 @@ type ClientInterface interface {
 
 	PutScanConfigsScanConfigID(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetScanEstimations request
+	GetScanEstimations(ctx context.Context, params *GetScanEstimationsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PostScanEstimations request with any body
+	PostScanEstimationsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PostScanEstimations(ctx context.Context, body PostScanEstimationsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteScanEstimationsScanEstimationID request
+	DeleteScanEstimationsScanEstimationID(ctx context.Context, scanEstimationID ScanEstimationID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetScanEstimationsScanEstimationID request
+	GetScanEstimationsScanEstimationID(ctx context.Context, scanEstimationID ScanEstimationID, params *GetScanEstimationsScanEstimationIDParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PatchScanEstimationsScanEstimationID request with any body
+	PatchScanEstimationsScanEstimationIDWithBody(ctx context.Context, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PatchScanEstimationsScanEstimationID(ctx context.Context, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, body PatchScanEstimationsScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// PutScanEstimationsScanEstimationID request with any body
+	PutScanEstimationsScanEstimationIDWithBody(ctx context.Context, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	PutScanEstimationsScanEstimationID(ctx context.Context, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, body PutScanEstimationsScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetScans request
 	GetScans(ctx context.Context, params *GetScansParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -209,6 +254,102 @@ type ClientInterface interface {
 	PutScansScanIDWithBody(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	PutScansScanID(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) GetAssetScanEstimations(ctx context.Context, params *GetAssetScanEstimationsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAssetScanEstimationsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAssetScanEstimationsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAssetScanEstimationsRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostAssetScanEstimations(ctx context.Context, body PostAssetScanEstimationsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostAssetScanEstimationsRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetAssetScanEstimationsAssetScanEstimationID(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *GetAssetScanEstimationsAssetScanEstimationIDParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetAssetScanEstimationsAssetScanEstimationIDRequest(c.Server, assetScanEstimationID, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PatchAssetScanEstimationsAssetScanEstimationIDWithBody(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchAssetScanEstimationsAssetScanEstimationIDRequestWithBody(c.Server, assetScanEstimationID, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PatchAssetScanEstimationsAssetScanEstimationID(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, body PatchAssetScanEstimationsAssetScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchAssetScanEstimationsAssetScanEstimationIDRequest(c.Server, assetScanEstimationID, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PutAssetScanEstimationsAssetScanEstimationIDWithBody(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutAssetScanEstimationsAssetScanEstimationIDRequestWithBody(c.Server, assetScanEstimationID, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PutAssetScanEstimationsAssetScanEstimationID(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, body PutAssetScanEstimationsAssetScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutAssetScanEstimationsAssetScanEstimationIDRequest(c.Server, assetScanEstimationID, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) GetAssetScans(ctx context.Context, params *GetAssetScansParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -643,6 +784,114 @@ func (c *Client) PutScanConfigsScanConfigID(ctx context.Context, scanConfigID Sc
 	return c.Client.Do(req)
 }
 
+func (c *Client) GetScanEstimations(ctx context.Context, params *GetScanEstimationsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetScanEstimationsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostScanEstimationsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostScanEstimationsRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PostScanEstimations(ctx context.Context, body PostScanEstimationsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPostScanEstimationsRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteScanEstimationsScanEstimationID(ctx context.Context, scanEstimationID ScanEstimationID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteScanEstimationsScanEstimationIDRequest(c.Server, scanEstimationID)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetScanEstimationsScanEstimationID(ctx context.Context, scanEstimationID ScanEstimationID, params *GetScanEstimationsScanEstimationIDParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetScanEstimationsScanEstimationIDRequest(c.Server, scanEstimationID, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PatchScanEstimationsScanEstimationIDWithBody(ctx context.Context, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchScanEstimationsScanEstimationIDRequestWithBody(c.Server, scanEstimationID, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PatchScanEstimationsScanEstimationID(ctx context.Context, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, body PatchScanEstimationsScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPatchScanEstimationsScanEstimationIDRequest(c.Server, scanEstimationID, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PutScanEstimationsScanEstimationIDWithBody(ctx context.Context, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutScanEstimationsScanEstimationIDRequestWithBody(c.Server, scanEstimationID, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) PutScanEstimationsScanEstimationID(ctx context.Context, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, body PutScanEstimationsScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewPutScanEstimationsScanEstimationIDRequest(c.Server, scanEstimationID, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetScans(ctx context.Context, params *GetScansParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetScansRequest(c.Server, params)
 	if err != nil {
@@ -749,6 +998,375 @@ func (c *Client) PutScansScanID(ctx context.Context, scanID ScanID, params *PutS
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewGetAssetScanEstimationsRequest generates requests for GetAssetScanEstimations
+func NewGetAssetScanEstimationsRequest(server string, params *GetAssetScanEstimationsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/assetScanEstimations")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.Filter != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$filter", runtime.ParamLocationQuery, *params.Filter); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Select != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$select", runtime.ParamLocationQuery, *params.Select); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Count != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$count", runtime.ParamLocationQuery, *params.Count); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Top != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$top", runtime.ParamLocationQuery, *params.Top); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Skip != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$skip", runtime.ParamLocationQuery, *params.Skip); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Expand != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$expand", runtime.ParamLocationQuery, *params.Expand); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.OrderBy != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$orderby", runtime.ParamLocationQuery, *params.OrderBy); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostAssetScanEstimationsRequest calls the generic PostAssetScanEstimations builder with application/json body
+func NewPostAssetScanEstimationsRequest(server string, body PostAssetScanEstimationsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostAssetScanEstimationsRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostAssetScanEstimationsRequestWithBody generates requests for PostAssetScanEstimations with any type of body
+func NewPostAssetScanEstimationsRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/assetScanEstimations")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewGetAssetScanEstimationsAssetScanEstimationIDRequest generates requests for GetAssetScanEstimationsAssetScanEstimationID
+func NewGetAssetScanEstimationsAssetScanEstimationIDRequest(server string, assetScanEstimationID AssetScanEstimationID, params *GetAssetScanEstimationsAssetScanEstimationIDParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "assetScanEstimationID", runtime.ParamLocationPath, assetScanEstimationID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/assetScanEstimations/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.Select != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$select", runtime.ParamLocationQuery, *params.Select); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Expand != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$expand", runtime.ParamLocationQuery, *params.Expand); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPatchAssetScanEstimationsAssetScanEstimationIDRequest calls the generic PatchAssetScanEstimationsAssetScanEstimationID builder with application/json body
+func NewPatchAssetScanEstimationsAssetScanEstimationIDRequest(server string, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, body PatchAssetScanEstimationsAssetScanEstimationIDJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPatchAssetScanEstimationsAssetScanEstimationIDRequestWithBody(server, assetScanEstimationID, params, "application/json", bodyReader)
+}
+
+// NewPatchAssetScanEstimationsAssetScanEstimationIDRequestWithBody generates requests for PatchAssetScanEstimationsAssetScanEstimationID with any type of body
+func NewPatchAssetScanEstimationsAssetScanEstimationIDRequestWithBody(server string, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "assetScanEstimationID", runtime.ParamLocationPath, assetScanEstimationID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/assetScanEstimations/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
+
+	return req, nil
+}
+
+// NewPutAssetScanEstimationsAssetScanEstimationIDRequest calls the generic PutAssetScanEstimationsAssetScanEstimationID builder with application/json body
+func NewPutAssetScanEstimationsAssetScanEstimationIDRequest(server string, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, body PutAssetScanEstimationsAssetScanEstimationIDJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPutAssetScanEstimationsAssetScanEstimationIDRequestWithBody(server, assetScanEstimationID, params, "application/json", bodyReader)
+}
+
+// NewPutAssetScanEstimationsAssetScanEstimationIDRequestWithBody generates requests for PutAssetScanEstimationsAssetScanEstimationID with any type of body
+func NewPutAssetScanEstimationsAssetScanEstimationIDRequestWithBody(server string, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "assetScanEstimationID", runtime.ParamLocationPath, assetScanEstimationID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/assetScanEstimations/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
+
+	return req, nil
 }
 
 // NewGetAssetScansRequest generates requests for GetAssetScans
@@ -2334,6 +2952,409 @@ func NewPutScanConfigsScanConfigIDRequestWithBody(server string, scanConfigID Sc
 	return req, nil
 }
 
+// NewGetScanEstimationsRequest generates requests for GetScanEstimations
+func NewGetScanEstimationsRequest(server string, params *GetScanEstimationsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/scanEstimations")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.Filter != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$filter", runtime.ParamLocationQuery, *params.Filter); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Select != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$select", runtime.ParamLocationQuery, *params.Select); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Count != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$count", runtime.ParamLocationQuery, *params.Count); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Top != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$top", runtime.ParamLocationQuery, *params.Top); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Skip != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$skip", runtime.ParamLocationQuery, *params.Skip); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Expand != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$expand", runtime.ParamLocationQuery, *params.Expand); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.OrderBy != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$orderby", runtime.ParamLocationQuery, *params.OrderBy); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPostScanEstimationsRequest calls the generic PostScanEstimations builder with application/json body
+func NewPostScanEstimationsRequest(server string, body PostScanEstimationsJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPostScanEstimationsRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewPostScanEstimationsRequestWithBody generates requests for PostScanEstimations with any type of body
+func NewPostScanEstimationsRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/scanEstimations")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteScanEstimationsScanEstimationIDRequest generates requests for DeleteScanEstimationsScanEstimationID
+func NewDeleteScanEstimationsScanEstimationIDRequest(server string, scanEstimationID ScanEstimationID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scanEstimationID", runtime.ParamLocationPath, scanEstimationID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/scanEstimations/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetScanEstimationsScanEstimationIDRequest generates requests for GetScanEstimationsScanEstimationID
+func NewGetScanEstimationsScanEstimationIDRequest(server string, scanEstimationID ScanEstimationID, params *GetScanEstimationsScanEstimationIDParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scanEstimationID", runtime.ParamLocationPath, scanEstimationID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/scanEstimations/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.Select != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$select", runtime.ParamLocationQuery, *params.Select); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Expand != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "$expand", runtime.ParamLocationQuery, *params.Expand); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewPatchScanEstimationsScanEstimationIDRequest calls the generic PatchScanEstimationsScanEstimationID builder with application/json body
+func NewPatchScanEstimationsScanEstimationIDRequest(server string, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, body PatchScanEstimationsScanEstimationIDJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPatchScanEstimationsScanEstimationIDRequestWithBody(server, scanEstimationID, params, "application/json", bodyReader)
+}
+
+// NewPatchScanEstimationsScanEstimationIDRequestWithBody generates requests for PatchScanEstimationsScanEstimationID with any type of body
+func NewPatchScanEstimationsScanEstimationIDRequestWithBody(server string, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scanEstimationID", runtime.ParamLocationPath, scanEstimationID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/scanEstimations/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
+
+	return req, nil
+}
+
+// NewPutScanEstimationsScanEstimationIDRequest calls the generic PutScanEstimationsScanEstimationID builder with application/json body
+func NewPutScanEstimationsScanEstimationIDRequest(server string, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, body PutScanEstimationsScanEstimationIDJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewPutScanEstimationsScanEstimationIDRequestWithBody(server, scanEstimationID, params, "application/json", bodyReader)
+}
+
+// NewPutScanEstimationsScanEstimationIDRequestWithBody generates requests for PutScanEstimationsScanEstimationID with any type of body
+func NewPutScanEstimationsScanEstimationIDRequestWithBody(server string, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scanEstimationID", runtime.ParamLocationPath, scanEstimationID)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/scanEstimations/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	if params.IfMatch != nil {
+		var headerParam0 string
+
+		headerParam0, err = runtime.StyleParamWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, *params.IfMatch)
+		if err != nil {
+			return nil, err
+		}
+
+		req.Header.Set("If-Match", headerParam0)
+	}
+
+	return req, nil
+}
+
 // NewGetScansRequest generates requests for GetScans
 func NewGetScansRequest(server string, params *GetScansParams) (*http.Request, error) {
 	var err error
@@ -2780,6 +3801,27 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// GetAssetScanEstimations request
+	GetAssetScanEstimationsWithResponse(ctx context.Context, params *GetAssetScanEstimationsParams, reqEditors ...RequestEditorFn) (*GetAssetScanEstimationsResponse, error)
+
+	// PostAssetScanEstimations request with any body
+	PostAssetScanEstimationsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAssetScanEstimationsResponse, error)
+
+	PostAssetScanEstimationsWithResponse(ctx context.Context, body PostAssetScanEstimationsJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAssetScanEstimationsResponse, error)
+
+	// GetAssetScanEstimationsAssetScanEstimationID request
+	GetAssetScanEstimationsAssetScanEstimationIDWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *GetAssetScanEstimationsAssetScanEstimationIDParams, reqEditors ...RequestEditorFn) (*GetAssetScanEstimationsAssetScanEstimationIDResponse, error)
+
+	// PatchAssetScanEstimationsAssetScanEstimationID request with any body
+	PatchAssetScanEstimationsAssetScanEstimationIDWithBodyWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchAssetScanEstimationsAssetScanEstimationIDResponse, error)
+
+	PatchAssetScanEstimationsAssetScanEstimationIDWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, body PatchAssetScanEstimationsAssetScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchAssetScanEstimationsAssetScanEstimationIDResponse, error)
+
+	// PutAssetScanEstimationsAssetScanEstimationID request with any body
+	PutAssetScanEstimationsAssetScanEstimationIDWithBodyWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutAssetScanEstimationsAssetScanEstimationIDResponse, error)
+
+	PutAssetScanEstimationsAssetScanEstimationIDWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, body PutAssetScanEstimationsAssetScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutAssetScanEstimationsAssetScanEstimationIDResponse, error)
+
 	// GetAssetScans request
 	GetAssetScansWithResponse(ctx context.Context, params *GetAssetScansParams, reqEditors ...RequestEditorFn) (*GetAssetScansResponse, error)
 
@@ -2876,6 +3918,30 @@ type ClientWithResponsesInterface interface {
 
 	PutScanConfigsScanConfigIDWithResponse(ctx context.Context, scanConfigID ScanConfigID, params *PutScanConfigsScanConfigIDParams, body PutScanConfigsScanConfigIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanConfigsScanConfigIDResponse, error)
 
+	// GetScanEstimations request
+	GetScanEstimationsWithResponse(ctx context.Context, params *GetScanEstimationsParams, reqEditors ...RequestEditorFn) (*GetScanEstimationsResponse, error)
+
+	// PostScanEstimations request with any body
+	PostScanEstimationsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostScanEstimationsResponse, error)
+
+	PostScanEstimationsWithResponse(ctx context.Context, body PostScanEstimationsJSONRequestBody, reqEditors ...RequestEditorFn) (*PostScanEstimationsResponse, error)
+
+	// DeleteScanEstimationsScanEstimationID request
+	DeleteScanEstimationsScanEstimationIDWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, reqEditors ...RequestEditorFn) (*DeleteScanEstimationsScanEstimationIDResponse, error)
+
+	// GetScanEstimationsScanEstimationID request
+	GetScanEstimationsScanEstimationIDWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *GetScanEstimationsScanEstimationIDParams, reqEditors ...RequestEditorFn) (*GetScanEstimationsScanEstimationIDResponse, error)
+
+	// PatchScanEstimationsScanEstimationID request with any body
+	PatchScanEstimationsScanEstimationIDWithBodyWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanEstimationsScanEstimationIDResponse, error)
+
+	PatchScanEstimationsScanEstimationIDWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, body PatchScanEstimationsScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanEstimationsScanEstimationIDResponse, error)
+
+	// PutScanEstimationsScanEstimationID request with any body
+	PutScanEstimationsScanEstimationIDWithBodyWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanEstimationsScanEstimationIDResponse, error)
+
+	PutScanEstimationsScanEstimationIDWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, body PutScanEstimationsScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanEstimationsScanEstimationIDResponse, error)
+
 	// GetScans request
 	GetScansWithResponse(ctx context.Context, params *GetScansParams, reqEditors ...RequestEditorFn) (*GetScansResponse, error)
 
@@ -2899,6 +3965,132 @@ type ClientWithResponsesInterface interface {
 	PutScansScanIDWithBodyWithResponse(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error)
 
 	PutScansScanIDWithResponse(ctx context.Context, scanID ScanID, params *PutScansScanIDParams, body PutScansScanIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScansScanIDResponse, error)
+}
+
+type GetAssetScanEstimationsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AssetScanEstimations
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAssetScanEstimationsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAssetScanEstimationsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostAssetScanEstimationsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *AssetScanEstimation
+	JSON400      *ApiResponse
+	JSON409      *AssetScanEstimationExists
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r PostAssetScanEstimationsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostAssetScanEstimationsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetAssetScanEstimationsAssetScanEstimationIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AssetScanEstimation
+	JSON404      *ApiResponse
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetAssetScanEstimationsAssetScanEstimationIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetAssetScanEstimationsAssetScanEstimationIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PatchAssetScanEstimationsAssetScanEstimationIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AssetScanEstimation
+	JSON400      *ApiResponse
+	JSON404      *ApiResponse
+	JSON409      *AssetScanEstimationExists
+	JSON412      *ApiResponse
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r PatchAssetScanEstimationsAssetScanEstimationIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PatchAssetScanEstimationsAssetScanEstimationIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PutAssetScanEstimationsAssetScanEstimationIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AssetScanEstimation
+	JSON400      *ApiResponse
+	JSON404      *ApiResponse
+	JSON409      *AssetScanEstimationExists
+	JSON412      *ApiResponse
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r PutAssetScanEstimationsAssetScanEstimationIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PutAssetScanEstimationsAssetScanEstimationIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
 }
 
 type GetAssetScansResponse struct {
@@ -3496,6 +4688,156 @@ func (r PutScanConfigsScanConfigIDResponse) StatusCode() int {
 	return 0
 }
 
+type GetScanEstimationsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ScanEstimations
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetScanEstimationsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetScanEstimationsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PostScanEstimationsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *ScanEstimation
+	JSON400      *ApiResponse
+	JSON409      *ScanEstimationExists
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r PostScanEstimationsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PostScanEstimationsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteScanEstimationsScanEstimationIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *SuccessResponse
+	JSON404      *ApiResponse
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteScanEstimationsScanEstimationIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteScanEstimationsScanEstimationIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type GetScanEstimationsScanEstimationIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ScanEstimation
+	JSON404      *ApiResponse
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetScanEstimationsScanEstimationIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetScanEstimationsScanEstimationIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PatchScanEstimationsScanEstimationIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ScanEstimation
+	JSON400      *ApiResponse
+	JSON404      *ApiResponse
+	JSON409      *ScanEstimationExists
+	JSON412      *ApiResponse
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r PatchScanEstimationsScanEstimationIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PatchScanEstimationsScanEstimationIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type PutScanEstimationsScanEstimationIDResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ScanEstimation
+	JSON400      *ApiResponse
+	JSON404      *ApiResponse
+	JSON409      *ScanEstimationExists
+	JSON412      *ApiResponse
+	JSONDefault  *ApiResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r PutScanEstimationsScanEstimationIDResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r PutScanEstimationsScanEstimationIDResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetScansResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -3644,6 +4986,75 @@ func (r PutScansScanIDResponse) StatusCode() int {
 		return r.HTTPResponse.StatusCode
 	}
 	return 0
+}
+
+// GetAssetScanEstimationsWithResponse request returning *GetAssetScanEstimationsResponse
+func (c *ClientWithResponses) GetAssetScanEstimationsWithResponse(ctx context.Context, params *GetAssetScanEstimationsParams, reqEditors ...RequestEditorFn) (*GetAssetScanEstimationsResponse, error) {
+	rsp, err := c.GetAssetScanEstimations(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAssetScanEstimationsResponse(rsp)
+}
+
+// PostAssetScanEstimationsWithBodyWithResponse request with arbitrary body returning *PostAssetScanEstimationsResponse
+func (c *ClientWithResponses) PostAssetScanEstimationsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostAssetScanEstimationsResponse, error) {
+	rsp, err := c.PostAssetScanEstimationsWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAssetScanEstimationsResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostAssetScanEstimationsWithResponse(ctx context.Context, body PostAssetScanEstimationsJSONRequestBody, reqEditors ...RequestEditorFn) (*PostAssetScanEstimationsResponse, error) {
+	rsp, err := c.PostAssetScanEstimations(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostAssetScanEstimationsResponse(rsp)
+}
+
+// GetAssetScanEstimationsAssetScanEstimationIDWithResponse request returning *GetAssetScanEstimationsAssetScanEstimationIDResponse
+func (c *ClientWithResponses) GetAssetScanEstimationsAssetScanEstimationIDWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *GetAssetScanEstimationsAssetScanEstimationIDParams, reqEditors ...RequestEditorFn) (*GetAssetScanEstimationsAssetScanEstimationIDResponse, error) {
+	rsp, err := c.GetAssetScanEstimationsAssetScanEstimationID(ctx, assetScanEstimationID, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetAssetScanEstimationsAssetScanEstimationIDResponse(rsp)
+}
+
+// PatchAssetScanEstimationsAssetScanEstimationIDWithBodyWithResponse request with arbitrary body returning *PatchAssetScanEstimationsAssetScanEstimationIDResponse
+func (c *ClientWithResponses) PatchAssetScanEstimationsAssetScanEstimationIDWithBodyWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchAssetScanEstimationsAssetScanEstimationIDResponse, error) {
+	rsp, err := c.PatchAssetScanEstimationsAssetScanEstimationIDWithBody(ctx, assetScanEstimationID, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePatchAssetScanEstimationsAssetScanEstimationIDResponse(rsp)
+}
+
+func (c *ClientWithResponses) PatchAssetScanEstimationsAssetScanEstimationIDWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PatchAssetScanEstimationsAssetScanEstimationIDParams, body PatchAssetScanEstimationsAssetScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchAssetScanEstimationsAssetScanEstimationIDResponse, error) {
+	rsp, err := c.PatchAssetScanEstimationsAssetScanEstimationID(ctx, assetScanEstimationID, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePatchAssetScanEstimationsAssetScanEstimationIDResponse(rsp)
+}
+
+// PutAssetScanEstimationsAssetScanEstimationIDWithBodyWithResponse request with arbitrary body returning *PutAssetScanEstimationsAssetScanEstimationIDResponse
+func (c *ClientWithResponses) PutAssetScanEstimationsAssetScanEstimationIDWithBodyWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutAssetScanEstimationsAssetScanEstimationIDResponse, error) {
+	rsp, err := c.PutAssetScanEstimationsAssetScanEstimationIDWithBody(ctx, assetScanEstimationID, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutAssetScanEstimationsAssetScanEstimationIDResponse(rsp)
+}
+
+func (c *ClientWithResponses) PutAssetScanEstimationsAssetScanEstimationIDWithResponse(ctx context.Context, assetScanEstimationID AssetScanEstimationID, params *PutAssetScanEstimationsAssetScanEstimationIDParams, body PutAssetScanEstimationsAssetScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutAssetScanEstimationsAssetScanEstimationIDResponse, error) {
+	rsp, err := c.PutAssetScanEstimationsAssetScanEstimationID(ctx, assetScanEstimationID, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutAssetScanEstimationsAssetScanEstimationIDResponse(rsp)
 }
 
 // GetAssetScansWithResponse request returning *GetAssetScansResponse
@@ -3958,6 +5369,84 @@ func (c *ClientWithResponses) PutScanConfigsScanConfigIDWithResponse(ctx context
 	return ParsePutScanConfigsScanConfigIDResponse(rsp)
 }
 
+// GetScanEstimationsWithResponse request returning *GetScanEstimationsResponse
+func (c *ClientWithResponses) GetScanEstimationsWithResponse(ctx context.Context, params *GetScanEstimationsParams, reqEditors ...RequestEditorFn) (*GetScanEstimationsResponse, error) {
+	rsp, err := c.GetScanEstimations(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetScanEstimationsResponse(rsp)
+}
+
+// PostScanEstimationsWithBodyWithResponse request with arbitrary body returning *PostScanEstimationsResponse
+func (c *ClientWithResponses) PostScanEstimationsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PostScanEstimationsResponse, error) {
+	rsp, err := c.PostScanEstimationsWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostScanEstimationsResponse(rsp)
+}
+
+func (c *ClientWithResponses) PostScanEstimationsWithResponse(ctx context.Context, body PostScanEstimationsJSONRequestBody, reqEditors ...RequestEditorFn) (*PostScanEstimationsResponse, error) {
+	rsp, err := c.PostScanEstimations(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePostScanEstimationsResponse(rsp)
+}
+
+// DeleteScanEstimationsScanEstimationIDWithResponse request returning *DeleteScanEstimationsScanEstimationIDResponse
+func (c *ClientWithResponses) DeleteScanEstimationsScanEstimationIDWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, reqEditors ...RequestEditorFn) (*DeleteScanEstimationsScanEstimationIDResponse, error) {
+	rsp, err := c.DeleteScanEstimationsScanEstimationID(ctx, scanEstimationID, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteScanEstimationsScanEstimationIDResponse(rsp)
+}
+
+// GetScanEstimationsScanEstimationIDWithResponse request returning *GetScanEstimationsScanEstimationIDResponse
+func (c *ClientWithResponses) GetScanEstimationsScanEstimationIDWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *GetScanEstimationsScanEstimationIDParams, reqEditors ...RequestEditorFn) (*GetScanEstimationsScanEstimationIDResponse, error) {
+	rsp, err := c.GetScanEstimationsScanEstimationID(ctx, scanEstimationID, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetScanEstimationsScanEstimationIDResponse(rsp)
+}
+
+// PatchScanEstimationsScanEstimationIDWithBodyWithResponse request with arbitrary body returning *PatchScanEstimationsScanEstimationIDResponse
+func (c *ClientWithResponses) PatchScanEstimationsScanEstimationIDWithBodyWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PatchScanEstimationsScanEstimationIDResponse, error) {
+	rsp, err := c.PatchScanEstimationsScanEstimationIDWithBody(ctx, scanEstimationID, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePatchScanEstimationsScanEstimationIDResponse(rsp)
+}
+
+func (c *ClientWithResponses) PatchScanEstimationsScanEstimationIDWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *PatchScanEstimationsScanEstimationIDParams, body PatchScanEstimationsScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PatchScanEstimationsScanEstimationIDResponse, error) {
+	rsp, err := c.PatchScanEstimationsScanEstimationID(ctx, scanEstimationID, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePatchScanEstimationsScanEstimationIDResponse(rsp)
+}
+
+// PutScanEstimationsScanEstimationIDWithBodyWithResponse request with arbitrary body returning *PutScanEstimationsScanEstimationIDResponse
+func (c *ClientWithResponses) PutScanEstimationsScanEstimationIDWithBodyWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*PutScanEstimationsScanEstimationIDResponse, error) {
+	rsp, err := c.PutScanEstimationsScanEstimationIDWithBody(ctx, scanEstimationID, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutScanEstimationsScanEstimationIDResponse(rsp)
+}
+
+func (c *ClientWithResponses) PutScanEstimationsScanEstimationIDWithResponse(ctx context.Context, scanEstimationID ScanEstimationID, params *PutScanEstimationsScanEstimationIDParams, body PutScanEstimationsScanEstimationIDJSONRequestBody, reqEditors ...RequestEditorFn) (*PutScanEstimationsScanEstimationIDResponse, error) {
+	rsp, err := c.PutScanEstimationsScanEstimationID(ctx, scanEstimationID, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePutScanEstimationsScanEstimationIDResponse(rsp)
+}
+
 // GetScansWithResponse request returning *GetScansResponse
 func (c *ClientWithResponses) GetScansWithResponse(ctx context.Context, params *GetScansParams, reqEditors ...RequestEditorFn) (*GetScansResponse, error) {
 	rsp, err := c.GetScans(ctx, params, reqEditors...)
@@ -4034,6 +5523,248 @@ func (c *ClientWithResponses) PutScansScanIDWithResponse(ctx context.Context, sc
 		return nil, err
 	}
 	return ParsePutScansScanIDResponse(rsp)
+}
+
+// ParseGetAssetScanEstimationsResponse parses an HTTP response from a GetAssetScanEstimationsWithResponse call
+func ParseGetAssetScanEstimationsResponse(rsp *http.Response) (*GetAssetScanEstimationsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAssetScanEstimationsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AssetScanEstimations
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostAssetScanEstimationsResponse parses an HTTP response from a PostAssetScanEstimationsWithResponse call
+func ParsePostAssetScanEstimationsResponse(rsp *http.Response) (*PostAssetScanEstimationsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostAssetScanEstimationsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest AssetScanEstimation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest AssetScanEstimationExists
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetAssetScanEstimationsAssetScanEstimationIDResponse parses an HTTP response from a GetAssetScanEstimationsAssetScanEstimationIDWithResponse call
+func ParseGetAssetScanEstimationsAssetScanEstimationIDResponse(rsp *http.Response) (*GetAssetScanEstimationsAssetScanEstimationIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetAssetScanEstimationsAssetScanEstimationIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AssetScanEstimation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePatchAssetScanEstimationsAssetScanEstimationIDResponse parses an HTTP response from a PatchAssetScanEstimationsAssetScanEstimationIDWithResponse call
+func ParsePatchAssetScanEstimationsAssetScanEstimationIDResponse(rsp *http.Response) (*PatchAssetScanEstimationsAssetScanEstimationIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PatchAssetScanEstimationsAssetScanEstimationIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AssetScanEstimation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest AssetScanEstimationExists
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePutAssetScanEstimationsAssetScanEstimationIDResponse parses an HTTP response from a PutAssetScanEstimationsAssetScanEstimationIDWithResponse call
+func ParsePutAssetScanEstimationsAssetScanEstimationIDResponse(rsp *http.Response) (*PutAssetScanEstimationsAssetScanEstimationIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PutAssetScanEstimationsAssetScanEstimationIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AssetScanEstimation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest AssetScanEstimationExists
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseGetAssetScansResponse parses an HTTP response from a GetAssetScansWithResponse call
@@ -5105,6 +6836,288 @@ func ParsePutScanConfigsScanConfigIDResponse(rsp *http.Response) (*PutScanConfig
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
 		var dest ScanConfigExists
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetScanEstimationsResponse parses an HTTP response from a GetScanEstimationsWithResponse call
+func ParseGetScanEstimationsResponse(rsp *http.Response) (*GetScanEstimationsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetScanEstimationsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ScanEstimations
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePostScanEstimationsResponse parses an HTTP response from a PostScanEstimationsWithResponse call
+func ParsePostScanEstimationsResponse(rsp *http.Response) (*PostScanEstimationsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PostScanEstimationsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest ScanEstimation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ScanEstimationExists
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteScanEstimationsScanEstimationIDResponse parses an HTTP response from a DeleteScanEstimationsScanEstimationIDWithResponse call
+func ParseDeleteScanEstimationsScanEstimationIDResponse(rsp *http.Response) (*DeleteScanEstimationsScanEstimationIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteScanEstimationsScanEstimationIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest SuccessResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetScanEstimationsScanEstimationIDResponse parses an HTTP response from a GetScanEstimationsScanEstimationIDWithResponse call
+func ParseGetScanEstimationsScanEstimationIDResponse(rsp *http.Response) (*GetScanEstimationsScanEstimationIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetScanEstimationsScanEstimationIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ScanEstimation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePatchScanEstimationsScanEstimationIDResponse parses an HTTP response from a PatchScanEstimationsScanEstimationIDWithResponse call
+func ParsePatchScanEstimationsScanEstimationIDResponse(rsp *http.Response) (*PatchScanEstimationsScanEstimationIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PatchScanEstimationsScanEstimationIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ScanEstimation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ScanEstimationExists
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 412:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON412 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && true:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSONDefault = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParsePutScanEstimationsScanEstimationIDResponse parses an HTTP response from a PutScanEstimationsScanEstimationIDWithResponse call
+func ParsePutScanEstimationsScanEstimationIDResponse(rsp *http.Response) (*PutScanEstimationsScanEstimationIDResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &PutScanEstimationsScanEstimationIDResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ScanEstimation
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ScanEstimationExists
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/api/models/models.gen.go
+++ b/api/models/models.gen.go
@@ -11,6 +11,14 @@ import (
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
 )
 
+// Defines values for AssetScanEstimationStateState.
+const (
+	AssetScanEstimationStateStateAborted AssetScanEstimationStateState = "Aborted"
+	AssetScanEstimationStateStateDone    AssetScanEstimationStateState = "Done"
+	AssetScanEstimationStateStateFailed  AssetScanEstimationStateState = "Failed"
+	AssetScanEstimationStateStatePending AssetScanEstimationStateState = "Pending"
+)
+
 // Defines values for AssetScanStateState.
 const (
 	AssetScanStateStateAborted     AssetScanStateState = "Aborted"
@@ -81,6 +89,27 @@ const (
 	ScanStateReasonSuccess                    ScanStateReason = "Success"
 	ScanStateReasonTimedOut                   ScanStateReason = "TimedOut"
 	ScanStateReasonUnexpected                 ScanStateReason = "Unexpected"
+)
+
+// Defines values for ScanEstimationState.
+const (
+	ScanEstimationStateAborted    ScanEstimationState = "Aborted"
+	ScanEstimationStateDiscovered ScanEstimationState = "Discovered"
+	ScanEstimationStateDone       ScanEstimationState = "Done"
+	ScanEstimationStateFailed     ScanEstimationState = "Failed"
+	ScanEstimationStateInProgress ScanEstimationState = "InProgress"
+	ScanEstimationStatePending    ScanEstimationState = "Pending"
+)
+
+// Defines values for ScanEstimationStateReason.
+const (
+	ScanEstimationStateReasonAborted                        ScanEstimationStateReason = "Aborted"
+	ScanEstimationStateReasonDiscoveryFailed                ScanEstimationStateReason = "DiscoveryFailed"
+	ScanEstimationStateReasonNothingToEstimate              ScanEstimationStateReason = "NothingToEstimate"
+	ScanEstimationStateReasonOneOrMoreAssetFailedToEstimate ScanEstimationStateReason = "OneOrMoreAssetFailedToEstimate"
+	ScanEstimationStateReasonSuccess                        ScanEstimationStateReason = "Success"
+	ScanEstimationStateReasonTimedOut                       ScanEstimationStateReason = "TimedOut"
+	ScanEstimationStateReasonUnexpected                     ScanEstimationStateReason = "Unexpected"
 )
 
 // Defines values for ScanRelationshipState.
@@ -202,6 +231,45 @@ type AssetScan struct {
 	// Summary A summary of the scan findings.
 	Summary         *ScanFindingsSummary `json:"summary,omitempty"`
 	Vulnerabilities *VulnerabilityScan   `json:"vulnerabilities,omitempty"`
+}
+
+// AssetScanEstimation defines model for AssetScanEstimation.
+type AssetScanEstimation struct {
+	// Asset Describes an asset object.
+	Asset             *Asset                          `json:"asset,omitempty"`
+	AssetScanTemplate *AssetScanTemplate              `json:"assetScanTemplate,omitempty"`
+	Estimation        *Estimation                     `json:"estimation,omitempty"`
+	Id                *string                         `json:"id,omitempty"`
+	Revision          *int                            `json:"revision,omitempty"`
+	ScanEstimation    *ScanEstimationFakeRelationship `json:"scanEstimation,omitempty"`
+	State             *AssetScanEstimationState       `json:"state,omitempty"`
+}
+
+// AssetScanEstimationExists defines model for AssetScanEstimationExists.
+type AssetScanEstimationExists struct {
+	AssetScanEstimation *AssetScanEstimation `json:"assetScanEstimation,omitempty"`
+
+	// Message Describes which unique constraint combination causes the conflict.
+	Message *string `json:"message,omitempty"`
+}
+
+// AssetScanEstimationState defines model for AssetScanEstimationState.
+type AssetScanEstimationState struct {
+	Errors             *[]string                      `json:"errors"`
+	LastTransitionTime *time.Time                     `json:"lastTransitionTime,omitempty"`
+	State              *AssetScanEstimationStateState `json:"state,omitempty"`
+}
+
+// AssetScanEstimationStateState defines model for AssetScanEstimationState.State.
+type AssetScanEstimationStateState string
+
+// AssetScanEstimations defines model for AssetScanEstimations.
+type AssetScanEstimations struct {
+	// Count Total AssetScanEstimations count according to the given filters
+	Count *int `json:"count,omitempty"`
+
+	// Items List of AssetScanEstimations according to the given filters
+	Items *[]AssetScanEstimation `json:"items,omitempty"`
 }
 
 // AssetScanExists defines model for AssetScanExists.
@@ -373,6 +441,18 @@ type DirInfo struct {
 	DirName    *string `json:"dirName,omitempty"`
 	Location   *string `json:"location,omitempty"`
 	ObjectType string  `json:"objectType"`
+}
+
+// Estimation defines model for Estimation.
+type Estimation struct {
+	// Cost Total cost of the scan ($)
+	Cost *float32 `json:"cost,omitempty"`
+
+	// Size Total size of the scan (GB)
+	Size *int `json:"size,omitempty"`
+
+	// Time Total time the scan will take (seconds)
+	Time *int `json:"time,omitempty"`
 }
 
 // Exploit defines model for Exploit.
@@ -698,6 +778,61 @@ type ScanConfigs struct {
 
 	// Items List of scan configs according to the given filters and page. List length must be lower or equal to pageSize.
 	Items *[]ScanConfig `json:"items,omitempty"`
+}
+
+// ScanEstimation defines model for ScanEstimation.
+type ScanEstimation struct {
+	// AssetIDs List of asset IDs to be estimated
+	AssetIDs     *[]string     `json:"assetIDs"`
+	EndTime      *time.Time    `json:"endTime,omitempty"`
+	Estimation   *Estimation   `json:"estimation,omitempty"`
+	Id           *string       `json:"id,omitempty"`
+	Revision     *int          `json:"revision,omitempty"`
+	ScanTemplate *ScanTemplate `json:"scanTemplate,omitempty"`
+	StartTime    *time.Time    `json:"startTime,omitempty"`
+
+	// State The lifecycle state of this scan estimation.
+	State *ScanEstimationState `json:"state,omitempty"`
+
+	// StateMessage Human-readable message indicating details about the last state transition.
+	StateMessage *string `json:"stateMessage,omitempty"`
+
+	// StateReason Machine-readable, UpperCamelCase text indicating the reason for the condition's last transition.
+	StateReason *ScanEstimationStateReason `json:"stateReason,omitempty"`
+	Summary     *ScanEstimationSummary     `json:"summary,omitempty"`
+}
+
+// ScanEstimationState The lifecycle state of this scan estimation.
+type ScanEstimationState string
+
+// ScanEstimationStateReason Machine-readable, UpperCamelCase text indicating the reason for the condition's last transition.
+type ScanEstimationStateReason string
+
+// ScanEstimationExists defines model for ScanEstimationExists.
+type ScanEstimationExists struct {
+	// Message Describes which unique constraint combination causes the conflict.
+	Message        *string         `json:"message,omitempty"`
+	ScanEstimation *ScanEstimation `json:"scanEstimation,omitempty"`
+}
+
+// ScanEstimationFakeRelationship defines model for ScanEstimationFakeRelationship.
+type ScanEstimationFakeRelationship struct {
+	Id *string `json:"id,omitempty"`
+}
+
+// ScanEstimationSummary defines model for ScanEstimationSummary.
+type ScanEstimationSummary struct {
+	JobsCompleted *int `json:"jobsCompleted,omitempty"`
+	JobsLeftToRun *int `json:"jobsLeftToRun,omitempty"`
+}
+
+// ScanEstimations defines model for ScanEstimations.
+type ScanEstimations struct {
+	// Count Total ScanEstimations count according to the given filters
+	Count *int `json:"count,omitempty"`
+
+	// Items List of ScanEstimations according to the given filters
+	Items *[]ScanEstimation `json:"items,omitempty"`
 }
 
 // ScanExists defines model for ScanExists.
@@ -1037,6 +1172,9 @@ type VulnerabilitySeverity string
 // AssetID defines model for assetID.
 type AssetID = string
 
+// AssetScanEstimationID defines model for assetScanEstimationID.
+type AssetScanEstimationID = string
+
 // AssetScanID defines model for assetScanID.
 type AssetScanID = string
 
@@ -1070,6 +1208,9 @@ type OdataTop = int
 // ScanConfigID defines model for scanConfigID.
 type ScanConfigID = string
 
+// ScanEstimationID defines model for scanEstimationID.
+type ScanEstimationID = string
+
 // ScanID defines model for scanID.
 type ScanID = string
 
@@ -1078,6 +1219,33 @@ type Success = SuccessResponse
 
 // UnknownError An object that is returned in all cases of failures.
 type UnknownError = ApiResponse
+
+// GetAssetScanEstimationsParams defines parameters for GetAssetScanEstimations.
+type GetAssetScanEstimationsParams struct {
+	Filter  *OdataFilter `form:"$filter,omitempty" json:"$filter,omitempty"`
+	Select  *OdataSelect `form:"$select,omitempty" json:"$select,omitempty"`
+	Count   *OdataCount  `form:"$count,omitempty" json:"$count,omitempty"`
+	Top     *OdataTop    `form:"$top,omitempty" json:"$top,omitempty"`
+	Skip    *OdataSkip   `form:"$skip,omitempty" json:"$skip,omitempty"`
+	Expand  *OdataExpand `form:"$expand,omitempty" json:"$expand,omitempty"`
+	OrderBy *OrderBy     `form:"$orderby,omitempty" json:"$orderby,omitempty"`
+}
+
+// GetAssetScanEstimationsAssetScanEstimationIDParams defines parameters for GetAssetScanEstimationsAssetScanEstimationID.
+type GetAssetScanEstimationsAssetScanEstimationIDParams struct {
+	Select *OdataSelect `form:"$select,omitempty" json:"$select,omitempty"`
+	Expand *OdataExpand `form:"$expand,omitempty" json:"$expand,omitempty"`
+}
+
+// PatchAssetScanEstimationsAssetScanEstimationIDParams defines parameters for PatchAssetScanEstimationsAssetScanEstimationID.
+type PatchAssetScanEstimationsAssetScanEstimationIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
+
+// PutAssetScanEstimationsAssetScanEstimationIDParams defines parameters for PutAssetScanEstimationsAssetScanEstimationID.
+type PutAssetScanEstimationsAssetScanEstimationIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
 
 // GetAssetScansParams defines parameters for GetAssetScans.
 type GetAssetScansParams struct {
@@ -1177,6 +1345,33 @@ type PutScanConfigsScanConfigIDParams struct {
 	IfMatch *Ifmatch `json:"If-Match,omitempty"`
 }
 
+// GetScanEstimationsParams defines parameters for GetScanEstimations.
+type GetScanEstimationsParams struct {
+	Filter  *OdataFilter `form:"$filter,omitempty" json:"$filter,omitempty"`
+	Select  *OdataSelect `form:"$select,omitempty" json:"$select,omitempty"`
+	Count   *OdataCount  `form:"$count,omitempty" json:"$count,omitempty"`
+	Top     *OdataTop    `form:"$top,omitempty" json:"$top,omitempty"`
+	Skip    *OdataSkip   `form:"$skip,omitempty" json:"$skip,omitempty"`
+	Expand  *OdataExpand `form:"$expand,omitempty" json:"$expand,omitempty"`
+	OrderBy *OrderBy     `form:"$orderby,omitempty" json:"$orderby,omitempty"`
+}
+
+// GetScanEstimationsScanEstimationIDParams defines parameters for GetScanEstimationsScanEstimationID.
+type GetScanEstimationsScanEstimationIDParams struct {
+	Select *OdataSelect `form:"$select,omitempty" json:"$select,omitempty"`
+	Expand *OdataExpand `form:"$expand,omitempty" json:"$expand,omitempty"`
+}
+
+// PatchScanEstimationsScanEstimationIDParams defines parameters for PatchScanEstimationsScanEstimationID.
+type PatchScanEstimationsScanEstimationIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
+
+// PutScanEstimationsScanEstimationIDParams defines parameters for PutScanEstimationsScanEstimationID.
+type PutScanEstimationsScanEstimationIDParams struct {
+	IfMatch *Ifmatch `json:"If-Match,omitempty"`
+}
+
 // GetScansParams defines parameters for GetScans.
 type GetScansParams struct {
 	Filter  *OdataFilter `form:"$filter,omitempty" json:"$filter,omitempty"`
@@ -1203,6 +1398,15 @@ type PatchScansScanIDParams struct {
 type PutScansScanIDParams struct {
 	IfMatch *Ifmatch `json:"If-Match,omitempty"`
 }
+
+// PostAssetScanEstimationsJSONRequestBody defines body for PostAssetScanEstimations for application/json ContentType.
+type PostAssetScanEstimationsJSONRequestBody = AssetScanEstimation
+
+// PatchAssetScanEstimationsAssetScanEstimationIDJSONRequestBody defines body for PatchAssetScanEstimationsAssetScanEstimationID for application/json ContentType.
+type PatchAssetScanEstimationsAssetScanEstimationIDJSONRequestBody = AssetScanEstimation
+
+// PutAssetScanEstimationsAssetScanEstimationIDJSONRequestBody defines body for PutAssetScanEstimationsAssetScanEstimationID for application/json ContentType.
+type PutAssetScanEstimationsAssetScanEstimationIDJSONRequestBody = AssetScanEstimation
 
 // PostAssetScansJSONRequestBody defines body for PostAssetScans for application/json ContentType.
 type PostAssetScansJSONRequestBody = AssetScan
@@ -1239,6 +1443,15 @@ type PatchScanConfigsScanConfigIDJSONRequestBody = ScanConfig
 
 // PutScanConfigsScanConfigIDJSONRequestBody defines body for PutScanConfigsScanConfigID for application/json ContentType.
 type PutScanConfigsScanConfigIDJSONRequestBody = ScanConfig
+
+// PostScanEstimationsJSONRequestBody defines body for PostScanEstimations for application/json ContentType.
+type PostScanEstimationsJSONRequestBody = ScanEstimation
+
+// PatchScanEstimationsScanEstimationIDJSONRequestBody defines body for PatchScanEstimationsScanEstimationID for application/json ContentType.
+type PatchScanEstimationsScanEstimationIDJSONRequestBody = ScanEstimation
+
+// PutScanEstimationsScanEstimationIDJSONRequestBody defines body for PutScanEstimationsScanEstimationID for application/json ContentType.
+type PutScanEstimationsScanEstimationIDJSONRequestBody = ScanEstimation
 
 // PostScansJSONRequestBody defines body for PostScans for application/json ContentType.
 type PostScansJSONRequestBody = Scan

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -905,6 +905,361 @@ paths:
         default:
           $ref: '#/components/responses/UnknownError'
 
+  /scanEstimations:
+    get:
+      summary: Get all scans. Each scan estimation contains details about a multi-asset scan estimation.
+      operationId: GetScanEstimations
+      parameters:
+        - $ref: '#/components/parameters/odataFilter'
+        - $ref: '#/components/parameters/odataSelect'
+        - $ref: '#/components/parameters/odataCount'
+        - $ref: '#/components/parameters/odataTop'
+        - $ref: '#/components/parameters/odataSkip'
+        - $ref: '#/components/parameters/odataExpand'
+        - $ref: '#/components/parameters/odataOrderBy'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanEstimations'
+        default:
+          $ref: '#/components/responses/UnknownError'
+    post:
+      summary: Create a multi-asset scan estimation
+      operationId: PostScanEstimations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanEstimation'
+        required: true
+      responses:
+        201:
+          description: A new scan estimation was created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanEstimation'
+        400:
+          description: Invalid scan estimation supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        409:
+          description: Scan estimation already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanEstimationExists'
+        default:
+          $ref: '#/components/responses/UnknownError'
+      x-codegen-request-body-name: body
+
+  /scanEstimations/{scanEstimationID}:
+    get:
+      summary: Get the details for a given multi-asset scan estimation.
+      operationId: GetScanEstimationsScanEstimationID
+      parameters:
+        - $ref: '#/components/parameters/scanEstimationID'
+        - $ref: '#/components/parameters/odataSelect'
+        - $ref: '#/components/parameters/odataExpand'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanEstimation'
+        404:
+          description: Scan estimation ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        default:
+          $ref: '#/components/responses/UnknownError'
+    put:
+      summary: Update a scan estimation.
+      operationId: PutScanEstimationsScanEstimationID
+      parameters:
+        - $ref: '#/components/parameters/scanEstimationID'
+        - $ref: '#/components/parameters/ifmatch'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanEstimation'
+        required: true
+      responses:
+        200:
+          description: Updated scan estimation successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanEstimation'
+        400:
+          description: Invalid scan estimation supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        404:
+          description: Scan estimation ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        409:
+          description: Scan estimation already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanEstimationExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        default:
+          $ref: '#/components/responses/UnknownError'
+      x-codegen-request-body-name: body
+    patch:
+      summary: Patch a scan estimation.
+      operationId: PatchScanEstimationsScanEstimationID
+      parameters:
+        - $ref: '#/components/parameters/scanEstimationID'
+        - $ref: '#/components/parameters/ifmatch'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScanEstimation'
+        required: true
+      responses:
+        200:
+          description: Patched scan estimation successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanEstimation'
+        400:
+          description: Invalid scan estimation supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        404:
+          description: Scan estimation ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        409:
+          description: Scan estimation already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ScanEstimationExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        default:
+          $ref: '#/components/responses/UnknownError'
+      x-codegen-request-body-name: body
+    delete:
+      summary: Delete a scan estimation.
+      operationId: DeleteScanEstimationsScanEstimationID
+      parameters:
+        - $ref: '#/components/parameters/scanEstimationID'
+      responses:
+        200:
+          $ref: '#/components/responses/Success'
+        404:
+          description: Scan estimation ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        default:
+          $ref: '#/components/responses/UnknownError'
+
+  /assetScanEstimations:
+    get:
+      summary: Get asset scan estimations according to the given filters
+      operationId: GetAssetScanEstimations
+      parameters:
+        - $ref: '#/components/parameters/odataFilter'
+        - $ref: '#/components/parameters/odataSelect'
+        - $ref: '#/components/parameters/odataCount'
+        - $ref: '#/components/parameters/odataTop'
+        - $ref: '#/components/parameters/odataSkip'
+        - $ref: '#/components/parameters/odataExpand'
+        - $ref: '#/components/parameters/odataOrderBy'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetScanEstimations'
+
+        default:
+          $ref: '#/components/responses/UnknownError'
+    post:
+      summary: Create an asset scan estimation for a specified asset
+      operationId: PostAssetScanEstimations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetScanEstimation'
+        required: true
+      responses:
+        201:
+          description: AssetScanEstimation was created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetScanEstimation'
+        400:
+          description: Invalid asset scan estimation supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        409:
+          description: Conflicting asset scan estimation found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetScanEstimationExists'
+        default:
+          $ref: '#/components/responses/UnknownError'
+      x-codegen-request-body-name: body
+
+  /assetScanEstimations/{assetScanEstimationID}:
+    get:
+      summary: Get an asset scan stimation.
+      operationId: GetAssetScanEstimationsAssetScanEstimationID
+      parameters:
+        - $ref: '#/components/parameters/assetScanEstimationID'
+        - $ref: '#/components/parameters/odataSelect'
+        - $ref: '#/components/parameters/odataExpand'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetScanEstimation'
+        404:
+          description: AssetScanEstimation ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        default:
+          $ref: '#/components/responses/UnknownError'
+    put:
+      summary: Update an asset scan estimation.
+      operationId: PutAssetScanEstimationsAssetScanEstimationID
+      parameters:
+        - $ref: '#/components/parameters/assetScanEstimationID'
+        - $ref: '#/components/parameters/ifmatch'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetScanEstimation'
+        required: true
+      responses:
+        200:
+          description: Updated an asset scan estimation successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetScanEstimation'
+        400:
+          description: Invalid asset scan estimation supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        404:
+          description: AssetScanEstimation ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        409:
+          description: Conflicting asset scan estimation found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetScanEstimationExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        default:
+          $ref: '#/components/responses/UnknownError'
+      x-codegen-request-body-name: body
+    patch:
+      summary: Patch an asset scan estimation
+      operationId: PatchAssetScanEstimationsAssetScanEstimationID
+      parameters:
+        - $ref: '#/components/parameters/assetScanEstimationID'
+        - $ref: '#/components/parameters/ifmatch'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssetScanEstimation'
+        required: true
+      responses:
+        200:
+          description: Updated an asset scan estimation successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetScanEstimation'
+        400:
+          description: Invalid asset scan estimation supplied.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        404:
+          description: AssetScanEstimation ID not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        409:
+          description: Conflicting asset scan estimation found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AssetScanEstimationExists'
+        412:
+          description: Etag didn't match.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+        default:
+          $ref: '#/components/responses/UnknownError'
+      x-codegen-request-body-name: body
+
 components:
   schemas:
     ApiResponse:
@@ -1945,6 +2300,25 @@ components:
             type: string
           nullable: true
 
+    AssetScanEstimationState:
+      type: object
+      properties:
+        state:
+          type: string
+          enum:
+            - Pending
+            - Aborted
+            - Failed
+            - Done
+        lastTransitionTime:
+          type: string
+          format: date-time
+        errors:
+          type: array
+          items:
+            type: string
+          nullable: true
+
     Package:
       type: object
       properties:
@@ -2407,6 +2781,147 @@ components:
               Rootkit: '#/components/schemas/RootkitFindingInfo'
               Exploit: '#/components/schemas/ExploitFindingInfo'
 
+    ScanEstimations:
+      type: object
+      properties:
+        count:
+          description: Total ScanEstimations count according to the given filters
+          type: integer
+        items:
+          description: List of ScanEstimations according to the given filters
+          type: array
+          items:
+            $ref: '#/components/schemas/ScanEstimation'
+
+    ScanEstimation:
+      type: object
+      properties:
+        id:
+          type: string
+        assetIDs:
+          description: List of asset IDs to be estimated
+          type: array
+          items:
+            type: string
+          nullable: true
+        state:
+          description: The lifecycle state of this scan estimation.
+          type: string
+          enum:
+            - Pending
+            - Discovered
+            - InProgress
+            - Aborted
+            - Failed
+            - Done
+        stateMessage:
+          description: Human-readable message indicating details about the last state transition.
+          type: string
+        stateReason:
+          description: Machine-readable, UpperCamelCase text indicating the reason for the condition's last transition.
+          type: string
+          enum:
+            - Aborted
+            - TimedOut
+            - OneOrMoreAssetFailedToEstimate
+            - DiscoveryFailed
+            - Unexpected
+            - NothingToEstimate
+            - Success
+        startTime:
+          type: string
+          format: date-time
+        endTime:
+          type: string
+          format: date-time
+        estimation:
+          $ref: '#/components/schemas/Estimation'
+        scanTemplate:
+          $ref: '#/components/schemas/ScanTemplate'
+        summary:
+          $ref: '#/components/schemas/ScanEstimationSummary'
+        revision:
+          type: integer
+
+    ScanEstimationExists:
+      type: object
+      properties:
+        message:
+          description: Describes which unique constraint combination causes the conflict.
+          type: string
+          readOnly: true
+        scanEstimation:
+          $ref: '#/components/schemas/ScanEstimation'
+
+    Estimation:
+      type: object
+      properties:
+        time:
+          description: Total time the scan will take (seconds)
+          type: integer
+        size:
+          description: Total size of the scan (GB)
+          type: integer
+        cost:
+          description: Total cost of the scan ($)
+          type: number
+          format: float
+
+    AssetScanEstimations:
+      type: object
+      properties:
+        count:
+          description: Total AssetScanEstimations count according to the given filters
+          type: integer
+        items:
+          description: List of AssetScanEstimations according to the given filters
+          type: array
+          items:
+            $ref: '#/components/schemas/AssetScanEstimation'
+
+    ScanEstimationFakeRelationship:
+      type: object
+      properties:
+        id:
+          type: string
+
+    AssetScanEstimation:
+      type: object
+      properties:
+        id:
+          type: string
+        asset:
+          $ref: '#/components/schemas/Asset'
+        # TODO (erezf) replace with ScanEstimationRelationship object (?)
+        scanEstimation:
+          $ref: '#/components/schemas/ScanEstimationFakeRelationship'
+        state:
+          $ref: '#/components/schemas/AssetScanEstimationState'
+        estimation:
+          $ref: '#/components/schemas/Estimation'
+        assetScanTemplate:
+          $ref: '#/components/schemas/AssetScanTemplate'
+        revision:
+          type: integer
+
+    AssetScanEstimationExists:
+      type: object
+      properties:
+        message:
+          description: Describes which unique constraint combination causes the conflict.
+          type: string
+          readOnly: true
+        assetScanEstimation:
+          $ref: '#/components/schemas/AssetScanEstimation'
+
+    ScanEstimationSummary:
+      type: object
+      properties:
+        jobsLeftToRun:
+          type: integer
+        jobsCompleted:
+          type: integer
+
   responses:
     Success:
       description: Success message
@@ -2500,7 +3015,21 @@ components:
       required: true
       schema:
         type: string
-        
+
+    scanEstimationID:
+      name: scanEstimationID
+      in: path
+      required: true
+      schema:
+        type: string
+
+    assetScanEstimationID:
+      name: assetScanEstimationID
+      in: path
+      required: true
+      schema:
+        type: string
+
     ifmatch:
       name: If-Match
       in: header

--- a/api/server/server.gen.go
+++ b/api/server/server.gen.go
@@ -21,6 +21,21 @@ import (
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// Get asset scan estimations according to the given filters
+	// (GET /assetScanEstimations)
+	GetAssetScanEstimations(ctx echo.Context, params GetAssetScanEstimationsParams) error
+	// Create an asset scan estimation for a specified asset
+	// (POST /assetScanEstimations)
+	PostAssetScanEstimations(ctx echo.Context) error
+	// Get an asset scan stimation.
+	// (GET /assetScanEstimations/{assetScanEstimationID})
+	GetAssetScanEstimationsAssetScanEstimationID(ctx echo.Context, assetScanEstimationID AssetScanEstimationID, params GetAssetScanEstimationsAssetScanEstimationIDParams) error
+	// Patch an asset scan estimation
+	// (PATCH /assetScanEstimations/{assetScanEstimationID})
+	PatchAssetScanEstimationsAssetScanEstimationID(ctx echo.Context, assetScanEstimationID AssetScanEstimationID, params PatchAssetScanEstimationsAssetScanEstimationIDParams) error
+	// Update an asset scan estimation.
+	// (PUT /assetScanEstimations/{assetScanEstimationID})
+	PutAssetScanEstimationsAssetScanEstimationID(ctx echo.Context, assetScanEstimationID AssetScanEstimationID, params PutAssetScanEstimationsAssetScanEstimationIDParams) error
 	// Get asset scans according to the given filters
 	// (GET /assetScans)
 	GetAssetScans(ctx echo.Context, params GetAssetScansParams) error
@@ -93,6 +108,24 @@ type ServerInterface interface {
 	// Update a scan config.
 	// (PUT /scanConfigs/{scanConfigID})
 	PutScanConfigsScanConfigID(ctx echo.Context, scanConfigID ScanConfigID, params PutScanConfigsScanConfigIDParams) error
+	// Get all scans. Each scan estimation contains details about a multi-asset scan estimation.
+	// (GET /scanEstimations)
+	GetScanEstimations(ctx echo.Context, params GetScanEstimationsParams) error
+	// Create a multi-asset scan estimation
+	// (POST /scanEstimations)
+	PostScanEstimations(ctx echo.Context) error
+	// Delete a scan estimation.
+	// (DELETE /scanEstimations/{scanEstimationID})
+	DeleteScanEstimationsScanEstimationID(ctx echo.Context, scanEstimationID ScanEstimationID) error
+	// Get the details for a given multi-asset scan estimation.
+	// (GET /scanEstimations/{scanEstimationID})
+	GetScanEstimationsScanEstimationID(ctx echo.Context, scanEstimationID ScanEstimationID, params GetScanEstimationsScanEstimationIDParams) error
+	// Patch a scan estimation.
+	// (PATCH /scanEstimations/{scanEstimationID})
+	PatchScanEstimationsScanEstimationID(ctx echo.Context, scanEstimationID ScanEstimationID, params PatchScanEstimationsScanEstimationIDParams) error
+	// Update a scan estimation.
+	// (PUT /scanEstimations/{scanEstimationID})
+	PutScanEstimationsScanEstimationID(ctx echo.Context, scanEstimationID ScanEstimationID, params PutScanEstimationsScanEstimationIDParams) error
 	// Get all scans. Each scan contains details about a multi-asset scheduled scan.
 	// (GET /scans)
 	GetScans(ctx echo.Context, params GetScansParams) error
@@ -116,6 +149,179 @@ type ServerInterface interface {
 // ServerInterfaceWrapper converts echo contexts to parameters.
 type ServerInterfaceWrapper struct {
 	Handler ServerInterface
+}
+
+// GetAssetScanEstimations converts echo context to params.
+func (w *ServerInterfaceWrapper) GetAssetScanEstimations(ctx echo.Context) error {
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetAssetScanEstimationsParams
+	// ------------- Optional query parameter "$filter" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$filter", ctx.QueryParams(), &params.Filter)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $filter: %s", err))
+	}
+
+	// ------------- Optional query parameter "$select" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$select", ctx.QueryParams(), &params.Select)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $select: %s", err))
+	}
+
+	// ------------- Optional query parameter "$count" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$count", ctx.QueryParams(), &params.Count)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $count: %s", err))
+	}
+
+	// ------------- Optional query parameter "$top" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$top", ctx.QueryParams(), &params.Top)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $top: %s", err))
+	}
+
+	// ------------- Optional query parameter "$skip" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$skip", ctx.QueryParams(), &params.Skip)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $skip: %s", err))
+	}
+
+	// ------------- Optional query parameter "$expand" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$expand", ctx.QueryParams(), &params.Expand)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $expand: %s", err))
+	}
+
+	// ------------- Optional query parameter "$orderby" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$orderby", ctx.QueryParams(), &params.OrderBy)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $orderby: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetAssetScanEstimations(ctx, params)
+	return err
+}
+
+// PostAssetScanEstimations converts echo context to params.
+func (w *ServerInterfaceWrapper) PostAssetScanEstimations(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.PostAssetScanEstimations(ctx)
+	return err
+}
+
+// GetAssetScanEstimationsAssetScanEstimationID converts echo context to params.
+func (w *ServerInterfaceWrapper) GetAssetScanEstimationsAssetScanEstimationID(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "assetScanEstimationID" -------------
+	var assetScanEstimationID AssetScanEstimationID
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "assetScanEstimationID", runtime.ParamLocationPath, ctx.Param("assetScanEstimationID"), &assetScanEstimationID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter assetScanEstimationID: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetAssetScanEstimationsAssetScanEstimationIDParams
+	// ------------- Optional query parameter "$select" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$select", ctx.QueryParams(), &params.Select)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $select: %s", err))
+	}
+
+	// ------------- Optional query parameter "$expand" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$expand", ctx.QueryParams(), &params.Expand)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $expand: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetAssetScanEstimationsAssetScanEstimationID(ctx, assetScanEstimationID, params)
+	return err
+}
+
+// PatchAssetScanEstimationsAssetScanEstimationID converts echo context to params.
+func (w *ServerInterfaceWrapper) PatchAssetScanEstimationsAssetScanEstimationID(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "assetScanEstimationID" -------------
+	var assetScanEstimationID AssetScanEstimationID
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "assetScanEstimationID", runtime.ParamLocationPath, ctx.Param("assetScanEstimationID"), &assetScanEstimationID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter assetScanEstimationID: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PatchAssetScanEstimationsAssetScanEstimationIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.PatchAssetScanEstimationsAssetScanEstimationID(ctx, assetScanEstimationID, params)
+	return err
+}
+
+// PutAssetScanEstimationsAssetScanEstimationID converts echo context to params.
+func (w *ServerInterfaceWrapper) PutAssetScanEstimationsAssetScanEstimationID(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "assetScanEstimationID" -------------
+	var assetScanEstimationID AssetScanEstimationID
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "assetScanEstimationID", runtime.ParamLocationPath, ctx.Param("assetScanEstimationID"), &assetScanEstimationID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter assetScanEstimationID: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PutAssetScanEstimationsAssetScanEstimationIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.PutAssetScanEstimationsAssetScanEstimationID(ctx, assetScanEstimationID, params)
+	return err
 }
 
 // GetAssetScans converts echo context to params.
@@ -827,6 +1033,195 @@ func (w *ServerInterfaceWrapper) PutScanConfigsScanConfigID(ctx echo.Context) er
 	return err
 }
 
+// GetScanEstimations converts echo context to params.
+func (w *ServerInterfaceWrapper) GetScanEstimations(ctx echo.Context) error {
+	var err error
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetScanEstimationsParams
+	// ------------- Optional query parameter "$filter" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$filter", ctx.QueryParams(), &params.Filter)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $filter: %s", err))
+	}
+
+	// ------------- Optional query parameter "$select" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$select", ctx.QueryParams(), &params.Select)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $select: %s", err))
+	}
+
+	// ------------- Optional query parameter "$count" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$count", ctx.QueryParams(), &params.Count)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $count: %s", err))
+	}
+
+	// ------------- Optional query parameter "$top" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$top", ctx.QueryParams(), &params.Top)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $top: %s", err))
+	}
+
+	// ------------- Optional query parameter "$skip" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$skip", ctx.QueryParams(), &params.Skip)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $skip: %s", err))
+	}
+
+	// ------------- Optional query parameter "$expand" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$expand", ctx.QueryParams(), &params.Expand)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $expand: %s", err))
+	}
+
+	// ------------- Optional query parameter "$orderby" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$orderby", ctx.QueryParams(), &params.OrderBy)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $orderby: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetScanEstimations(ctx, params)
+	return err
+}
+
+// PostScanEstimations converts echo context to params.
+func (w *ServerInterfaceWrapper) PostScanEstimations(ctx echo.Context) error {
+	var err error
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.PostScanEstimations(ctx)
+	return err
+}
+
+// DeleteScanEstimationsScanEstimationID converts echo context to params.
+func (w *ServerInterfaceWrapper) DeleteScanEstimationsScanEstimationID(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "scanEstimationID" -------------
+	var scanEstimationID ScanEstimationID
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "scanEstimationID", runtime.ParamLocationPath, ctx.Param("scanEstimationID"), &scanEstimationID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanEstimationID: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.DeleteScanEstimationsScanEstimationID(ctx, scanEstimationID)
+	return err
+}
+
+// GetScanEstimationsScanEstimationID converts echo context to params.
+func (w *ServerInterfaceWrapper) GetScanEstimationsScanEstimationID(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "scanEstimationID" -------------
+	var scanEstimationID ScanEstimationID
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "scanEstimationID", runtime.ParamLocationPath, ctx.Param("scanEstimationID"), &scanEstimationID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanEstimationID: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetScanEstimationsScanEstimationIDParams
+	// ------------- Optional query parameter "$select" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$select", ctx.QueryParams(), &params.Select)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $select: %s", err))
+	}
+
+	// ------------- Optional query parameter "$expand" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "$expand", ctx.QueryParams(), &params.Expand)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter $expand: %s", err))
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.GetScanEstimationsScanEstimationID(ctx, scanEstimationID, params)
+	return err
+}
+
+// PatchScanEstimationsScanEstimationID converts echo context to params.
+func (w *ServerInterfaceWrapper) PatchScanEstimationsScanEstimationID(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "scanEstimationID" -------------
+	var scanEstimationID ScanEstimationID
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "scanEstimationID", runtime.ParamLocationPath, ctx.Param("scanEstimationID"), &scanEstimationID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanEstimationID: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PatchScanEstimationsScanEstimationIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.PatchScanEstimationsScanEstimationID(ctx, scanEstimationID, params)
+	return err
+}
+
+// PutScanEstimationsScanEstimationID converts echo context to params.
+func (w *ServerInterfaceWrapper) PutScanEstimationsScanEstimationID(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "scanEstimationID" -------------
+	var scanEstimationID ScanEstimationID
+
+	err = runtime.BindStyledParameterWithLocation("simple", false, "scanEstimationID", runtime.ParamLocationPath, ctx.Param("scanEstimationID"), &scanEstimationID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter scanEstimationID: %s", err))
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params PutScanEstimationsScanEstimationIDParams
+
+	headers := ctx.Request().Header
+	// ------------- Optional header parameter "If-Match" -------------
+	if valueList, found := headers[http.CanonicalHeaderKey("If-Match")]; found {
+		var IfMatch Ifmatch
+		n := len(valueList)
+		if n != 1 {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Expected one value for If-Match, got %d", n))
+		}
+
+		err = runtime.BindStyledParameterWithLocation("simple", false, "If-Match", runtime.ParamLocationHeader, valueList[0], &IfMatch)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter If-Match: %s", err))
+		}
+
+		params.IfMatch = &IfMatch
+	}
+
+	// Invoke the callback with all the unmarshalled arguments
+	err = w.Handler.PutScanEstimationsScanEstimationID(ctx, scanEstimationID, params)
+	return err
+}
+
 // GetScans converts echo context to params.
 func (w *ServerInterfaceWrapper) GetScans(ctx echo.Context) error {
 	var err error
@@ -1044,6 +1439,11 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 		Handler: si,
 	}
 
+	router.GET(baseURL+"/assetScanEstimations", wrapper.GetAssetScanEstimations)
+	router.POST(baseURL+"/assetScanEstimations", wrapper.PostAssetScanEstimations)
+	router.GET(baseURL+"/assetScanEstimations/:assetScanEstimationID", wrapper.GetAssetScanEstimationsAssetScanEstimationID)
+	router.PATCH(baseURL+"/assetScanEstimations/:assetScanEstimationID", wrapper.PatchAssetScanEstimationsAssetScanEstimationID)
+	router.PUT(baseURL+"/assetScanEstimations/:assetScanEstimationID", wrapper.PutAssetScanEstimationsAssetScanEstimationID)
 	router.GET(baseURL+"/assetScans", wrapper.GetAssetScans)
 	router.POST(baseURL+"/assetScans", wrapper.PostAssetScans)
 	router.GET(baseURL+"/assetScans/:assetScanID", wrapper.GetAssetScansAssetScanID)
@@ -1068,6 +1468,12 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.GET(baseURL+"/scanConfigs/:scanConfigID", wrapper.GetScanConfigsScanConfigID)
 	router.PATCH(baseURL+"/scanConfigs/:scanConfigID", wrapper.PatchScanConfigsScanConfigID)
 	router.PUT(baseURL+"/scanConfigs/:scanConfigID", wrapper.PutScanConfigsScanConfigID)
+	router.GET(baseURL+"/scanEstimations", wrapper.GetScanEstimations)
+	router.POST(baseURL+"/scanEstimations", wrapper.PostScanEstimations)
+	router.DELETE(baseURL+"/scanEstimations/:scanEstimationID", wrapper.DeleteScanEstimationsScanEstimationID)
+	router.GET(baseURL+"/scanEstimations/:scanEstimationID", wrapper.GetScanEstimationsScanEstimationID)
+	router.PATCH(baseURL+"/scanEstimations/:scanEstimationID", wrapper.PatchScanEstimationsScanEstimationID)
+	router.PUT(baseURL+"/scanEstimations/:scanEstimationID", wrapper.PutScanEstimationsScanEstimationID)
 	router.GET(baseURL+"/scans", wrapper.GetScans)
 	router.POST(baseURL+"/scans", wrapper.PostScans)
 	router.DELETE(baseURL+"/scans/:scanID", wrapper.DeleteScansScanID)
@@ -1080,106 +1486,115 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+w9a28bOZJ/hehbYGYXip3MzR1w/ubITkYYyzYsJ3OLzeKW6i5JnLTIHpLtWBPkvx9I",
-	"NlvsB/uhp531N1tNFl/1ZlXxaxCyZcIoUCmCs69BgjleggSu/8NCgBxdqD8JDc6CBMtFMAgoXkJwln8d",
-	"BBz+SAmHKDiTPIVBIMIFLLHqJleJaiokJ3QefPs2ML0mIabNcLMW/WDPCI0InXshr7/3g0tmSyzDRQ51",
-	"ATgCvoY7mr0a6wY1YAiVMAeu4bAISzxkKZU5qD9S4Ks1pL+E+msNnCljMWC6hnP5mGAaeQGB+dy8MA3o",
-	"HYklcC+gmfncAdANj4C/XXkhMfV9umoCNQgeX83Zq6yHBWgHmEAMoX/vhPncYaaTzyTxg1Efu5zkPfMD",
-	"kawVhggxHTI6I36ELTTph7OiicREf+r6phqLhFEBmjdM0jAEof8MGZVgcBonSUxCLAmjp78LRtVva5h/",
-	"4TALzoL/OF0znVPzVZxm8O6yMcyIEYiQk0SBC87skGgJQuA5KLT4QD9T9oVecs74zqZynpCmaWRjItCD",
-	"mr3WHRVct+/Z11LPc4rY9HcIJZILLBERiINMOYUIEYpwHKMQCxCIzdAMkzjlIE6CQZBwlgCXxGy8Xf3Z",
-	"14ADjm5ovLKnV8WC7Bczqtqwc8VcqzO70P9NQSBMkWbA2Uyr4xu2T2esdRtVw3s1Ac2auZATAH0MM8aX",
-	"WAZnQYQlvJJkCcGgyglIVMsgYtwXEIcHIojBgDIdGkIROVMubss9kzhGNF1OgatT0W3N4S3wAyB4AI54",
-	"StGMcSQXRJi9W0/CHSddLjFftdJBiOk7I6fEJOuiDhL4klAsIbrpvHLv+Q/ZclnYjtL3y0ciMn2gevSd",
-	"jl2BchDVh2xfFiRcoJSSP1JAIaNCckyoRCFbTtVqCaMoxKmiCbnQLWYxMUi5Ke7fQazhioURAV46QNxp",
-	"iSRbU4aZdYgpmgIychaiZ0goLVtYJBxP470TUodx909Y7ci2FqT/UOfxTx/6qVlo5Ijjm1lw9o/NSayA",
-	"yN8GATwmMSOGbJs6X5p2eiJrnVnccqaEK0R1OqcXx5Y4/oI5tI05Ns3smEsiQq3VpNwsobV/qYMFxEGw",
-	"lIcwVNNMkzYwd8XmE4kltAsIzpj83GFj70w7OzcxZcvWPpMpW+YdMtRoQ+LywQsIObRPb6Kb5YNJ3N4l",
-	"x9iJbp11S/v1S8X2RPqQxhQ4npKYWEJpgvLRab4yK66RBx3XcA/LJNaI0kjUjTJz0uFo1+zhycpONbv3",
-	"oLY2nlj8KU7vfcymOEYKTYiQJBSaoRuxqfBb8X6l587wksSkTr1Vre4V1+2MY7ZD87xHNEkdXK7MfLKe",
-	"cgKFKRPVszpRbVFVBd0CTAekvqMfT5dUngqKE7FgUm8GPJ78tU6Kb7HwQSDIn9A0GfVd2Rjjt2ohuYwj",
-	"VP73z7XaqvnFD1B9Rz/e3dzcv5sM0MXoboBG4/P3lwhkWLe+xrMp62RPWzh6qOffUVi2K2cvwvP7EJ7t",
-	"+m1PcXpnUadZrE4crlhkBkAj+6GbmSQk5rJPl0aeZeihOivOmXGeEwkGhSsToWkc42kMJarBnOOVNdzu",
-	"OaaCKEztvUgzLaDpUh3WNdPTpRAFg+AWNHYEg2ASLiBKY/2rOorVPdNnPQhG9JazOQchgkFwPmVc6kYX",
-	"jIJz7J33qEYlcplxvkudkKckxL9V925u1JPOEAvqTJFH73pqtYx814O4/HbXsBVT3gvcNQ/eNega3rfb",
-	"IVrxP20hgM6iADZB77xjR92jpmNf9aMKoqsOUO1pMa5nr24yvdqxp6QsA2jEhdyMrGCDUl3eZfaQuezp",
-	"JOiLPTIViAIfUSExDWHIQR9Yd5D+ztWlZRd16kd7W1djMdesP5f738c+uEusofSwyR26tjEF0g0RDkPG",
-	"lYRGkmmrfU4egCJzBSs6eUNz9lYc8YoIqY1vZ8zm0RCmEUrwHE6Q7hwDncsFWqZCoimgmH0BjpQ9+0eK",
-	"YwVBtZ2QP0FZmP2YrDEralfWxmbvMzsV01VmMjbqtmPtj29TVm9Z1KndBeGd2g0ZlZgotFriOfTsolv/",
-	"cxBERJ2n9lWbu84lThKlg519DWoG6D6VQVAcrNOMBoFdfMveDAK7my2bPQiy02k7O0tiq2vDdwxG2PuT",
-	"ejTZiDRrqHJvJCkQoUejwc3obxizNLrl7IFEJnzEmhznv02U6fBnypWJ8n54q82H8LOOIrl8lMApjmts",
-	"iUEtHlecQDxcEAmhTI060/06bApxdw3wHney1YzsqxnOwcraz/WmofXj1YSLuBa4A7zOei7RcxXzs8/X",
-	"vsmHSuxBdC63voQky8yN3Zs/7unAGs+l3zbnHLC8wRHxb23MTExKf6TpN7nMk1lz+g9g4oIqoxfYU53f",
-	"wrcm4yi8eFv7URIZ13dLebyVp+Sbf9mZG8wez9qh3MH5q2Vzcc92di4NJ2XviLb0lawXsfnuOep32eem",
-	"4HmuiDO9u+VI2yeRnd024SdlL++shA6dlMVbHH7Gc3BRqU1rK/hO+3TMfP59uhiXdK9BSqZ8n76Zf75P",
-	"lxpSbNNjc6bVGeIgGFvPRuedHQTlndhkxwZBhiA98GcQZPvYY5sHgTnp7ngwCAp4uAGyNqnYipxYSqO3",
-	"q872XYUcVX8TblNUiX9bADXhPxnFoi9YIIUx7AE4RGi6Qlhbr+4t5kZ6CX3AMYnWcT9dJuJ0MjOhoBTw",
-	"HvNp4He+AILZmh02bbblmk8xeMBeSvU0wuzta1fnSG/LKx+gFXQn0escQbuUG68dsqX4XvPBq0Bm360y",
-	"0kGqWNO4PmLhFsuF2gy17BmJwUTlZTaCQNZx3OmgswGPqj7UMPzOGqA9lANrgO6Nvw8fOiuA6zW02kJL",
-	"kDjCEneGnXlHx7bfRkrmuIjAlSOuCuev/hD4mpjVJUTEb2IZNItuM1rwfPfbbwIegGup2jMKw/bTMadC",
-	"DrGEOTOX+lUsByEvWqwx1abWkKvd8wZFpjt1lA/m0GRSF9hSRY6Nr1lr1tdKQt241gZE4kMfx89WbvML",
-	"mS/ydlUQY4hIumxocMW+5F/rvHPl9sc1E3Ptu6JTJLB1AAadpz4GE5MQbBLU5kN4fSlJyuOGHan58ABc",
-	"1DOJhm3biAHYLT8w3ecXCOVRN/elDYKERR4e38/PVhsm5xCpE3LzmSSJjqV5h0ncFFRjzMSPLE7NBHEU",
-	"6VAgHN8665/hWEA5OU1tlDJDlAKPpyyV6OMYccYkejDgBhVaDfkqkYZa7aT/DkrpvVamZJbtVjtLQf6E",
-	"9287+KuzhgNntNq9tMZxL4FvOnkFdva9i7585zStJZ4a87wz8djFHZh43MDKyr72jhZaL2IDmXZXPIlc",
-	"jF2Ob+7+HgyCXy/vri+vgkFwfnt7NRqe349urhW1jO7Gv53fXSpkvP71+ua3ay/JfD627/Iupcrwt9F1",
-	"kzx/tycZZ3CQyACZSPSC9D1BoxliNF4hBQvbUEFEBBIgB4hI9IXEMZoCwkgQOrdQLMwoS7aCIoA13JAz",
-	"ekXoGqR2BaScA5VIT88OoD58CmacLfXvnwJlR+t4S/0pG1HZ1xVL2w6ih50yZYsWloNptJ4I5rCeic6U",
-	"M0vS8+ApRVjWdK8ssTBvA0YvR1u+7qTyhjCbQSjJAyC1yJNgECwJdU/xTZmvWhBVg3vI2foQEDwmHIQS",
-	"4DoZAh7xMlFEFfwX+hn9Df0NvanzahWWUx+nT+ExXxYRaI2KSCxYGkdIcjKfA88caidbeLAmb2/GPrLD",
-	"FMerP3uS1qCJWmtnYEPBK+MnRmfpzuLWSs4GLK5Tet/oojVAZ3QhFIFMDcma4N3Nlc3eodIep6lXaW3P",
-	"sO4efWVaVuL0+wZvO6HQVdqIyQzCVag4ompk3F+Ky2WEUFXeLnIftD9Eul2t06ONfe7ZX9Ilpq844Egd",
-	"pi1zgJSyofRcOkcRSExikWl2ilPFWPFAvQiZh4yfeLfjDnBWCqE49BiHC0IhH3yAPiQJ8CFeQjzEApBU",
-	"3MSZiRqba2C5FAkZNfLtB2GmVZxQHh2S75c6zugmlcEguKFww8eMg74zMBuZR6TbvV/lG/yBwmMCoQFz",
-	"zeSC0Hne3FamqD2A7pkUeQZF79TBStagP8d8mcaSvLJBeVYuWzSsZS9rStoEbKZDVNPZIiJyjlsETGZI",
-	"s5VMlOcwlFpge2k5S1mmYBj5otO5lUpAnIII7VlSWzAZN8a2+wGZ+h0mGaJN/fWqd15pYL77LneOelWz",
-	"GWduW+oWBRYK2NWxysK+8XbjbD+Lx3uosnBkPO9Q62Ddo++ln3tQhwqKdsY8flS0u9mbhGU2JaM/AXbT",
-	"Zfn+hVXzA6rKXcFKtjebmYGfJ56jL0RpDUWeU3WO9UsbdpIQ+uX6Ov22zfZ15tAz99ZNoeiQd+MYfX3z",
-	"aJ2RtkhOdZI+vOhSyoatVuRCmUbo4kkeF1CVNlLxqEsHK2oy51UT53bf16LuoD1tbx0b1tPkzjlrT5PJ",
-	"+og8LT5umSncpDIHvRP9924mN/NWp1RlV3lbmwHVZny3cs3D6xdbG+sh81WP0HUSUSogUgcXkyWxLkKW",
-	"lOxwNJKqofhEVYObi/P7c5RVo8zA2Hu6IqiQxTGElvmb7AoFQ/v2MuDGsWe8aICUcXmC3uniHNr99on+",
-	"SzschJISP+aFvE7shdMA/QDpqy8g5Kuffvjrvww0O4NsiE9UMvS70guKCR55R3T+2wRxmCv7+BPdLGO9",
-	"XeQe3QnSbYqHcYp0m8u/mZOkfVM2c5psWzLCWy2ioXSlsRM1ppSty4kuP2SzV2vFk6MmdLvTq6+4UZZm",
-	"v7OpGDLFV2TBo+1wXdXkCmbynt2l1HOhWr3sa9Flkow+NRvMNBvGEVlfEeMYJSlPmABxYjfBn6i8G3m4",
-	"xI+3mOM4hnji3LpV+dMSP5JlunSqBrrJqyZK0XgH1i4uQlGSAV+XEsziczN4wdlPr/X1jfnnTb0QfBFg",
-	"uxBgSkqxVE5Asb2WY9ZXVYQiYRqbA87QVq8FIuOW0RM0uvMn6vpsGEdTmDEOaAr6rjGVTOF5iON4pcSD",
-	"gmFmmh//60EHUisShj+D/YVAXgikkUBaRe2zIJg2I8JLQKXAj8nbm3EwCD5+uLq+vDt/O7oa3f89GATj",
-	"86ss3GNyOby7vFc/jSbDm+t3o/cf7mxUyN3Nzf2vI/Xx8n9vr25G97X3PZO2WhClq/my68i6jUgGoFqN",
-	"Gz/echL6biwkX43x47mUsEx8pncqYJIwaecoPHferjpV6eLzwbrB2rUFNxpDnc33SXf1z2ntxYIixOKM",
-	"LrDEir3WTkd9tKWs6r5f0jmh8NEbDalMlpnWh9+R2OdM+ZWyL/Qj4anwtcimcEE4hJJx0tKuYaxJKpK2",
-	"+Sj1/x5/hq7hnZvUITlsBZKnUXtk87IjNhuvkvTdEq8PNBqyOF167i+BRjZcqPpxRmK4rc3eUcRbyN7J",
-	"Enes+Wn8snW62YzQOfCEkzrEuGYSzozgIAJRJrMbAa+XomlpuoFvcf4t3ijKMjudAwdZOuUhq1y2Z3Wz",
-	"fAWbhB8V3OvHCYGcQJhyIlfvOTNFRnuEPWblzVAYszRSuKshobkGVRa9xi+6JPRKcwdXU+1XmL389EjP",
-	"dzvyNztE9j6JbmRaaNpZEDrf9Tse93i+1d5KPEenSJfYqMzsM9RnJT3gOO1APaq7bVy33bbMTxk781Ih",
-	"Ncm6Rs/x1K2wn91aNI3lRgqFaxwA3mSBGKc0XPQLP9sqOSHGUo3iDWhf5wa0XexlLc0V3Zowe/Ejh547",
-	"RBtKPN9x1RY/ey7ghrPnpTO1dWicnS0camFTa3G29t7xOAy2lNxfre8ium9/AdZQ9exwwG2aTkSE5KzX",
-	"0Bemi1ZLHnv1fEceDYWugI88lZ8I/bxlulayTjbrGDuceBNMOyaQFm9XnexR98p85c9hasabYYYlZZkk",
-	"OQn7Y80466ez0cKsrseWiWreQSqznmIBk5AVrtuNT8wp/Z5fU/vakWWCQ+n73jrDixzpS9cT+neUGHEj",
-	"XO97dmOFUQRS24HoitD0EWn6IdPUXgoVVzu6uCKfa5QUpe2PLv7vavTrJZoRiCOky2zYQBf1+RRkeMrE",
-	"Kw4xYGEMhq0Cy+0dtN8mqa6oTlY6mFEElVnzfmjoxyX+nWljUP9xsiSUcZQB7PgQgbcSSmezo8iTD2x9",
-	"VPhh1Qaxt8C+nd95/nK1inxlUpvWZi7v9S5m1y1AaO1oL809I7UEOLLs3RM7NORE+1drQm08QTm/kPmi",
-	"e+sr9qV7Y5MR3r39NcxjMifTGDr0ad/3mpT24d3ofjQ8vwoGwS+j978Eg2B8eTH6MA4GwdXNb8EguL58",
-	"fzV6P3p7dVlXjF7r8oZus7JzwcfxMMbaijy/HYnA4TXBm5PXJ6+zbCqKExKcBf958vrkTWCkt17VKS5U",
-	"950bz0+efqU0juA9SKcG8KDwiK6Hb6ybnLpvsPquxMvNs4dQuzY3j7J1bX3Pku4T+Uy6N85erO3aPH/9",
-	"9Z+lp0d/ev16d299rg/O/+KoUXpnOI295efyCZ4WniT95oZPKETpUYDZZKmLGoS7ZaKIcUp8gJBvWbTa",
-	"/c7Yx1/dl2K/VY7kzb4GLvFj+1EX5MrqlOrYhZ93iRXNL8COTB0w95EokarB8qn8z+53I4vprpnOMIvB",
-	"1ld46ylpmXSyK9zVV2ewfgQzDyfBSCQQkhmBKH+08fFVyCKYA32VYearKYtWtlC8+ltDd5jr6Vfn2e9v",
-	"3VjteeGh8H5c131kfE9c17K7g7CvFu718+ufD0UcawodXeibA42HO2WhLg6eZMa2eZ69xCfVz0fBF/ti",
-	"vDn8ozPnAyHch8TURiwyicwtPkvjePX0OPUToIunJi5+fvPToTblUuI5ikhEf5BIU8zO5JWm/SImdhRM",
-	"gyBJ65SuVL6wkhdW8sJK/u1YicHFstrRU8ttdx+8uA6eoevgoG6DLi6BvboDjuIKqOWAiMKXjByfjiNg",
-	"rz4APxfWnxGOOeBohUC327ndv4llb636zKKPIAZzDVHE3Qv9u8Hec9N+M6VKKVQeim9ef8FSfhrYc1hl",
-	"Yi+2ujlXs7wT83plk/jb+uifuRvniblw9ue+yfGh1W1zCJw4iH11FNuq0a7KeE7Fnjoykj0FsfldGS2G",
-	"2Hbi+XihxoNT44su8sITjssTlDI/c97v8elw+Rs/L06M5+TEyI/tQG6MOHaqKzV6MxyE2ocgyB9rOqxH",
-	"ozBsnU/DfW/syF4NO5W9+TWKL5/VzCRr4FSZ27FXw65xA2Z4+tW+KtnFu2Gx2UaX9lei8tF24eM4mES3",
-	"J7hP/4I9xEYfw04P4Pl6Ghr4z/eHIEriyAXkFaJMuJKLLU0eiN2T7JGl2EGwSG8duMLj+EaNR5B9Fzie",
-	"xTmssXpbU/8F7TdBe2vJv6D9YdDemrJ98V5pcFm4/4ldrE9luEmAnt+OJgmEwZZYlacM60+1iQt7t710",
-	"NYdsTTpm1+yGKJbq9m2GW9H7xcR/Tia+e3KHs/Ldmuotln4RtfYhLwoF7A9q75dHrjP5C68eHN/sd6ez",
-	"N9O/8jRGHWY6E9lzdEOpCnxXSeLwztOv6386eQQcrJ84PXszV3fYZ+UacI93r+6Bwrs3DS6C/ZzI8/UV",
-	"NPOu7xNp6l0GZQxqchscC4v2fXPaV4YeCg+tw6Eoto5vfTWI0SdBLU9Mmn9PSSfll9a2c8i8MJTDMhTr",
-	"ynlhKC8M5alEbGzCUayB0urWeXHoPD+HzqFdOeIEXeJwkeOhxISK0tMrzc+ZtrqA9un8OYbbp8Xh81Q8",
-	"PXt18bRw7317dfz42JeHGvdOZ8eO2DA3WGRpwc/NjbN3/02r42bbHX/ebpon5qA5nGfGVExqkzst7pr9",
-	"484hbKljWFGtDpknYzgd1WLat6nUX8x+d+6W3fhZXjjBLjlBwZPywgleOMFh/CSdHSTfvv1/AAAA//9o",
-	"qXurAMsAAA==",
+	"H4sIAAAAAAAC/+x9e2/buLbvVyF0NzAzG07Szp17gZP/0sTtGJMX4rRzNnY3zqYl2uZEIjUklcZT9Lsf",
+	"8KGXRUqU3+n2f4lFLlLkev64uPQ1CGmSUoKI4MH51yCFDCZIIKb+g5wjMbqSf2ISnAcpFPNgEBCYoOC8",
+	"eDoIGPozwwxFwblgGRoEPJyjBMpuYpHKplwwTGbBt28D3WscQjLkAidQYEraR2i0XXG87lF6055iEmEy",
+	"c1Iun/eji6cJFOG8oDpHMEKspDuantyoBhYymAg0Q0zRoREU8JJmRBSk/swQW5SU/haqpxY6E0pjBElJ",
+	"Z/iSQhI5CSH9uP3FFKH3OBaIOQlN9WMPQncsQuzdwkmJyueTRRupQfByMqMnpkdOMB9gjGIUuteO68ce",
+	"Mx0/4dRNRj702clH6iYiaCcNHkJySckUuxm21qQfz3I/kebrSTNvE2TeX4a/ycY8pYQjpfHGWRgirv4M",
+	"KRFISw5M0xiHasZnf3BK5G8lzb8xNA3Og/9zVqrSM/2Unxl6D2YMPWKEeMhwKskF5/mQIEGcwxmSzPeR",
+	"PBH6hQwZo2xjU7lIcds0zJgAqUH1WquOkm617/nXpZ4XBNDJHygUQMyhAJgDhkTGCIoAJgDGMQghRxzQ",
+	"KZhCHGcM8dNgEKSMpogJrBc+f/vzrwFDMLoj8SLfvSYXmF/0qHLBLqQKb87sSv03QRxAApSaNzNtjq+N",
+	"GZnSzmWUDR/lBJQBYFyMEVLbMKUsgSI4DyIo0InACQoGTX2DI6saimFfQgw9Y441ByxLuxYUXqj++rI8",
+	"UgFjQLJkgpjcFdVWb94cPiOAnhEDLCNgShkQc8z12pWTqI6TJQlki045CCF5r60hH5suciMRSzCBAkV3",
+	"3m/u3P9LmiS15Vh6PnzB3Hg5za332nZJqsKoLmb7MsfhHGQE/5khEFLCBYOYCBDSZCLfFlMCQphJmRBz",
+	"1WIaY82Uq/L+A4oVXT7XhsYpB4BVWgJBS8nQsw4hARMEtDVH0SsUlI4lrAuOo/HWBclj3O0LVjezlYb0",
+	"n3I//uViPzkLxRxxfDcNzv+5uojVGPnbIEAvaUyxFtu2zkPdTk2k9Mz5PaPSuKLI5tk6eSyB8RfIUNeY",
+	"N7pZPmaCeah8p4zpV+jsv9QhJ8QQpxkL0aWcZpZ2kXmoNx8LKFC3gWCUiiePhX3Q7fK58QlNOvuMJzQp",
+	"OhjW6GLi5Y3nKGSoe3pj1awYTMDuLgXHjlVr0y3r1y/j6wvpcxYTxOAExzgXlDYqnyrNF/qNLfbA8x0e",
+	"UZLGilFahbp01de1m7Ax8nnvqQ4CVJtPq0IoW7oFvduHGnoPWF+u9/AJNVha9HntkpaR6G9+G9Xq5ox7",
+	"vZKNDQ7WBbKtWWMRVHSj/sICaUXWYAqSxTGcxGhpApAxuMg9kEcGCcdyoEdpS72dmoIFEMkSaVXvkVIL",
+	"wSC4mFAmUBQMgvcQx+qPK0pQxej2XAILD4RtfoyNBFA9AAxDyuQ8pccoN2yGnxEBGqrh1sCgWN/6UNeY",
+	"C+kqWQfrHKYgugLX1rexfQ27RMh7CoctLh+QNCjxOLea9el9iOkExkCyLOYCh1y5sTpYkKpRbqOM7qcw",
+	"wTG2BfWyVS4ffpY179A+7xFJs4oFb8x8XE45RbUpY9mzOVGFIzXFYo50ByCfgx/PEiLOOIEpn1OhFgO9",
+	"nP5kFfPVX3wQcPwXapuMfA4wATfv5IsUegcT8f9/sYqi/sVNUD4HPz7c3T2+Hw/A1ehhAEY3Fx+GAInQ",
+	"9n6te7MciR52SOCQnv/EEKE7JD2GDN9HyNAd1ff0zB9y1mkPJsYVrbjklpGotx/FRJ8urTrrtTiLt1RN",
+	"lyjnsPQcx+EcRZl2GeVWLB6p2utBMCL3jM4Y4rzmYK7iVxamdmmNKsq4n3e2ZMS/Nddupt0Tb4o1d6au",
+	"ozc9Nasi3/QgVX27adpSKW+FbqmDN03aovs2O0Qn/2cdAuBtCtAq7F109PQ9LB37uh9NEr4+QLNnznE9",
+	"e/nZ9GbHnpZymUArL1QhrGbE897EQ/og3cvQ13sYF4ggNiJcQBKiS4bUhvmTdHduvppJgpA/5pkQVvDN",
+	"bfe/j3WovmJf8KSMMb0xk26HuwNDqY7ZPhqAJAIpnKFToDrHiMzEHCQZF2CCQEy/IAZkPPtnBmNJQbYd",
+	"47/QaW/QRYcV1jfrUrOPJk6FZGFCxlbf9kadQnY5q/c08mp3hZlXu0tKBMSSrRI4Qz27qNb/GgQRlvup",
+	"Tuh0hkcC01T6YOdfA8sA/lMZBPXBvGY0CPKX71ibQZCvZsdiDwKzO117l4vY4lbrHc0R+amxnU1WEk2L",
+	"VG5NJDnAZG8yuJr8XcY0i+4ZfcaRTs3LQ46L38cydPgrYzJE+XB5r8KH8Ell6A1fBGIExpZYYmDl4wYI",
+	"xMI5FigUmXZn/JMAJij29wAfoVespm2fZbgKV1of20PDHMezpOJVI/AKcVv0vCTPTc43j29dkw+l2UPR",
+	"hVg79QInBsburR+3tGGt+9JvmQsNuLzAEXYvbUzD4hytH9P0m1zbKWxIuVPzyWdSK0ldpODvH//2UxUy",
+	"nsYUVtK6dCJLCwStiCr4uUb0w7uf7LizQTtsVOSzksQXHMdAwCcEfuQopCTiNoo2xWVAXsu6PCOdKNrY",
+	"mNp0bJCOa7s1hnr1zvpQYBHbu2UsXgtEanltgxDmnFti7R64uHJb6mu2MZb9l3vK+fHZmjBS+RKrr14l",
+	"MlmGIyU9R86QCUk6trR7Embv1smrWAbAp0vs4OVH38PwCc5QlZW6HNoarNynozkO6dNFo/W9BllCOfr0",
+	"NUcXfbpYRLHLxS+UljfFQXCTgz7eKzsIlldilRUbBIZBevDPIDDr2GOZB4HeaX8+GAQ1PlyBWduiDylO",
+	"NCPRu4V36NsQR9lf51/WTeDvc0R0PqiRWPAFciA5hj4jhiIwWQCoLGPVWq/kspFnGOOoTAT1mUilk54J",
+	"QTI26TGfFn3nyq2YluqwbbFzrXmIeRX5eV3P+DQ/mN5ark0xwGbyaypb0G3lbkqseunCh37g9K3N89wZ",
+	"8bAqOWpgT+a4h2Keu61THCOdpm3CJw5yTN1ro82Ae3UfLArf2wPMN2XHHmA1GcLFD94OYPkOnWFiggSM",
+	"oIDetA1wfJP3W8nJvKkzcGOLm8b5q/tOlCVzNUERdkefms2ieyMLjufu0JajZ8SUVe2ZoJL3U5cQuLiE",
+	"As2ozndocjni4qojGpNtrIGcdc1bHBl/6VjemF2LiS3np8kcK59AW96vU4T8tNYKQuJinwoEudzmVzyb",
+	"F+2aJG5QhLOkpcE1/VI8tQGXy+33GyYW3nfDp0jR2rkpZJa5FEyMQ5Tfil19CCeWkmYsblkRy4NnxLhd",
+	"SbQs20oKIF/yHct9cbayPOrqMOMgSGnk0PH9IEhrBqE1j338hNPUK49dh4mfaJzpCcIoUllSML6vvP8U",
+	"xhwt31aWC8U0JArghGYCfLoBjFIBnjW5QUNWQ7ZIhZbWfNL/QNLpvZWhpLn+bJ0lx3+hD+88oHzTcFAZ",
+	"zbqWeXDcy+DrTk6DbZ77+MsPlaZW4bGE597Ck7/cjoWnmnPaWNfeiVTlS6xg0x7qO1GYseHN3cM/gkHw",
+	"2/DhdngdDIKL+/vr0eXF4+juVkrL6OHm94uHoWTG299u736/dYrM076xy4eMyMA/TzwcF2UjeoqxoQO4",
+	"IaRPA2rW9xSMpoCSeAEkLZhnUQLMAUdiALDQpwcTBCDgmMxyKjnNyNy+RXUCJd2QUXKNSUlSQQEZY4gI",
+	"fU6RDyAffA6mjCbq98+BjKNVKqo5ylAjyvi6EWnng6hhJ1TGorXXgSQqJwIZKmeirk5XjklYRgAUlu6N",
+	"V6zNW5Mxxy5Q1CZVNETTKQoFfkZAvuRpMAgSTKq7+HZZr+YkmgH3JaPlJgD0kjLEpQFX90TQC0xSKVTB",
+	"/wO/gL+Dv4O3NlSr9jr2KwwEvRSvhTkoWRHwOc3iCAiGZzPEDKB2ugaCNX53d+MSO0hgvPirp2gN2qTV",
+	"OoM8S74xfqp9Fn8VVzo5K6g4r/veo6vO3KXRFZcCMtEiq/OaV3c2e2eRO0BTp9PafV3UPzFNt7RcEe2X",
+	"117JEm/KRoynKFyEUiPKRhr+klrOCELTebsqMGh39ni3W6dGu3HBs79mCSQnDMFIbmZe9wZIZ0P6uWQG",
+	"IiQgjrnx7KSmiqHUgeolRJFNf+pcjgcETW2c+tA3MJxjgorBB+BjmiJ2CRMUX0KOgJDapDITOTZTxAor",
+	"ElKi7dsPXE+rPqEicaZYL7md0V0mgkFwR9Adu6EMqTMDvZBFsn6+9otigT8S9JKiUJO5pWKOyaxonpcq",
+	"sm6A/yWT4nJJ77vkjWvk7qIjSRYLfJLnK+Z2OWdDq3opJWkVssaHaN70izAvNG6dMJ4CpVbKrARNQ7oF",
+	"eS9lZwk1Doa2L6q+h3QJcCWVovsC2RpKxvcG/XL+brFEne6v071zWgP93HW4s9ejmtU0c9errlFxp8Zd",
+	"nmV3ts23K1+EzPl4C2V39sznHsVvyh59D/2qG7WrfPHKmPtPGK8u9ioZq17VSXq5oKa2yK6d0J2XNFlZ",
+	"rHbmm4JyTY5u6sG4qYb9UA9XtdJlQ+5qpcJLi+Ma+JXEOQC3ZNX6Qj6v3ahB1FgAqw7pJjwu96tO7w86",
+	"4Zc0SWMkaqBGRQPJJtdoKh7pQ0YcmHrH8H1t7a5q2mynnM0qlWzaitgcANP7vLL7xZr3CpvWpQYhV7PV",
+	"CWJFwRrwBUs9VXfImydH/cqNVC4v9qsRUum3bpWQyhx61uyoXr30uK9bQUT71t+ojLRGUYvKZVEnuyxV",
+	"0WjWLwbG/tRuNeRJc81QTEilMqxwheXmg2xSSX1ztbBttKPtfQXgdTR5qOy1o8m43CJHi09rVhjpNMu9",
+	"CgRtHUNuDzw2VrawIyjo1Jq7D77XRrJD6qo6pWrXg4yjSG5cjBOcn5/RdAmkBiMhG/LPRDa4u7p4vADm",
+	"CwGGTJ7EUicV0jhGYa789a1MSUMdfOVRhjr10kdMCEh39hS8V0W91NnUZ/JvFfFwaSV+LMoen+bZGAPw",
+	"A8pOviAuTn7+4ad/a2r5DMwQn4mg4A8ZNNcvhhYdwcXvY8DQTHrln8lqlW66Te7eTwj8pribUMxvLv9h",
+	"Jwjdi7LaicK6paacVaZaCv1rEFVxyjL0OlZlC/OqF1bzVHET/BJe7JW6dhMZNRai4cukRj6VGjSeDWUA",
+	"l/lTMAZpxlLKET/NF8Fd4GQz9jCBL/eQwThG8biSktLUTwl8wUmWVGqsV4te6BR+DZ2X5z+YgNQQLwuv",
+	"m8srhl5w/vMbldug/3lrN4JHA7YJAyatFM3EWN/rbd9mlceBCTCXgPUGG7ZV74IifWahJqh958+keqBB",
+	"GZigKWUITJBKxMkElXwewjheSPMgaeiZFtv/ZuANQnRXvjkKyFFAWgWk09S+CoHpCiKcArSUFTl+d3cT",
+	"DIJPH69vhw8X70bXo8d/BIPg5uLa5EKOh5cPw0f502h8eXf7fvTh40OeMvlwd/f420g+HP73/fXd6NGK",
+	"Lo+7akgt5a0tQ0c5bIQNgea3i+DLPcOh6zhfsMUNfLkQAiWpK/TOOBqnVORz5I6EsKo71ejiOqCs3mSy",
+	"FupqvQekn4/93b9KaycX1CnWZ3QFBZTq1Tod+TAvgWl7PiQzTNAn51UBGbJMlT/8HscuMOU3Qr+QT5hl",
+	"3NXCTOEKMxQKynBHu5axxhlPu+Yj3f9H+IRID7B+lfNovtOT6MM4gl7x8NlcVW8Ui+m4zIZIdEnjLHGc",
+	"ziIS5bm0zYdTHKN769VWKby1q63mVmsefmpc1uabTTGZIZYybGOMWyrQuTYcmANChTkRcKIUba+mGrhe",
+	"zr3EK11BMLuz4xsIlbLSTS3bsypq8Qar5ObW4PX93A8YozBjWCw+MKqLk/e4E2DKooIwplkkeVdRAjNF",
+	"amA9wEwwuVbaoeqp9vuM1fKHGnt+5bD4wiE3X3NUjXQLJTtzTGab/urhI5yttbYCzsAZUKW5GjN7QvYr",
+	"u88wzjykR3bPG9uWOy8P2DiQTlz3n3Lvy1HUKX9crWHXWqasVvCuQsB5ky6GGQnn/fJf1rq5F0MhR3He",
+	"9iovznUd7JmW+oiuFMxe+qgizx5ZUALONlztza2ea7xRWfOlPc3r11VWtraptUW18qz13HE/Cnap8k2z",
+	"+Bn3X/4arUvZ02ODuzydCHPBaK+hr3QX5Za89Or5Hr9oCV0gNnJUjMTkac27zGl5E9vzYk3qrL7gWV2h",
+	"frpaKa1QPTJfuC/4tvPNpeGSZZskGA77c82N6aeuaoem6NWat7idgzRmPYEcjUNaO24v6xmaHI7imNrV",
+	"DicpDIXreecMrwqmXzqeUL+DVJsbXkXfzYkVBBESKg4E15hkL0DJD55k+aFQ/W1HV9f4yeKkSG9/dPU/",
+	"16PfhmCKURwBVYMqT3SRj8+QCM8oP2EoRpDrgGGthNf8DNodkzTfyGYrK5xRJ2WieTc18GMC/6AqGFR/",
+	"nCaYUAYMQc8PGDnLhHmHHXWdvOPoo6EPmzFIfgrsWvmNF/dofn2mMalVv+mwvNabmJ1fglAJtC/N3Yha",
+	"ihjI1bsjd+iSYYWvWlJtHEk5v+LZ3L/1Nf3i31iXS/Fvf4tmMZ7hSYw8+nSvu6Xey+XD6HF0eXEdDIJf",
+	"Rx9+DQbBzfBq9PEmGATXd78Hg+B2+OF69GH07npo+4iN8uW13JqarMGnm8sYqijy4n7Eg4quCd6evjl9",
+	"Y64aE5ji4Dz4v6dvTt8G2nqrtzqDjo8rzjQGVNxSlr5H8AEJ68cYJUEGE6QwNJcuKZuc0QgK+F5hYc5j",
+	"8uXmYxS3naovN9eftfZt/UhT/4k8Yf/GQ3Vg7938jkWIvdNpAMzE62o7fn7zJi+JjTSgBdM0xjocOPvD",
+	"5HNoFbLCRyS5Zq6lTw2aHAr1YAqz2Fm5tZjqmak1MmSMahkpkisk81Q/V4j8s4lVrRdu4cd7yl0MKS0O",
+	"4uIdjRbbXDi9bqV5kxr6W2Pv3m5/CktqvdlMlb80BdNVMsQvm2SpFBfwkmU6I1110779gGdy3GJW/7XN",
+	"xTKZ45Y5XppMb3VQaJ2nMoKnmxIHdVaHACTO0VRdhxSFeIpRVHxe/+UkpBGaIXJiWPxkQqNF/nEb+bca",
+	"yKrYz75afh1dfeur8C9sVHpbAetctmUPckW8Y8XaoVd/efPLrmTQphJGV+rsQzH2RtV8jakrF940cBDO",
+	"Lapc/nyAvIaniZqwZpwDsik7Z9uPqS6b7NRY5nxgmsXx4qAtzEHJ3KsweL+8/XlXazYUcAYiHJEfBFCi",
+	"tzGLq1SMk309TesgSDObJ5qJo/I6Kq+j8joqr+0oL83ATv49XSUy8AN6jvDOK4V3dg/qbAjJ2Tp+szfU",
+	"plXPHhhCswNYpq963wECszHYpQq2+EIspb+4jpf4nYAoBwid7AYw8YdJdskvO4sl9hZB+McNBxYs7D1C",
+	"2FFcsLq5+F7xi82BFkdVclQlR1Xyn6JKbGhCbwihGz44QgevEDrYKWzgAwlsFQ7YCxRg1YCAoC9GHA8H",
+	"CNgqBuDWwuoxgDFDMFoApNptPO5fJbLPo3oT0UcoRjrztM67V+p3zb0Xuv1qTpV0qBwS3/7+tUj5MLhn",
+	"t87EVmJ1va/69dRbtZu/tbf+lcM4BwbhbA++KfihE7bZBU/sJL7aS2zVGlcZndOIp/bMZIdgNr+roEUL",
+	"20aQj6M07lwaj77IUSfsVydIZz4vgdwGYeSVD48gxqsCMYpt2xGMEceVgtqtaEaFobZhCAz5XSMatWFt",
+	"mIZZnUNANfKpbA3XMIvhVsemQeXDAhtGNfJ3XEEZnn01f3mhGzk35xeK+ztRxWibwDh2ZtHzHdwmvpBv",
+	"YivGsNENeL1IQ4v++f4YRFocMUdFUXCdrlTlljYEYvMiu2crthMuUkuHqsZj/0GNw5B9Fzxu8hxKrl43",
+	"1D+y/Spsn0fyR7bfDdvnoWxfvpcenKnwcJq/rMtluEsRubgfjVMUBmtyVVElTj2y1qrYeuylCniad1I5",
+	"u3o1eP3Tpa7FqH7h9Bjiv6YQv7pzu4vyq9+Y7Yj066y1DXtR+6DvTuP95ZFtIX/tK9D7D/ur09la6N/4",
+	"VLiNMysT2XJ2w9KH/3wtSUV3nn0t//FCBCpcP6707K1cq8O+Kmigur1bhQcqe9sKEWxnR14vVtCuu75P",
+	"prFDBssc1AYb7IuLtn1y2teG7ooPc8Chbrb2H321mNGDkJYDs+bf06WTur5YF5A5KpTdKpQcyjkqlKNC",
+	"OZSMjVU0Sh6geNYqPZYpfe0gzx4qlBqgh5+CIQznjbIy5vtDfOmzvBAkWSzwiaM4SydYtP3ipfutW+pR",
+	"srQEjtBBFS3dWblS39pH46UJbRtIauHs1fW2BpcaVUi7AaYKjbULq/FGTbXXBjah7RbzrANOSxrN0+xu",
+	"YZdeNwB1iNVhd8FMdiBKF4jqtJ4d8NS++W0XkeX+iix2c20NsjqwsoqHUlCxS8YO1Jf4/mCs/mUT26Gs",
+	"o/LZr/KpwVtH5XNUPgcNea1WtJV31Ws9lmp9nRDXXoEtTzRrjqIsNgrWA8zaJoS1D+CqA646FIxqu8BU",
+	"uxbfLQZV5ce+OlQDT95wE1+xJB431fBeG6C0dRSpEzpad8VfNzh0YJDQfnGgpt3pgIG2zzu7iLX2EWF1",
+	"gjoHE0ztNYLaetjU28x+d/DMZjCZoybYpCaoISxHTXDUBLvBSrwBkm/f/jcAAP//t/AhBe79AAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/pkg/apiserver/database/gorm/asset_scan_estimation.go
+++ b/pkg/apiserver/database/gorm/asset_scan_estimation.go
@@ -1,0 +1,293 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gorm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/openclarity/vmclarity/api/models"
+	"github.com/openclarity/vmclarity/pkg/apiserver/common"
+	"github.com/openclarity/vmclarity/pkg/apiserver/database/types"
+	"github.com/openclarity/vmclarity/pkg/shared/utils"
+)
+
+const (
+	assetScanEstimationsSchemaName = "AssetScanEstimation"
+)
+
+type AssetScanEstimation struct {
+	ODataObject
+}
+
+type AssetScanEstimationsTableHandler struct {
+	DB *gorm.DB
+}
+
+func (db *Handler) AssetScanEstimationsTable() types.AssetScanEstimationsTable {
+	return &AssetScanEstimationsTableHandler{
+		DB: db.DB,
+	}
+}
+
+func (s *AssetScanEstimationsTableHandler) GetAssetScanEstimations(params models.GetAssetScanEstimationsParams) (models.AssetScanEstimations, error) {
+	var assetScanEstimations []AssetScanEstimation
+	err := ODataQuery(s.DB, assetScanEstimationsSchemaName, params.Filter, params.Select, params.Expand, params.OrderBy, params.Top, params.Skip, true, &assetScanEstimations)
+	if err != nil {
+		return models.AssetScanEstimations{}, err
+	}
+
+	items := make([]models.AssetScanEstimation, len(assetScanEstimations))
+	for i, assetScanEstimation := range assetScanEstimations {
+		var ase models.AssetScanEstimation
+		if err = json.Unmarshal(assetScanEstimation.Data, &ase); err != nil {
+			return models.AssetScanEstimations{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+		}
+		items[i] = ase
+	}
+
+	output := models.AssetScanEstimations{Items: &items}
+
+	if params.Count != nil && *params.Count {
+		count, err := ODataCount(s.DB, assetScanEstimationsSchemaName, params.Filter)
+		if err != nil {
+			return models.AssetScanEstimations{}, fmt.Errorf("failed to count records: %w", err)
+		}
+		output.Count = &count
+	}
+
+	return output, nil
+}
+
+func (s *AssetScanEstimationsTableHandler) GetAssetScanEstimation(assetScanEstimationID models.AssetScanEstimationID, params models.GetAssetScanEstimationsAssetScanEstimationIDParams) (models.AssetScanEstimation, error) {
+	var dbAssetScanEstimation AssetScanEstimation
+	filter := fmt.Sprintf("id eq '%s'", assetScanEstimationID)
+	err := ODataQuery(s.DB, assetScanEstimationsSchemaName, &filter, params.Select, params.Expand, nil, nil, nil, false, &dbAssetScanEstimation)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.AssetScanEstimation{}, types.ErrNotFound
+		}
+		return models.AssetScanEstimation{}, err
+	}
+
+	var ase models.AssetScanEstimation
+	err = json.Unmarshal(dbAssetScanEstimation.Data, &ase)
+	if err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	return ase, nil
+}
+
+// nolint:cyclop
+func (s *AssetScanEstimationsTableHandler) CreateAssetScanEstimation(assetScanEstimation models.AssetScanEstimation) (models.AssetScanEstimation, error) {
+	// Check the user provided asset id field
+	if assetScanEstimation.Asset == nil || assetScanEstimation.Asset.Id == nil || *assetScanEstimation.Asset.Id == "" {
+		return models.AssetScanEstimation{}, &common.BadRequestError{
+			Reason: "asset.id is a required field",
+		}
+	}
+
+	// Check the user didn't provide an ID
+	if assetScanEstimation.Id != nil {
+		return models.AssetScanEstimation{}, &common.BadRequestError{
+			Reason: "can not specify id field when creating a new AssetScanEstimation",
+		}
+	}
+
+	// Generate a new UUID
+	assetScanEstimation.Id = utils.PointerTo(uuid.New().String())
+
+	// Initialise revision
+	assetScanEstimation.Revision = utils.PointerTo(1)
+
+	// Check the existing DB entries to ensure that the scan id and asset id fields are unique
+	existingAssetScanEstimation, err := s.checkUniqueness(assetScanEstimation)
+	if err != nil {
+		var conflictErr *common.ConflictError
+		if errors.As(err, &conflictErr) {
+			return existingAssetScanEstimation, err
+		}
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to check existing scan: %w", err)
+	}
+
+	marshaled, err := json.Marshal(assetScanEstimation)
+	if err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to convert API model to DB model: %w", err)
+	}
+
+	newAssetScanEstimation := AssetScanEstimation{}
+	newAssetScanEstimation.Data = marshaled
+
+	if err := s.DB.Create(&newAssetScanEstimation).Error; err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to create asset scan estimation in db: %w", err)
+	}
+
+	var ase models.AssetScanEstimation
+	err = json.Unmarshal(newAssetScanEstimation.Data, &ase)
+	if err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	return ase, nil
+}
+
+// nolint:cyclop,gocognit
+func (s *AssetScanEstimationsTableHandler) SaveAssetScanEstimation(assetScanEstimation models.AssetScanEstimation, params models.PutAssetScanEstimationsAssetScanEstimationIDParams) (models.AssetScanEstimation, error) {
+	if assetScanEstimation.Id == nil || *assetScanEstimation.Id == "" {
+		return models.AssetScanEstimation{}, &common.BadRequestError{
+			Reason: "id is required to save asset scan Estimation",
+		}
+	}
+
+	// Check the user provided asset id field
+	if assetScanEstimation.Asset == nil || assetScanEstimation.Asset.Id == nil || *assetScanEstimation.Asset.Id == "" {
+		return models.AssetScanEstimation{}, &common.BadRequestError{
+			Reason: "asset.id is a required field",
+		}
+	}
+
+	// Check the existing DB entries to ensure that the scan id and asset id fields are unique
+	existingAssetScanEstimation, err := s.checkUniqueness(assetScanEstimation)
+	if err != nil {
+		var conflictErr *common.ConflictError
+		if errors.As(err, &conflictErr) {
+			return existingAssetScanEstimation, err
+		}
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to check existing asset scan estimation: %w", err)
+	}
+
+	var dbObj AssetScanEstimation
+	if err := getExistingObjByID(s.DB, assetScanEstimationsSchemaName, *assetScanEstimation.Id, &dbObj); err != nil {
+		return models.AssetScanEstimation{}, err
+	}
+
+	var dbAssetScanEstimation models.AssetScanEstimation
+	err = json.Unmarshal(dbObj.Data, &dbAssetScanEstimation)
+	if err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	if err := checkRevisionEtag(params.IfMatch, dbAssetScanEstimation.Revision); err != nil {
+		return models.AssetScanEstimation{}, err
+	}
+
+	assetScanEstimation.Revision = bumpRevision(dbAssetScanEstimation.Revision)
+
+	marshaled, err := json.Marshal(assetScanEstimation)
+	if err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to convert API model to DB model: %w", err)
+	}
+
+	dbObj.Data = marshaled
+
+	if err := s.DB.Save(&dbObj).Error; err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to save asset scan estimation in db: %w", err)
+	}
+
+	var ase models.AssetScanEstimation
+	err = json.Unmarshal(dbObj.Data, &ase)
+	if err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	return ase, nil
+}
+
+// nolint:cyclop
+func (s *AssetScanEstimationsTableHandler) UpdateAssetScanEstimation(assetScanEstimation models.AssetScanEstimation, params models.PatchAssetScanEstimationsAssetScanEstimationIDParams) (models.AssetScanEstimation, error) {
+	if assetScanEstimation.Id == nil || *assetScanEstimation.Id == "" {
+		return models.AssetScanEstimation{}, &common.BadRequestError{
+			Reason: "id is required to update asset scan estimation",
+		}
+	}
+
+	var dbObj AssetScanEstimation
+	if err := getExistingObjByID(s.DB, assetScanEstimationsSchemaName, *assetScanEstimation.Id, &dbObj); err != nil {
+		return models.AssetScanEstimation{}, err
+	}
+
+	var err error
+	var dbAssetScanEstimation models.AssetScanEstimation
+	err = json.Unmarshal(dbObj.Data, &dbAssetScanEstimation)
+	if err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	if err := checkRevisionEtag(params.IfMatch, dbAssetScanEstimation.Revision); err != nil {
+		return models.AssetScanEstimation{}, err
+	}
+
+	assetScanEstimation.Revision = bumpRevision(dbAssetScanEstimation.Revision)
+
+	dbObj.Data, err = patchObject(dbObj.Data, assetScanEstimation)
+	if err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to apply patch: %w", err)
+	}
+
+	var ase models.AssetScanEstimation
+	err = json.Unmarshal(dbObj.Data, &ase)
+	if err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	// Check the existing DB entries to ensure that the scanEstimation id and asset id fields are unique
+	existingAssetScanEstimation, err := s.checkUniqueness(ase)
+	if err != nil {
+		var conflictErr *common.ConflictError
+		if errors.As(err, &conflictErr) {
+			return existingAssetScanEstimation, err
+		}
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to check existing asset scan estimation: %w", err)
+	}
+
+	if err := s.DB.Save(&dbObj).Error; err != nil {
+		return models.AssetScanEstimation{}, fmt.Errorf("failed to save asset scan estimation in db: %w", err)
+	}
+
+	return ase, nil
+}
+
+func (s *AssetScanEstimationsTableHandler) checkUniqueness(assetScanEstimation models.AssetScanEstimation) (models.AssetScanEstimation, error) {
+	// We only check unique if ScanEstimation is set, so return early if it's not set.
+	if assetScanEstimation.ScanEstimation == nil || assetScanEstimation.ScanEstimation.Id == nil || *assetScanEstimation.ScanEstimation.Id == "" {
+		return models.AssetScanEstimation{}, nil
+	}
+
+	// If ScanEstimation is set we need to check if there is another asset scan estimation with
+	// the same scanEstimation id and asset id.
+	var assetScanEstimations []AssetScanEstimation
+	filter := fmt.Sprintf("id ne '%s' and asset/id eq '%s' and scanEstimation/id eq '%s'", *assetScanEstimation.Id, assetScanEstimation.Asset.Id, assetScanEstimation.ScanEstimation.Id)
+	err := ODataQuery(s.DB, assetScanEstimationsSchemaName, &filter, nil, nil, nil, nil, nil, true, &assetScanEstimations)
+	if err != nil {
+		return models.AssetScanEstimation{}, err
+	}
+
+	if len(assetScanEstimations) > 0 {
+		var as models.AssetScanEstimation
+		if err = json.Unmarshal(assetScanEstimations[0].Data, &as); err != nil {
+			return models.AssetScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+		}
+		return as, &common.ConflictError{
+			Reason: fmt.Sprintf("AssetScanEstimation exists with same asset id=%s and scanEstimation id=%s)", assetScanEstimation.Asset.Id, assetScanEstimation.ScanEstimation.Id),
+		}
+	}
+	return models.AssetScanEstimation{}, nil
+}

--- a/pkg/apiserver/database/gorm/database.go
+++ b/pkg/apiserver/database/gorm/database.go
@@ -75,6 +75,8 @@ func initDataBase(config types.DBConfig) (*gorm.DB, error) {
 		ScanConfig{},
 		Scan{},
 		Finding{},
+		AssetScanEstimation{},
+		ScanEstimation{},
 	); err != nil {
 		return nil, fmt.Errorf("failed to run auto migration: %w", err)
 	}
@@ -94,6 +96,11 @@ func initDataBase(config types.DBConfig) (*gorm.DB, error) {
 		return nil, fmt.Errorf("failed to create index asset_scans_id_idx: %w", idb.Error)
 	}
 
+	idb = db.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS asset_scan_estimations_id_idx ON asset_scan_estimations((%s))", SQLVariant.JSONExtract("Data", "$.id")))
+	if idb.Error != nil {
+		return nil, fmt.Errorf("failed to create index asset_scan_estimations_id_idx: %w", idb.Error)
+	}
+
 	idb = db.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS scan_configs_id_idx ON scan_configs((%s))", SQLVariant.JSONExtract("Data", "$.id")))
 	if idb.Error != nil {
 		return nil, fmt.Errorf("failed to create index scan_configs_id_idx: %w", idb.Error)
@@ -102,6 +109,11 @@ func initDataBase(config types.DBConfig) (*gorm.DB, error) {
 	idb = db.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS scans_id_idx ON scans((%s))", SQLVariant.JSONExtract("Data", "$.id")))
 	if idb.Error != nil {
 		return nil, fmt.Errorf("failed to create index scans_id_idx: %w", idb.Error)
+	}
+
+	idb = db.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS scan_estimations_id_idx ON scan_estimations((%s))", SQLVariant.JSONExtract("Data", "$.id")))
+	if idb.Error != nil {
+		return nil, fmt.Errorf("failed to create index scan_estimations_id_idx: %w", idb.Error)
 	}
 
 	idb = db.Exec(fmt.Sprintf("CREATE INDEX IF NOT EXISTS findings_id_idx ON findings((%s))", SQLVariant.JSONExtract("Data", "$.id")))

--- a/pkg/apiserver/database/gorm/odata.go
+++ b/pkg/apiserver/database/gorm/odata.go
@@ -879,6 +879,96 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 			},
 		},
 	},
+	scanEstimationSchemaName: {
+		Table: "scan_estimations",
+		Fields: odatasql.Schema{
+			"id":        odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"startTime": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"endTime":   odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"assetIDs": odatasql.FieldMeta{
+				FieldType: odatasql.CollectionFieldType,
+				CollectionItemMeta: &odatasql.FieldMeta{
+					FieldType: odatasql.PrimitiveFieldType,
+				},
+			},
+			"state": odatasql.FieldMeta{
+				FieldType: odatasql.PrimitiveFieldType,
+			},
+			"stateMessage": odatasql.FieldMeta{
+				FieldType: odatasql.PrimitiveFieldType,
+			},
+			"stateReason": odatasql.FieldMeta{
+				FieldType: odatasql.PrimitiveFieldType,
+			},
+			"estimation": odatasql.FieldMeta{
+				FieldType:           odatasql.ComplexFieldType,
+				ComplexFieldSchemas: []string{"Estimation"},
+			},
+			"scanTemplate": odatasql.FieldMeta{
+				FieldType:           odatasql.ComplexFieldType,
+				ComplexFieldSchemas: []string{"ScanTemplate"},
+			},
+			"summary": odatasql.FieldMeta{
+				FieldType:           odatasql.ComplexFieldType,
+				ComplexFieldSchemas: []string{"ScanEstimationSummary"},
+			},
+		},
+	},
+	"Estimation": {
+		Fields: odatasql.Schema{
+			"time": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"size": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"cost": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType}, // TODO are we handling float numbers in the db?
+		},
+	},
+	"ScanEstimationSummary": {
+		Fields: odatasql.Schema{
+			"jobsLeftToRun": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"jobsCompleted": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+		},
+	},
+	assetScanEstimationsSchemaName: {
+		Table: "asset_scan_estimations",
+		Fields: odatasql.Schema{
+			"id": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"asset": odatasql.FieldMeta{
+				FieldType:            odatasql.RelationshipFieldType,
+				RelationshipSchema:   assetSchemaName,
+				RelationshipProperty: "id",
+			},
+			"scanEstimation": odatasql.FieldMeta{
+				FieldType:           odatasql.ComplexFieldType,
+				ComplexFieldSchemas: []string{"ScanEstimationFakeRelationship"},
+			},
+			"estimation": odatasql.FieldMeta{
+				FieldType:           odatasql.ComplexFieldType,
+				ComplexFieldSchemas: []string{"Estimation"},
+			},
+			"assetScanTemplate": odatasql.FieldMeta{
+				FieldType:           odatasql.ComplexFieldType,
+				ComplexFieldSchemas: []string{"AssetScanTemplate"},
+			},
+			"state": odatasql.FieldMeta{
+				FieldType:           odatasql.ComplexFieldType,
+				ComplexFieldSchemas: []string{"AssetScanEstimationState"},
+			},
+		},
+	},
+	"AssetScanEstimationState": {
+		Fields: odatasql.Schema{
+			"state":              odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"lastTransitionTime": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			"errors": odatasql.FieldMeta{
+				FieldType:          odatasql.CollectionFieldType,
+				CollectionItemMeta: &odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+			},
+		},
+	},
+	"ScanEstimationFakeRelationship": {
+		Fields: odatasql.Schema{
+			"id": odatasql.FieldMeta{FieldType: odatasql.PrimitiveFieldType},
+		},
+	},
 }
 
 func ODataQuery(db *gorm.DB, schema string, filterString, selectString, expandString, orderby *string, top, skip *int, collection bool, result interface{}) error {

--- a/pkg/apiserver/database/gorm/scan_estimation.go
+++ b/pkg/apiserver/database/gorm/scan_estimation.go
@@ -1,0 +1,227 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gorm
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/openclarity/vmclarity/api/models"
+	"github.com/openclarity/vmclarity/pkg/apiserver/common"
+	"github.com/openclarity/vmclarity/pkg/apiserver/database/types"
+	"github.com/openclarity/vmclarity/pkg/shared/utils"
+)
+
+const (
+	scanEstimationSchemaName = "ScanEstimation"
+)
+
+type ScanEstimation struct {
+	ODataObject
+}
+
+type ScanEstimationsTableHandler struct {
+	DB *gorm.DB
+}
+
+func (db *Handler) ScanEstimationsTable() types.ScanEstimationsTable {
+	return &ScanEstimationsTableHandler{
+		DB: db.DB,
+	}
+}
+
+func (s *ScanEstimationsTableHandler) GetScanEstimations(params models.GetScanEstimationsParams) (models.ScanEstimations, error) {
+	var scanEstimations []ScanEstimation
+	err := ODataQuery(s.DB, scanEstimationSchemaName, params.Filter, params.Select, params.Expand, params.OrderBy, params.Top, params.Skip, true, &scanEstimations)
+	if err != nil {
+		return models.ScanEstimations{}, err
+	}
+
+	items := make([]models.ScanEstimation, len(scanEstimations))
+	for i, sc := range scanEstimations {
+		var scanEstimation models.ScanEstimation
+		err = json.Unmarshal(sc.Data, &scanEstimation)
+		if err != nil {
+			return models.ScanEstimations{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+		}
+		items[i] = scanEstimation
+	}
+
+	output := models.ScanEstimations{Items: &items}
+
+	if params.Count != nil && *params.Count {
+		count, err := ODataCount(s.DB, scanEstimationSchemaName, params.Filter)
+		if err != nil {
+			return models.ScanEstimations{}, fmt.Errorf("failed to count records: %w", err)
+		}
+		output.Count = &count
+	}
+
+	return output, nil
+}
+
+func (s *ScanEstimationsTableHandler) GetScanEstimation(scanEstimationID models.ScanEstimationID, params models.GetScanEstimationsScanEstimationIDParams) (models.ScanEstimation, error) {
+	var dbScanEstimation ScanEstimation
+	filter := fmt.Sprintf("id eq '%s'", scanEstimationID)
+	err := ODataQuery(s.DB, scanEstimationSchemaName, &filter, params.Select, params.Expand, nil, nil, nil, false, &dbScanEstimation)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return models.ScanEstimation{}, types.ErrNotFound
+		}
+		return models.ScanEstimation{}, err
+	}
+
+	var apiScanEstimation models.ScanEstimation
+	err = json.Unmarshal(dbScanEstimation.Data, &apiScanEstimation)
+	if err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	return apiScanEstimation, nil
+}
+
+func (s *ScanEstimationsTableHandler) CreateScanEstimation(scanEstimation models.ScanEstimation) (models.ScanEstimation, error) {
+	// Check the user didn't provide an ID
+	if scanEstimation.Id != nil {
+		return models.ScanEstimation{}, &common.BadRequestError{
+			Reason: "can not specify id field when creating a new ScanEstimation",
+		}
+	}
+
+	// Generate a new UUID
+	scanEstimation.Id = utils.PointerTo(uuid.New().String())
+
+	// Initialise revision
+	scanEstimation.Revision = utils.PointerTo(1)
+
+	marshaled, err := json.Marshal(scanEstimation)
+	if err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to convert API model to DB model: %w", err)
+	}
+
+	newScanEstimation := ScanEstimation{}
+	newScanEstimation.Data = marshaled
+
+	if err = s.DB.Create(&newScanEstimation).Error; err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to create scan estimation in db: %w", err)
+	}
+
+	var apiScanEstimation models.ScanEstimation
+	err = json.Unmarshal(newScanEstimation.Data, &apiScanEstimation)
+	if err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	return apiScanEstimation, nil
+}
+
+// nolint:cyclop
+func (s *ScanEstimationsTableHandler) SaveScanEstimation(scanEstimation models.ScanEstimation, params models.PutScanEstimationsScanEstimationIDParams) (models.ScanEstimation, error) {
+	if scanEstimation.Id == nil || *scanEstimation.Id == "" {
+		return models.ScanEstimation{}, &common.BadRequestError{
+			Reason: "id is required to save scan estimation",
+		}
+	}
+
+	var dbObj ScanEstimation
+	if err := getExistingObjByID(s.DB, scanEstimationSchemaName, *scanEstimation.Id, &dbObj); err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to get scan estimation from db: %w", err)
+	}
+
+	var dbScanEstimation models.ScanEstimation
+	if err := json.Unmarshal(dbObj.Data, &dbScanEstimation); err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to convert DB object to API model: %w", err)
+	}
+
+	if err := checkRevisionEtag(params.IfMatch, dbScanEstimation.Revision); err != nil {
+		return models.ScanEstimation{}, err
+	}
+
+	scanEstimation.Revision = bumpRevision(dbScanEstimation.Revision)
+
+	marshaled, err := json.Marshal(scanEstimation)
+	if err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to convert API model to DB model: %w", err)
+	}
+
+	dbObj.Data = marshaled
+
+	if err = s.DB.Save(&dbObj).Error; err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to save scan estimation in db: %w", err)
+	}
+
+	var apiScanEstimation models.ScanEstimation
+	if err = json.Unmarshal(dbObj.Data, &apiScanEstimation); err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	return apiScanEstimation, nil
+}
+
+// nolint:cyclop
+func (s *ScanEstimationsTableHandler) UpdateScanEstimation(scanEstimation models.ScanEstimation, params models.PatchScanEstimationsScanEstimationIDParams) (models.ScanEstimation, error) {
+	if scanEstimation.Id == nil || *scanEstimation.Id == "" {
+		return models.ScanEstimation{}, &common.BadRequestError{
+			Reason: "id is required to update scan estimation",
+		}
+	}
+
+	var dbObj ScanEstimation
+	if err := getExistingObjByID(s.DB, scanEstimationSchemaName, *scanEstimation.Id, &dbObj); err != nil {
+		return models.ScanEstimation{}, err
+	}
+
+	var dbScanEstimation models.ScanEstimation
+	if err := json.Unmarshal(dbObj.Data, &dbScanEstimation); err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to convert DB object to API model: %w", err)
+	}
+
+	if err := checkRevisionEtag(params.IfMatch, dbScanEstimation.Revision); err != nil {
+		return models.ScanEstimation{}, err
+	}
+
+	scanEstimation.Revision = bumpRevision(dbScanEstimation.Revision)
+
+	var err error
+	dbObj.Data, err = patchObject(dbObj.Data, scanEstimation)
+	if err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to apply patch: %w", err)
+	}
+
+	var ret models.ScanEstimation
+	err = json.Unmarshal(dbObj.Data, &ret)
+	if err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to convert DB model to API model: %w", err)
+	}
+
+	if err := s.DB.Save(&dbObj).Error; err != nil {
+		return models.ScanEstimation{}, fmt.Errorf("failed to save scan estimation in db: %w", err)
+	}
+
+	return ret, nil
+}
+
+func (s *ScanEstimationsTableHandler) DeleteScanEstimation(scanEstimationID models.ScanEstimationID) error {
+	if err := deleteObjByID(s.DB, scanEstimationID, &ScanEstimation{}); err != nil {
+		return fmt.Errorf("failed to delete scan estimation: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/apiserver/database/types/database.go
+++ b/pkg/apiserver/database/types/database.go
@@ -55,6 +55,8 @@ type Database interface {
 	ScansTable() ScansTable
 	AssetsTable() AssetsTable
 	FindingsTable() FindingsTable
+	ScanEstimationsTable() ScanEstimationsTable
+	AssetScanEstimationsTable() AssetScanEstimationsTable
 }
 
 type ScansTable interface {
@@ -110,4 +112,24 @@ type FindingsTable interface {
 	SaveFinding(finding models.Finding) (models.Finding, error)
 
 	DeleteFinding(findingID models.FindingID) error
+}
+
+type ScanEstimationsTable interface {
+	GetScanEstimations(params models.GetScanEstimationsParams) (models.ScanEstimations, error)
+	GetScanEstimation(scanEstimationID models.ScanEstimationID, params models.GetScanEstimationsScanEstimationIDParams) (models.ScanEstimation, error)
+
+	CreateScanEstimation(scanEstimation models.ScanEstimation) (models.ScanEstimation, error)
+	UpdateScanEstimation(scanEstimation models.ScanEstimation, params models.PatchScanEstimationsScanEstimationIDParams) (models.ScanEstimation, error)
+	SaveScanEstimation(scanEstimation models.ScanEstimation, params models.PutScanEstimationsScanEstimationIDParams) (models.ScanEstimation, error)
+
+	DeleteScanEstimation(scanEstimationID models.ScanEstimationID) error
+}
+
+type AssetScanEstimationsTable interface {
+	GetAssetScanEstimations(params models.GetAssetScanEstimationsParams) (models.AssetScanEstimations, error)
+	GetAssetScanEstimation(assetScanEstimationID models.AssetScanEstimationID, params models.GetAssetScanEstimationsAssetScanEstimationIDParams) (models.AssetScanEstimation, error)
+
+	CreateAssetScanEstimation(assetScanEstimations models.AssetScanEstimation) (models.AssetScanEstimation, error)
+	UpdateAssetScanEstimation(assetScanEstimations models.AssetScanEstimation, params models.PatchAssetScanEstimationsAssetScanEstimationIDParams) (models.AssetScanEstimation, error)
+	SaveAssetScanEstimation(assetScanEstimations models.AssetScanEstimation, params models.PutAssetScanEstimationsAssetScanEstimationIDParams) (models.AssetScanEstimation, error)
 }

--- a/pkg/apiserver/rest/asset_scan_estimation_controller.go
+++ b/pkg/apiserver/rest/asset_scan_estimation_controller.go
@@ -1,0 +1,151 @@
+package rest
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+
+	"github.com/openclarity/vmclarity/api/models"
+	"github.com/openclarity/vmclarity/pkg/apiserver/common"
+	databaseTypes "github.com/openclarity/vmclarity/pkg/apiserver/database/types"
+	"github.com/openclarity/vmclarity/pkg/shared/utils"
+)
+
+func (s *ServerImpl) GetAssetScanEstimations(ctx echo.Context, params models.GetAssetScanEstimationsParams) error {
+	dbAssetScanEstimations, err := s.dbHandler.AssetScanEstimationsTable().GetAssetScanEstimations(params)
+	if err != nil {
+		return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to get asset scan estimations results from db: %v", err))
+	}
+
+	return sendResponse(ctx, http.StatusOK, dbAssetScanEstimations)
+}
+
+func (s *ServerImpl) PostAssetScanEstimations(ctx echo.Context) error {
+	var assetScanEstimation models.AssetScanEstimation
+	err := ctx.Bind(&assetScanEstimation)
+	if err != nil {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("failed to bind request: %v", err))
+	}
+
+	createdAssetScanEstimation, err := s.dbHandler.AssetScanEstimationsTable().CreateAssetScanEstimation(assetScanEstimation)
+	if err != nil {
+		var conflictErr *common.ConflictError
+		if errors.As(err, &conflictErr) {
+			existResponse := &models.AssetScanEstimationExists{
+				Message:             utils.PointerTo(conflictErr.Reason),
+				AssetScanEstimation: &createdAssetScanEstimation,
+			}
+			return sendResponse(ctx, http.StatusConflict, existResponse)
+		}
+		return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to create asset scan estimation in db: %v", err))
+	}
+
+	return sendResponse(ctx, http.StatusCreated, createdAssetScanEstimation)
+}
+
+func (s *ServerImpl) GetAssetScanEstimationsAssetScanEstimationID(ctx echo.Context, assetScanEstimationID models.AssetScanEstimationID, params models.GetAssetScanEstimationsAssetScanEstimationIDParams) error {
+	dbAssetScanEstimation, err := s.dbHandler.AssetScanEstimationsTable().GetAssetScanEstimation(assetScanEstimationID, params)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return sendError(ctx, http.StatusNotFound, err.Error())
+		}
+		return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to get asset scan estimation from db. assetScanEstimationID=%v: %v", assetScanEstimationID, err))
+	}
+
+	return sendResponse(ctx, http.StatusOK, dbAssetScanEstimation)
+}
+func (s *ServerImpl) PatchAssetScanEstimationsAssetScanEstimationID(ctx echo.Context, assetScanEstimationID models.AssetScanEstimationID, params models.PatchAssetScanEstimationsAssetScanEstimationIDParams) error {
+	var assetScanEstimation models.AssetScanEstimation
+	err := ctx.Bind(&assetScanEstimation)
+	if err != nil {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("failed to bind request: %v", err))
+	}
+
+	// check that an asset scan estimation with that id exists.
+	_, err = s.dbHandler.AssetScanEstimationsTable().GetAssetScanEstimation(assetScanEstimationID, models.GetAssetScanEstimationsAssetScanEstimationIDParams{})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return sendError(ctx, http.StatusNotFound, fmt.Sprintf("asset scan estimation was not found. assetScanEstimationID=%v: %v", assetScanEstimationID, err))
+		}
+		return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to get asset scan estimation. assetScanEstimationID=%v: %v", assetScanEstimationID, err))
+	}
+
+	// PATCH request might not contain the ID in the body, so set it from
+	// the URL field so that the DB layer knows which object is being updated.
+	if assetScanEstimation.Id != nil && *assetScanEstimation.Id != assetScanEstimationID {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("id in body %s does not match object %s to be updated", *assetScanEstimation.Id, assetScanEstimationID))
+	}
+	assetScanEstimation.Id = &assetScanEstimationID
+
+	updatedAssetScanEstimation, err := s.dbHandler.AssetScanEstimationsTable().UpdateAssetScanEstimation(assetScanEstimation, params)
+	if err != nil {
+		var validationErr *common.BadRequestError
+		var conflictErr *common.ConflictError
+		var preconditionFailedErr *databaseTypes.PreconditionFailedError
+		switch true {
+		case errors.As(err, &conflictErr):
+			existResponse := &models.AssetScanEstimationExists{
+				Message:             utils.PointerTo(conflictErr.Reason),
+				AssetScanEstimation: &updatedAssetScanEstimation,
+			}
+			return sendResponse(ctx, http.StatusConflict, existResponse)
+		case errors.As(err, &validationErr):
+			return sendError(ctx, http.StatusBadRequest, err.Error())
+		case errors.As(err, &preconditionFailedErr):
+			return sendError(ctx, http.StatusPreconditionFailed, err.Error())
+		default:
+			return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to update asset scan estimation in db. assetScanEstimationID=%v: %v", assetScanEstimationID, err))
+		}
+	}
+
+	return sendResponse(ctx, http.StatusOK, updatedAssetScanEstimation)
+}
+func (s *ServerImpl) PutAssetScanEstimationsAssetScanEstimationID(ctx echo.Context, assetScanEstimationID models.AssetScanEstimationID, params models.PutAssetScanEstimationsAssetScanEstimationIDParams) error {
+	var assetScanEstimation models.AssetScanEstimation
+	err := ctx.Bind(&assetScanEstimation)
+	if err != nil {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("failed to bind request: %v", err))
+	}
+
+	// check that an asset scan estimation with that id exists.
+	_, err = s.dbHandler.AssetScanEstimationsTable().GetAssetScanEstimation(assetScanEstimationID, models.GetAssetScanEstimationsAssetScanEstimationIDParams{})
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return sendError(ctx, http.StatusNotFound, fmt.Sprintf("asset scan estimation was not found. assetScanEstimationID=%v: %v", assetScanEstimationID, err))
+		}
+		return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to get asset scan estimation. assetScanEstimationID=%v: %v", assetScanEstimationID, err))
+	}
+
+	// PUT request might not contain the ID in the body, so set it from
+	// the URL field so that the DB layer knows which object is being updated.
+	if assetScanEstimation.Id != nil && *assetScanEstimation.Id != assetScanEstimationID {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("id in body %s does not match object %s to be updated", *assetScanEstimation.Id, assetScanEstimationID))
+	}
+	assetScanEstimation.Id = &assetScanEstimationID
+
+	updatedAssetScanEstimation, err := s.dbHandler.AssetScanEstimationsTable().SaveAssetScanEstimation(assetScanEstimation, params)
+	if err != nil {
+		var validationErr *common.BadRequestError
+		var conflictErr *common.ConflictError
+		var preconditionFailedErr *databaseTypes.PreconditionFailedError
+		switch true {
+		case errors.As(err, &conflictErr):
+			existResponse := &models.AssetScanEstimationExists{
+				Message:             utils.PointerTo(conflictErr.Reason),
+				AssetScanEstimation: &updatedAssetScanEstimation,
+			}
+			return sendResponse(ctx, http.StatusConflict, existResponse)
+		case errors.As(err, &validationErr):
+			return sendError(ctx, http.StatusBadRequest, err.Error())
+		case errors.As(err, &preconditionFailedErr):
+			return sendError(ctx, http.StatusPreconditionFailed, err.Error())
+		default:
+			return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to update asset scan estimation in db. assetScanEstimationID=%v: %v", assetScanEstimationID, err))
+		}
+	}
+
+	return sendResponse(ctx, http.StatusOK, updatedAssetScanEstimation)
+}

--- a/pkg/apiserver/rest/scan_estimation_controller.go
+++ b/pkg/apiserver/rest/scan_estimation_controller.go
@@ -1,0 +1,152 @@
+package rest
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/openclarity/vmclarity/api/models"
+	"github.com/openclarity/vmclarity/pkg/apiserver/common"
+	databaseTypes "github.com/openclarity/vmclarity/pkg/apiserver/database/types"
+	"github.com/openclarity/vmclarity/pkg/shared/utils"
+)
+
+func (s *ServerImpl) GetScanEstimations(ctx echo.Context, params models.GetScanEstimationsParams) error {
+	scanEstimations, err := s.dbHandler.ScanEstimationsTable().GetScanEstimations(params)
+	if err != nil {
+		return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to get scan estimations from db: %v", err))
+	}
+
+	return sendResponse(ctx, http.StatusOK, scanEstimations)
+}
+func (s *ServerImpl) PostScanEstimations(ctx echo.Context) error {
+	var scanEstimation models.ScanEstimation
+	err := ctx.Bind(&scanEstimation)
+	if err != nil {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("failed to bind request: %v", err))
+	}
+
+	createdScanEstimation, err := s.dbHandler.ScanEstimationsTable().CreateScanEstimation(scanEstimation)
+	if err != nil {
+		var conflictErr *common.ConflictError
+		var validationErr *common.BadRequestError
+		switch true {
+		case errors.As(err, &conflictErr):
+			existResponse := &models.ScanEstimationExists{
+				Message:        utils.PointerTo(conflictErr.Reason),
+				ScanEstimation: &createdScanEstimation,
+			}
+			return sendResponse(ctx, http.StatusConflict, existResponse)
+		case errors.As(err, &validationErr):
+			return sendError(ctx, http.StatusBadRequest, err.Error())
+		default:
+			return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to create scan estimation in db: %v", err))
+		}
+	}
+
+	return sendResponse(ctx, http.StatusCreated, createdScanEstimation)
+}
+func (s *ServerImpl) DeleteScanEstimationsScanEstimationID(ctx echo.Context, scanEstimationID models.ScanEstimationID) error {
+	success := models.Success{
+		Message: utils.PointerTo(fmt.Sprintf("scan estimation %v deleted", scanEstimationID)),
+	}
+
+	if err := s.dbHandler.ScanEstimationsTable().DeleteScanEstimation(scanEstimationID); err != nil {
+		if errors.Is(err, databaseTypes.ErrNotFound) {
+			return sendError(ctx, http.StatusNotFound, fmt.Sprintf("ScanEstimation with ID %v not found", scanEstimationID))
+		}
+		return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to delete scan estimation from db. scanEstimationID=%v: %v", scanEstimationID, err))
+	}
+
+	return sendResponse(ctx, http.StatusOK, &success)
+}
+func (s *ServerImpl) GetScanEstimationsScanEstimationID(ctx echo.Context, scanEstimationID models.ScanEstimationID, params models.GetScanEstimationsScanEstimationIDParams) error {
+	scanEstimation, err := s.dbHandler.ScanEstimationsTable().GetScanEstimation(scanEstimationID, params)
+	if err != nil {
+		if errors.Is(err, databaseTypes.ErrNotFound) {
+			return sendError(ctx, http.StatusNotFound, fmt.Sprintf("ScanEstimation with ID %v not found", scanEstimationID))
+		}
+		return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to get scan estimation from db. id=%v: %v", scanEstimationID, err))
+	}
+	return sendResponse(ctx, http.StatusOK, scanEstimation)
+}
+func (s *ServerImpl) PatchScanEstimationsScanEstimationID(ctx echo.Context, scanEstimationID models.ScanEstimationID, params models.PatchScanEstimationsScanEstimationIDParams) error {
+	var scanEstimation models.ScanEstimation
+	err := ctx.Bind(&scanEstimation)
+	if err != nil {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("failed to bind request: %v", err))
+	}
+
+	// PATCH request might not contain the ID in the body, so set it from
+	// the URL field so that the DB layer knows which object is being updated.
+	if scanEstimation.Id != nil && *scanEstimation.Id != scanEstimationID {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("id in body %s does not match object %s to be updated", *scanEstimation.Id, scanEstimationID))
+	}
+	scanEstimation.Id = &scanEstimationID
+
+	updatedScanEstimation, err := s.dbHandler.ScanEstimationsTable().UpdateScanEstimation(scanEstimation, params)
+	if err != nil {
+		var validationErr *common.BadRequestError
+		var conflictErr *common.BadRequestError
+		var preconditionFailedErr *databaseTypes.PreconditionFailedError
+		switch true {
+		case errors.Is(err, databaseTypes.ErrNotFound):
+			return sendError(ctx, http.StatusNotFound, fmt.Sprintf("ScanEstimation with ID %v not found", scanEstimationID))
+		case errors.As(err, &conflictErr):
+			existResponse := &models.ScanEstimationExists{
+				Message:        utils.PointerTo(conflictErr.Reason),
+				ScanEstimation: &updatedScanEstimation,
+			}
+			return sendResponse(ctx, http.StatusConflict, existResponse)
+		case errors.As(err, &validationErr):
+			return sendError(ctx, http.StatusBadRequest, err.Error())
+		case errors.As(err, &preconditionFailedErr):
+			return sendError(ctx, http.StatusPreconditionFailed, err.Error())
+		default:
+			return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to update scan estimation in db. scanEstimationID=%v: %v", scanEstimationID, err))
+		}
+	}
+
+	return sendResponse(ctx, http.StatusOK, updatedScanEstimation)
+}
+func (s *ServerImpl) PutScanEstimationsScanEstimationID(ctx echo.Context, scanEstimationID models.ScanEstimationID, params models.PutScanEstimationsScanEstimationIDParams) error {
+	var scanEstimation models.ScanEstimation
+	err := ctx.Bind(&scanEstimation)
+	if err != nil {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("failed to bind request: %v", err))
+	}
+
+	// PUT request might not contain the ID in the body, so set it from the
+	// URL field so that the DB layer knows which object is being updated.
+	if scanEstimation.Id != nil && *scanEstimation.Id != scanEstimationID {
+		return sendError(ctx, http.StatusBadRequest, fmt.Sprintf("id in body %s does not match object %s to be updated", *scanEstimation.Id, scanEstimationID))
+	}
+	scanEstimation.Id = &scanEstimationID
+
+	updatedScanEstimation, err := s.dbHandler.ScanEstimationsTable().SaveScanEstimation(scanEstimation, params)
+	if err != nil {
+		var validationErr *common.BadRequestError
+		var conflictErr *common.ConflictError
+		var preconditionFailedErr *databaseTypes.PreconditionFailedError
+		switch true {
+		case errors.Is(err, databaseTypes.ErrNotFound):
+			return sendError(ctx, http.StatusNotFound, fmt.Sprintf("ScanEstimation with ID %v not found", scanEstimationID))
+		case errors.As(err, &conflictErr):
+			existResponse := &models.ScanEstimationExists{
+				Message:        utils.PointerTo(conflictErr.Reason),
+				ScanEstimation: &updatedScanEstimation,
+			}
+			return sendResponse(ctx, http.StatusConflict, existResponse)
+		case errors.As(err, &validationErr):
+			return sendError(ctx, http.StatusBadRequest, err.Error())
+		case errors.As(err, &preconditionFailedErr):
+			return sendError(ctx, http.StatusPreconditionFailed, err.Error())
+		default:
+			return sendError(ctx, http.StatusInternalServerError, fmt.Sprintf("failed to save scan estimation in db. scanEstimationID=%v: %v", scanEstimationID, err))
+		}
+	}
+
+	return sendResponse(ctx, http.StatusOK, updatedScanEstimation)
+}


### PR DESCRIPTION
## Description

https://github.com/openclarity/vmclarity/discussions/465

Adding the ability to post a new scan estimation request which will perform a cost estimation of a scan/assetScan according to the scan configuration (scan scope) and previous asset scans statistics.

Adds 2 new resources: ScanEstimation and AssetScanEstimation with corresponding API endpoints.
Also added 2 new tables in the DB and 2 new reconcile controllers for these new resources (see orchestrator PR: ).

The cost calculation implementation  for AWS will be added soon.

## Type of Change

[ ] Bug Fix  
[* ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  
