### PR TITLE
Limit gitleaks scanned files to 50MB. TODO: make configurable

### DIFF
--- a/pkg/shared/families/secrets/gitleaks/gitleaks.go
+++ b/pkg/shared/families/secrets/gitleaks/gitleaks.go
@@ -75,9 +75,9 @@ func (a *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 		}()
 		reportPath := file.Name()
 
-		// ./gitleaks detect --source=<source> --no-git -r <report-path> -f json --exit-code 0
+		// ./gitleaks detect --source=<source> --no-git -r <report-path> -f json --exit-code 0 --max-target-megabytes 50
 		// nolint:gosec
-		cmd := exec.Command(a.config.BinaryPath, "detect", fmt.Sprintf("--source=%v", userInput), "--no-git", "-r", reportPath, "-f", "json", "--exit-code", "0")
+		cmd := exec.Command(a.config.BinaryPath, "detect", fmt.Sprintf("--source=%v", userInput), "--no-git", "-r", reportPath, "-f", "json", "--exit-code", "0", "--max-target-megabytes", "50")
 		a.logger.Infof("Running gitleaks command: %v", cmd.String())
 		_, err = sharedutils.RunCommand(cmd)
 		if err != nil {


### PR DESCRIPTION
## Description

Limit gitleaks scanned files to 50MB. TODO: make configurable

Closes #622

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
