### PR TITLE
fix(lint): failing linter for go modules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,17 @@ linters-settings:
       # Replace these for trivy
       - github.com/docker/docker
       - oras.land/oras-go
+      # End-to-end testing
+      - github.com/spdx/tools-golang
+      - go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+      - go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+      - go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp
+      - cloud.google.com/go
+      - github.com/cucumber/godog
+      - k8s.io/api
+      - k8s.io/apimachinery
+      - k8s.io/client-go
+      - github.com/docker/cli
 
   gosec:
     # To specify a set of rules to explicitly exclude.

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ bin/golangci-lint-$(GOLANGCI_VERSION): | $(BIN_DIR)
 
 GOMODULES := $(shell find $(ROOT_DIR) -name 'go.mod')
 LINTGOMODULES = $(addprefix lint-, $(GOMODULES))
+FIXGOMODULES = $(addprefix fix-, $(GOMODULES))
 
 .PHONY: $(LINTGOMODULES)
 $(LINTGOMODULES):
@@ -174,9 +175,12 @@ lint-cfn:
 .PHONY: lint
 lint: lint-go lint-cfn ## Run linters
 
+.PHONY: $(FIXGOMODULES)
+$(FIXGOMODULES):
+	cd $(dir $(@:fix-%=%)) && "$(GOLANGCI_BIN)" run -c "$(GOLANGCI_CONFIG)" --fix
+
 .PHONY: fix
-fix: bin/golangci-lint ## Fix lint violations
-	./bin/golangci-lint run --fix
+fix: bin/golangci-lint $(FIXGOMODULES) ## Fix lint violations
 
 bin/licensei: bin/licensei-${LICENSEI_VERSION}
 	@ln -sf licensei-${LICENSEI_VERSION} bin/licensei

--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,15 @@ bin/golangci-lint-$(GOLANGCI_VERSION): | $(BIN_DIR)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | bash -s -- -b "$(BIN_DIR)" "v$(GOLANGCI_VERSION)"
 	@mv bin/golangci-lint $@
 
+GOMODULES := $(shell find $(ROOT_DIR) -name 'go.mod')
+LINTGOMODULES = $(addprefix lint-, $(GOMODULES))
+
+.PHONY: $(LINTGOMODULES)
+$(LINTGOMODULES):
+	cd $(dir $(@:lint-%=%)) && "$(GOLANGCI_BIN)" run -c "$(GOLANGCI_CONFIG)"
+
 .PHONY: lint-go
-lint-go: bin/golangci-lint
-	find . -name go.mod -execdir "$(GOLANGCI_BIN)" run --tests -c "$(GOLANGCI_CONFIG)" \;
+lint-go: bin/golangci-lint $(LINTGOMODULES)
 
 .PHONY: lint-cfn
 lint-cfn:

--- a/e2e/basic_scan_test.go
+++ b/e2e/basic_scan_test.go
@@ -31,7 +31,7 @@ var _ = ginkgo.Describe("Running a basic scan (only SBOM)", func() {
 		ginkgo.It("should finish successfully", func(ctx ginkgo.SpecContext) {
 			ginkgo.By("waiting until test asset is found")
 			assetsParams := models.GetAssetsParams{
-				Filter: utils.PointerTo(fmt.Sprintf("%s", DefaultScope)),
+				Filter: utils.PointerTo(DefaultScope),
 			}
 			gomega.Eventually(func() bool {
 				assets, err := client.GetAssets(ctx, assetsParams)


### PR DESCRIPTION
## Description

Fix `make lint-go` target to fail in case there are linter errors reported.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
