### PR TITLE
feat: bump golangci-lint version to 1.54.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -77,6 +77,8 @@ linters:
     - ireturn # Allow returning with interfaces
     - exhaustruct # Allow structures with uninitialized fields
     - gci # imports still has gci lint errors after run `gci write --skip-generated -s standard -s default -s "prefix(github.com/openclarity/vmclarity)"`
+    - depguard # NOTE(chrisgacsal): need discussion before enabling it
+    - tagalign # NOTE(chrisgacsal): does not seem to provide much value
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ $(BIN_DIR):
 
 GOLANGCI_BIN := $(BIN_DIR)/golangci-lint
 GOLANGCI_CONFIG := $(ROOT_DIR)/.golangci.yml
-GOLANGCI_VERSION := 1.52.2
+GOLANGCI_VERSION := 1.54.2
 
 bin/golangci-lint: bin/golangci-lint-$(GOLANGCI_VERSION)
 	@ln -sf golangci-lint-$(GOLANGCI_VERSION) bin/golangci-lint

--- a/pkg/apiserver/config.go
+++ b/pkg/apiserver/config.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	BackendRestHost       = "BACKEND_REST_HOST"
-	BackendRestDisableTLS = "BACKEND_REST_DISABLE_TLS"
+	BackendRestDisableTLS = "BACKEND_REST_DISABLE_TLS" // nolint:gosec
 	BackendRestPort       = "BACKEND_REST_PORT"
 	HealthCheckAddress    = "HEALTH_CHECK_ADDRESS"
 

--- a/pkg/cli/utils/apimodel.go
+++ b/pkg/cli/utils/apimodel.go
@@ -186,10 +186,10 @@ func ConvertMalwareResultToAPIModel(malwareResults *malware.MergedResults) *mode
 	}
 
 	metadata := []models.ScannerMetadata{}
-	for name, summary := range malwareResults.ScansSummary {
-		nameVal := name // Prevent loop variable pointer export
+	for n, s := range malwareResults.ScansSummary {
+		name, summary := n, s // Prevent loop variable pointer export
 		metadata = append(metadata, models.ScannerMetadata{
-			ScannerName: &nameVal,
+			ScannerName: &name,
 			ScannerSummary: &models.ScannerSummary{
 				DataRead:           &summary.DataRead,
 				DataScanned:        &summary.DataScanned,

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -62,7 +62,7 @@ const (
 
 	AssetScanPollingInterval  = "ASSET_SCAN_POLLING_INTERVAL"
 	AssetScanReconcileTimeout = "ASSET_SCAN_RECONCILE_TIMEOUT"
-	AssetScanAbortTimeout     = "ASSET_SCAN_ABORT_TIMEOUT"
+	AssetScanAbortTimeout     = "ASSET_SCAN_ABORT_TIMEOUT" // nolint:gosec
 
 	AssetScanProcessorPollingInterval  = "ASSET_SCAN_PROCESSOR_POLLING_INTERVAL"
 	AssetScanProcessorReconcileTimeout = "ASSET_SCAN_PROCESSOR_RECONCILE_TIMEOUT"

--- a/pkg/uibackend/rest/dashboard_riskiest_assets.go
+++ b/pkg/uibackend/rest/dashboard_riskiest_assets.go
@@ -38,7 +38,7 @@ const (
 	totalSecretsSummaryFieldName                 = "totalSecrets"
 	totalVulnerabilitiesSummaryFieldName         = "totalVulnerabilities"
 	totalCriticalVulnerabilitiesSummaryFieldName = "totalCriticalVulnerabilities"
-	totalHighVulnerabilitiesSummaryFieldName     = "totalHighVulnerabilities"
+	totalHighVulnerabilitiesSummaryFieldName     = "totalHighVulnerabilities" // nolint:gosec
 	totalMediumVulnerabilitiesSummaryFieldName   = "totalMediumVulnerabilities"
 	totalLowVulnerabilitiesFieldName             = "totalLowVulnerabilities"
 	totalNegligibleVulnerabilitiesFieldName      = "totalNegligibleVulnerabilities"


### PR DESCRIPTION
## Description

Bump `golangci-lint` version to `1.54.2`. The `depguard` and `tagalign` linters were added since `1.52.x` which are temporarily disabled as former seems to be usefull, but requires a discussion with the team before enabling it while, the latter does not seem to provide much of a value besides making the structs with struct tags a bit more readable/organized.
Also fixed a couple of linter errors reported by `gosec`.

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
