### PR TITLE
Fixing issue for Incorrect use of errors.Join in aws/client.go #608

### DIFF
--- a/pkg/orchestrator/provider/aws/client.go
+++ b/pkg/orchestrator/provider/aws/client.go
@@ -314,8 +314,18 @@ func (c *Client) RunAssetScan(ctx context.Context, config *provider.ScanJobConfi
 	//                    in parallel.
 
 	// Create scanner instance
-	numOfGoroutines := 2
-	errs := make([]error, numOfGoroutines)
+	var errs []error
+	errsChan := make(chan error)
+
+	var errWg sync.WaitGroup
+	errWg.Add(1)
+	go func() {
+		defer errWg.Done()
+		for e := range errsChan {
+			errs = append(errs, e)
+		}
+	}()
+
 	var scannnerInstance *Instance
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -327,23 +337,23 @@ func (c *Client) RunAssetScan(ctx context.Context, config *provider.ScanJobConfi
 		var err error
 		scannnerInstance, err = c.createInstance(ctx, c.config.ScannerRegion, config)
 		if err != nil {
-			errs = append(errs, WrapError(fmt.Errorf("failed to create scanner VM instance: %w", err)))
+			errsChan <- WrapError(fmt.Errorf("failed to create scanner VM instance: %w", err))
 			return
 		}
 
 		ready, err := scannnerInstance.IsReady(ctx)
 		if err != nil {
-			errs = append(errs, WrapError(fmt.Errorf("failed to get scanner VM instance state: %w", err)))
+			errsChan <- WrapError(fmt.Errorf("failed to get scanner VM instance state: %w", err))
 			return
 		}
 		logger.WithFields(logrus.Fields{
 			"ScannerInstanceID": scannnerInstance.ID,
 		}).Debugf("Scanner instance is ready: %t", ready)
 		if !ready {
-			errs = append(errs, RetryableError{
+			errsChan <- RetryableError{
 				Err:   errors.New("scanner instance is not ready"),
 				After: InstanceReadynessAfter,
-			})
+			}
 		}
 	}()
 
@@ -360,22 +370,22 @@ func (c *Client) RunAssetScan(ctx context.Context, config *provider.ScanJobConfi
 
 		assetVMLocation, err := NewLocation(vmInfo.Location)
 		if err != nil {
-			errs = append(errs, FatalError{
+			errsChan <- FatalError{
 				Err: fmt.Errorf("failed to parse Location for asset VM instance: %w", err),
-			})
+			}
 			return
 		}
 
 		var SrcEC2Instance *ec2types.Instance
 		SrcEC2Instance, err = c.getInstanceWithID(ctx, vmInfo.InstanceID, assetVMLocation.Region)
 		if err != nil {
-			errs = append(errs, WrapError(fmt.Errorf("failed to fetch asset VM instance: %w", err)))
+			errsChan <- WrapError(fmt.Errorf("failed to fetch asset VM instance: %w", err))
 			return
 		}
 		if SrcEC2Instance == nil {
-			errs = append(errs, FatalError{
+			errsChan <- FatalError{
 				Err: fmt.Errorf("failed to find asset VM instance. InstanceID=%s", vmInfo.InstanceID),
-			})
+			}
 			return
 		}
 
@@ -385,17 +395,17 @@ func (c *Client) RunAssetScan(ctx context.Context, config *provider.ScanJobConfi
 
 		srcVol := srcInstance.RootVolume()
 		if srcVol == nil {
-			errs = append(errs, FatalError{
+			errsChan <- FatalError{
 				Err: errors.New("failed to get root block device for asset VM instance"),
-			})
+			}
 			return
 		}
 
 		logger.WithField("AssetVolumeID", srcVol.ID).Debug("Creating asset volume snapshot for asset VM instance")
 		srcVolSnapshot, err := srcVol.CreateSnapshot(ctx)
 		if err != nil {
-			errs = append(errs, WrapError(fmt.Errorf("failed to create volume snapshot from asset volume. AssetVolumeID=%s: %w",
-				srcVol.ID, err)))
+			errsChan <- WrapError(fmt.Errorf("failed to create volume snapshot from asset volume. AssetVolumeID=%s: %w",
+				srcVol.ID, err))
 			return
 		}
 
@@ -403,7 +413,7 @@ func (c *Client) RunAssetScan(ctx context.Context, config *provider.ScanJobConfi
 		if err != nil {
 			err = fmt.Errorf("failed to get volume snapshot state. AssetVolumeSnapshotID=%s: %w",
 				srcVolSnapshot.ID, err)
-			errs = append(errs, WrapError(err))
+			errsChan <- WrapError(err)
 			return
 		}
 
@@ -412,10 +422,10 @@ func (c *Client) RunAssetScan(ctx context.Context, config *provider.ScanJobConfi
 			"AssetVolumeSnapshotID": srcVolSnapshot.ID,
 		}).Debugf("Asset volume snapshot is ready: %t", ready)
 		if !ready {
-			errs = append(errs, RetryableError{
+			errsChan <- RetryableError{
 				Err:   errors.New("asset volume snapshot is not ready"),
 				After: SnapshotReadynessAfter,
-			})
+			}
 			return
 		}
 
@@ -427,7 +437,7 @@ func (c *Client) RunAssetScan(ctx context.Context, config *provider.ScanJobConfi
 		if err != nil {
 			err = fmt.Errorf("failed to copy asset volume snapshot to location. AssetVolumeSnapshotID=%s Location=%s: %w",
 				srcVolSnapshot.ID, c.config.ScannerRegion, err)
-			errs = append(errs, WrapError(err))
+			errsChan <- WrapError(err)
 			return
 		}
 
@@ -435,7 +445,7 @@ func (c *Client) RunAssetScan(ctx context.Context, config *provider.ScanJobConfi
 		if err != nil {
 			err = fmt.Errorf("failed to get volume snapshot state. ScannerVolumeSnapshotID=%s: %w",
 				srcVolSnapshot.ID, err)
-			errs = append(errs, WrapError(err))
+			errsChan <- WrapError(err)
 			return
 		}
 
@@ -446,16 +456,19 @@ func (c *Client) RunAssetScan(ctx context.Context, config *provider.ScanJobConfi
 		}).Debugf("Scanner volume snapshot is ready: %t", ready)
 
 		if !ready {
-			errs = append(errs, RetryableError{
+			errsChan <- RetryableError{
 				Err:   errors.New("scanner volume snapshot is not ready"),
 				After: SnapshotReadynessAfter,
-			})
+			}
 			return
 		}
 	}()
 	wg.Wait()
-
-	errs = append(errs, err)
+	close(errsChan)
+	errWg.Wait()
+	if err != nil {
+		errs = append(errs, err)
+	}
 	err = errors.Join(errs...)
 	if err != nil {
 		return err
@@ -666,8 +679,17 @@ func (c *Client) RemoveAssetScan(ctx context.Context, config *provider.ScanJobCo
 	ec2Tags := EC2TagsFromScanMetadata(config.ScanMetadata)
 	ec2Filters := EC2FiltersFromEC2Tags(ec2Tags)
 
-	numOfGoroutines := 3
-	errs := make([]error, numOfGoroutines)
+	var errs []error
+	errsChan := make(chan error)
+
+	var errWg sync.WaitGroup
+	errWg.Add(1)
+	go func() {
+		defer errWg.Done()
+		for e := range errsChan {
+			errs = append(errs, e)
+		}
+	}()
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -678,15 +700,15 @@ func (c *Client) RemoveAssetScan(ctx context.Context, config *provider.ScanJobCo
 		logger.Debug("Deleting scanner VM Instance.")
 		done, err := c.deleteInstances(ctx, ec2Filters, c.config.ScannerRegion)
 		if err != nil {
-			errs = append(errs, WrapError(fmt.Errorf("failed to delete scanner VM instance: %w", err)))
+			errsChan <- WrapError(fmt.Errorf("failed to delete scanner VM instance: %w", err))
 			return
 		}
 		// Deleting scanner VM instance is in-progress, thus cannot proceed with deleting the scanner volume.
 		if !done {
-			errs = append(errs, RetryableError{
+			errsChan <- RetryableError{
 				Err:   errors.New("deleting Scanner VM instance is in-progress"),
 				After: InstanceReadynessAfter,
-			})
+			}
 			return
 		}
 
@@ -695,15 +717,15 @@ func (c *Client) RemoveAssetScan(ctx context.Context, config *provider.ScanJobCo
 		done, err = c.deleteVolumes(ctx, ec2Filters, c.config.ScannerRegion)
 
 		if err != nil {
-			errs = append(errs, WrapError(fmt.Errorf("failed to delete scanner volume: %w", err)))
+			errsChan <- WrapError(fmt.Errorf("failed to delete scanner volume: %w", err))
 			return
 		}
 
 		if !done {
-			errs = append(errs, RetryableError{
+			errsChan <- RetryableError{
 				Err:   errors.New("deleting Scanner volume is in-progress"),
 				After: VolumeReadynessAfter,
-			})
+			}
 			return
 		}
 	}()
@@ -716,14 +738,14 @@ func (c *Client) RemoveAssetScan(ctx context.Context, config *provider.ScanJobCo
 		logger.Debug("Deleting scanner volume snapshot.")
 		done, err := c.deleteVolumeSnapshots(ctx, ec2Filters, c.config.ScannerRegion)
 		if err != nil {
-			errs = append(errs, WrapError(fmt.Errorf("failed to delete scanner volume snapshot: %w", err)))
+			errsChan <- WrapError(fmt.Errorf("failed to delete scanner volume snapshot: %w", err))
 			return
 		}
 		if !done {
-			errs = append(errs, RetryableError{
+			errsChan <- RetryableError{
 				Err:   errors.New("deleting Scanner volume snapshot is in-progress"),
 				After: SnapshotReadynessAfter,
-			})
+			}
 			return
 		}
 	}()
@@ -735,9 +757,9 @@ func (c *Client) RemoveAssetScan(ctx context.Context, config *provider.ScanJobCo
 
 		location, err := NewLocation(vmInfo.Location)
 		if err != nil {
-			errs = append(errs, FatalError{
+			errsChan <- FatalError{
 				Err: fmt.Errorf("failed to parse Location string. Location=%s: %w", vmInfo.Location, err),
-			})
+			}
 			return
 		}
 
@@ -748,23 +770,25 @@ func (c *Client) RemoveAssetScan(ctx context.Context, config *provider.ScanJobCo
 		logger.WithField("AssetLocation", vmInfo.Location).Debug("Deleting asset volume snapshot.")
 		done, err := c.deleteVolumeSnapshots(ctx, ec2Filters, location.Region)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to delete asset volume snapshot: %w", err))
+			errsChan <- fmt.Errorf("failed to delete asset volume snapshot: %w", err)
 			return
 		}
 
 		if !done {
-			errs = append(errs, RetryableError{
+			errsChan <- RetryableError{
 				Err:   errors.New("deleting Asset volume snapshot is in-progress"),
 				After: SnapshotReadynessAfter,
-			})
+			}
 			return
 		}
 	}()
 	wg.Wait()
-
-	errs = append(errs, err)
+	close(errsChan)
+	errWg.Wait()
+	if err != nil {
+		errs = append(errs, err)
+	}
 	err = errors.Join(errs...)
-
 	return err
 }
 


### PR DESCRIPTION
## Description

Changing data type of "errs" from channel to slice 
By using slice , there is no need for "for loop" for iterating channel, we can use slice directly in errors.Join(errs...) function

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
