### PR TITLE
Add success job to ci.yml which only runs if everything else succeeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,13 @@ jobs:
       image_tag: ${{ github.sha }}
       push: false
       upload: false
+
+  success:
+    needs:
+      - build
+      - helm-docs-verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo Success
+        run: |
+          echo "::notice Success!"


### PR DESCRIPTION
## Description

This job can be used as the indicator that every required job succeeded by the branch protection rules. Adding this means we no longer need to update the branch protection rules every time we make a change to the workflow instead it can be completely controlled in the workflow by managing whether "Success" runs successful.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[X] Other (please describe)  CI/CD

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
