### PR TITLE
fix: family errors export

### DIFF
--- a/pkg/cli/presenter/vmclarity.go
+++ b/pkg/cli/presenter/vmclarity.go
@@ -87,7 +87,7 @@ func (v *VMClarityPresenter) ExportSbomResult(ctx context.Context, res families.
 		assetScan.Stats = &models.AssetScanStats{}
 	}
 
-	errs := []string{}
+	var errs []string
 
 	if res.Err != nil {
 		errs = append(errs, res.Err.Error())
@@ -135,7 +135,7 @@ func (v *VMClarityPresenter) ExportVulResult(ctx context.Context, res families.F
 		assetScan.Stats = &models.AssetScanStats{}
 	}
 
-	errs := []string{}
+	var errs []string
 
 	if res.Err != nil {
 		errs = append(errs, res.Err.Error())
@@ -182,7 +182,7 @@ func (v *VMClarityPresenter) ExportSecretsResult(ctx context.Context, res famili
 		assetScan.Stats = &models.AssetScanStats{}
 	}
 
-	errs := []string{}
+	var errs []string
 
 	if res.Err != nil {
 		errs = append(errs, res.Err.Error())
@@ -252,7 +252,7 @@ func (v *VMClarityPresenter) ExportMalwareResult(ctx context.Context, res famili
 		assetScan.Stats = &models.AssetScanStats{}
 	}
 
-	errs := []string{}
+	var errs []string
 
 	if res.Err != nil {
 		errs = append(errs, res.Err.Error())
@@ -299,7 +299,7 @@ func (v *VMClarityPresenter) ExportExploitsResult(ctx context.Context, res famil
 		assetScan.Stats = &models.AssetScanStats{}
 	}
 
-	errs := []string{}
+	var errs []string
 
 	if res.Err != nil {
 		errs = append(errs, res.Err.Error())


### PR DESCRIPTION
## Description

In some of the families, when we export results from the CLI, we are not exporting the status/errors as null, but as an empty list. This breaks our ability to do the query: "status/family/errors eq null" for an assetScan.

## Type of Change

[ *] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [* ] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [* ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ *] All code style checks pass
- [ *] New code contribution is covered by automated tests
- [ *] All new and existing tests pass
