### PR TITLE
fix(make): remove deprecated clean-backend and run go mod tidy in all modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,9 +205,14 @@ license-cache: bin/licensei ## Generate license cache
 .PHONY: check
 check: lint test helm-lint ## Run tests and linters
 
+TIDYGOMODULES = $(addprefix tidy-, $(GOMODULES))
+
+.PHONY: $(TIDYGOMODULES)
+$(TIDYGOMODULES):
+	cd $(dir $(@:tidy-%=%)) && go mod tidy
+
 .PHONY: gomod-tidy
-gomod-tidy:
-	go mod tidy
+gomod-tidy: $(TIDYGOMODULES)
 
 .PHONY: gen-api
 gen-api: gen-apiserver-api gen-uibackend-api ## Generating API code

--- a/Makefile
+++ b/Makefile
@@ -140,8 +140,12 @@ e2e: docker-apiserver docker-cli docker-orchestrator docker-ui docker-ui-backend
 clean-ui:
 	@(rm -rf ui/build ; echo "UI cleanup done" )
 
+.PHONY: clean-go
+clean-go:
+	@(rm -rf bin ; echo "GO executables cleanup done" )
+
 .PHONY: clean
-clean: clean-ui clean-backend ## Clean all build artifacts
+clean: clean-ui clean-go ## Clean all build artifacts
 
 $(BIN_DIR):
 	@mkdir -p $(BIN_DIR)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -31,11 +31,11 @@ To add a new test, create a new `<test_name>_test.go` file in the current direct
 ```go
 var _ = ginkgo.Describe("<add a brief test case description>", func() {
     reportFailedConfig := ReportFailedConfig{}
-	ginkgo.Context("<describe conditions or inputs>", func() {
+    ginkgo.Context("<describe conditions or inputs>", func() {
         ginkgo.It("<describe the behaviour or feature being tested>", func(ctx ginkgo.SpecContext) {
-			<implement test code>
-		})
-	})
+            <implement test code>
+        })
+    })
     ginkgo.AfterEach(func(ctx ginkgo.SpecContext) {
         if ginkgo.CurrentSpecReport().Failed() {
             reportFailedConfig.startTime = ginkgo.CurrentSpecReport().StartTime


### PR DESCRIPTION
## Description

* Remove deprecated `clean-backend` and add `clean-go` to remove all GO executables
* Change `gomod-tidy` to run in all directories with `go.mod` files

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
