### PR TITLE
fix(uibackend): reduce recalculation interval

### DIFF
--- a/e2e/docker-compose.override.yml
+++ b/e2e/docker-compose.override.yml
@@ -9,17 +9,6 @@ services:
         source: /tmp
         target: /tmp
 
-  # Note(paralta): Override uibackend healthcheck is required because if server background recalculation fails the
-  # recalculation interval (backgroundRecalculationInterval) will be 15min. Plus, the uibackend is currently not
-  # covered by end-to-end tests.
-  uibackend:
-    ports:
-      - "8890:8890"
-    healthcheck:
-      test: ["CMD", "nc", "-z", "127.0.0.1", "8890"]
-      interval: 10s
-      retries: 60
-
   alpine:
     image: alpine:3.18.2
     command: ["sleep", "infinity"]

--- a/pkg/uibackend/rest/server.go
+++ b/pkg/uibackend/rest/server.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	backgroundRecalculationInterval = 15 * time.Minute
+	backgroundRecalculationInterval = 2 * time.Minute
 )
 
 type ServerImpl struct {


### PR DESCRIPTION
## Description

Reduce background recalculation interval in uibackend because the healthcheck will fail intermittently with a timeout if the recalculation fails and needs a rerun. 

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
