### PR TITLE
feat(test): build all services when running e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,12 +127,14 @@ test: ## Run Unit Tests
 	@go test ./...
 
 .PHONY: e2e
-e2e: docker-apiserver docker-cli docker-orchestrator ## Run go e2e test against code
+e2e: docker-apiserver docker-cli docker-orchestrator docker-ui docker-ui-backend ## Run go e2e test against code
 	@cd e2e && \
 	export APIServerContainerImage=${DOCKER_REGISTRY}/vmclarity-apiserver:${DOCKER_TAG} && \
 	export OrchestratorContainerImage=${DOCKER_REGISTRY}/vmclarity-orchestrator:${DOCKER_TAG} && \
 	export ScannerContainerImage=${DOCKER_REGISTRY}/vmclarity-cli:${DOCKER_TAG} && \
-    go test -v -failfast -test.v -test.paniconexit0 -timeout 2h -ginkgo.v .
+	export UIContainerImage=${DOCKER_REGISTRY}/vmclarity-ui:${DOCKER_TAG} && \
+	export UIBackendContainerImage=${DOCKER_REGISTRY}/vmclarity-ui-backend:${DOCKER_TAG} && \
+	go test -v -failfast -test.v -test.paniconexit0 -timeout 2h -ginkgo.v .
 
 .PHONY: clean-ui
 clean-ui:


### PR DESCRIPTION
## Description

When running end to end tests with `make e2e`, build all service images and use them for testing.

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
