### PR TITLE
Buffered Asset Discovery

### DIFF
--- a/pkg/orchestrator/provider/kubernetes/provider.go
+++ b/pkg/orchestrator/provider/kubernetes/provider.go
@@ -74,8 +74,11 @@ func (p *Provider) Kind() models.CloudProvider {
 	return models.Kubernetes
 }
 
-func (p *Provider) DiscoverAssets(ctx context.Context) ([]models.AssetType, error) {
-	return nil, fmt.Errorf("not implemented")
+func (p *Provider) DiscoverAssets(ctx context.Context) provider.AssetDiscoverer {
+	assetDiscoverer := provider.NewSimpleAssetDiscoverer()
+	assetDiscoverer.Error = fmt.Errorf("not implemented")
+	close(assetDiscoverer.OutputChan)
+	return assetDiscoverer
 }
 
 func (p *Provider) RunAssetScan(context.Context, *provider.ScanJobConfig) error {


### PR DESCRIPTION
## Description

Resolve https://github.com/openclarity/vmclarity/issues/445

Modify DiscoverAssets interface to return a channel of assets instead of
a list. This lays the foundation to prevent us from keeping big chunks
of assets in memory.

In a future PR, all the providers should be updated to paginate fetching
assets from their downstream APIs and feed the channel.
 
## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[X] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
