### PR TITLE
Revert "ci(test): add e2e tests to ci pipeline (#602)"

### DIFF
--- a/.github/workflows/build-and-push-component.yaml
+++ b/.github/workflows/build-and-push-component.yaml
@@ -29,11 +29,6 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -65,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ matrix.platform }}
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/openclarity/${{ inputs.image_name }}:${{ inputs.image_tag }}
           file: ${{ inputs.dockerfile }}
           push: ${{ inputs.push }}
@@ -78,7 +73,7 @@ jobs:
             COMMIT_HASH=${{ github.sha }}
 
       - name: Upload artifact
-        if: ${{ inputs.upload == 'true' && matrix.platform == 'linux/amd64'}}
+        if: ${{ inputs.upload == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ inputs.image_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,46 +75,7 @@ jobs:
     with:
       image_tag: ${{ github.sha }}
       push: false
-      upload: true
-
-  e2e:
-    needs: build
-    name: E2E Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Download all artifacts
-        uses: actions/download-artifact@v3
-
-      - name: Load Docker images
-        run: |
-          ls
-          docker load --input vmclarity-apiserver/vmclarity-apiserver.tar
-          docker load --input vmclarity-orchestrator/vmclarity-orchestrator.tar
-          docker load --input vmclarity-ui-backend/vmclarity-ui-backend.tar
-          docker load --input vmclarity-ui/vmclarity-ui.tar
-          docker load --input vmclarity-cli/vmclarity-cli.tar
-          docker image ls -a
-
-      - name: Run end to end tests
-        env:
-          DOCKER_TAG: ${{ github.sha }}
-          APIServerContainerImage: ghcr.io/openclarity/vmclarity-apiserver:${{ github.sha }}
-          OrchestratorContainerImage: ghcr.io/openclarity/vmclarity-orchestrator:${{ github.sha }}
-          UIContainerImage: ghcr.io/openclarity/vmclarity-ui:${{ github.sha }}
-          UIBackendContainerImage: ghcr.io/openclarity/vmclarity-ui-backend:${{ github.sha }}
-          ScannerContainerImage: ghcr.io/openclarity/vmclarity-cli:${{ github.sha }}
-        run: cd e2e && go test -v -failfast -test.v -test.paniconexit0 -timeout 2h -ginkgo.v .
+      upload: false
 
   success:
     needs:


### PR DESCRIPTION
## Description

Reverts #602 as it broke the publishing container images for multiple architectures. This removes the E2E testing from the CI pipeline which will be re-added in a followup PR.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
