### PR TITLE
fix(apiserver): change odata filter in check uniqueness for containers

### DIFF
--- a/e2e/basic_scan_test.go
+++ b/e2e/basic_scan_test.go
@@ -31,7 +31,7 @@ var _ = ginkgo.Describe("Running a basic scan (only SBOM)", func() {
 		ginkgo.It("should finish successfully", func(ctx ginkgo.SpecContext) {
 			ginkgo.By("waiting until test asset is found")
 			assetsParams := models.GetAssetsParams{
-				Filter: utils.PointerTo(fmt.Sprintf("terminatedOn eq null and %s", DefaultScope)),
+				Filter: utils.PointerTo(fmt.Sprintf("%s", DefaultScope)),
 			}
 			gomega.Eventually(func() bool {
 				assets, err := client.GetAssets(ctx, assetsParams)

--- a/pkg/apiserver/database/gorm/asset.go
+++ b/pkg/apiserver/database/gorm/asset.go
@@ -305,10 +305,10 @@ func (t *AssetsTableHandler) checkUniqueness(asset models.Asset) (*models.Asset,
 			*asset.Id, *info.DirName, *info.Location,
 		)
 	case models.ContainerInfo:
-		filter = fmt.Sprintf("id ne '%s' and assetInfo/Id eq '%s'", *asset.Id, *info.Id)
+		filter = fmt.Sprintf("id ne '%s' and assetInfo/id eq '%s'", *asset.Id, *info.Id)
 
 	case models.ContainerImageInfo:
-		filter = fmt.Sprintf("id ne '%s' and assetInfo/Id eq '%s'", *asset.Id, *info.Id)
+		filter = fmt.Sprintf("id ne '%s' and assetInfo/id eq '%s'", *asset.Id, *info.Id)
 
 	default:
 		return nil, fmt.Errorf("asset type is not supported (%T): %w", discriminator, err)


### PR DESCRIPTION
## Description

While developing the E2E tests, I noticed that some container and image assets appeared more than once in the DB. This was due to a case mismatch in the ODATA filter when we check for asset uniqueness.

The check for asset is found in the basic test should now always succeed without filtering by terminated assets.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
