### PR TITLE
feat: raw yara rule sources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/openclarity/kubeclarity/cli v0.0.0-00010101000000-000000000000
 	github.com/openclarity/kubeclarity/shared v0.0.0
 	github.com/openclarity/vmclarity/api v0.0.0
+	github.com/openclarity/yara-rule-server v0.1.0
 	github.com/parnurzeal/gorequest v0.2.16
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -183,6 +183,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/github/go-spdx/v2 v2.1.2 // indirect
+	github.com/go-co-op/gocron v1.32.1 // indirect
 	github.com/go-enry/go-license-detector/v4 v4.3.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
@@ -343,6 +344,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rs/zerolog v1.29.0 // indirect
 	github.com/rubenv/sql-migrate v1.3.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -861,6 +861,8 @@ github.com/github/go-spdx/v2 v2.1.2/go.mod h1:hMCrsFgT0QnCwn7G8gxy/MxMpy67WgZrwF
 github.com/glebarez/go-sqlite v1.21.2 h1:3a6LFC4sKahUunAmynQKLZceZCOzUthkRkEAl9gAXWo=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
+github.com/go-co-op/gocron v1.32.1 h1:h+StA6Qzlv+ImlCaLfA26rLN9eS/l4sO7oWmPUbRVIY=
+github.com/go-co-op/gocron v1.32.1/go.mod h1:UGz2oYvVS6PsqlwuOdo5L1Djsg/cQjxJ6T5ntkhp9Bg=
 github.com/go-enry/go-license-detector/v4 v4.3.0 h1:OFlQAVNw5FlKUjX4OuW8JOabu8MQHjTKDb9pdeNYMUw=
 github.com/go-enry/go-license-detector/v4 v4.3.0/go.mod h1:HaM4wdNxSlz/9Gw0uVOKSQS5JVFqf2Pk8xUPEn6bldI=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
@@ -1755,6 +1757,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -1762,6 +1766,7 @@ github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
@@ -2064,6 +2069,7 @@ go.starlark.net v0.0.0-20230525235612-a134d8f9ddca/go.mod h1:jxU+3+j+71eXOW14274
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=

--- a/go.sum
+++ b/go.sum
@@ -1616,6 +1616,8 @@ github.com/openclarity/kubeclarity/cli v0.0.0-20230919093336-30e3c0ea31f4 h1:MpX
 github.com/openclarity/kubeclarity/cli v0.0.0-20230919093336-30e3c0ea31f4/go.mod h1:XG2waTwEuBMrTIVCLbp1NT4QJjHRE8D+M3qHi9q4U3o=
 github.com/openclarity/kubeclarity/shared v0.0.0-20230919093336-30e3c0ea31f4 h1:HUu4UBS8TooA7D5E/gA/o3iKoU58ym/c/mPRQMqG5M0=
 github.com/openclarity/kubeclarity/shared v0.0.0-20230919093336-30e3c0ea31f4/go.mod h1:JYu6NKnOy7zsc0zMGIVJ3SMRr1jBAvrEdQ28/pjJYww=
+github.com/openclarity/yara-rule-server v0.1.0 h1:vMO3EV40V+FhdVqi3JVE87VWD83uKKoaQVbY/c+LYgM=
+github.com/openclarity/yara-rule-server v0.1.0/go.mod h1:hnCN/zJ56tlUWMUvos56m0sHQIxzuGhcsMHWnJNT56U=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/pkg/shared/families/malware/yara/config/config.go
+++ b/pkg/shared/families/malware/yara/config/config.go
@@ -20,6 +20,6 @@ import "github.com/openclarity/yara-rule-server/pkg/config"
 type Config struct {
 	BinaryPath      string              `yaml:"binary_path" mapstructure:"binary_path"`
 	CompiledRuleURL string              `yaml:"compiled_rule_url" mapstructure:"compiled_rule_url"`
-	RuleSources     []config.RuleSource `yaml:"compiled_rule_url" mapstructure:"rule_sources"`
+	RuleSources     []config.RuleSource `yaml:"rule_sources" mapstructure:"rule_sources"`
 	YaracPath       string              `yaml:"yarac_path" mapstructure:"yarac_path"`
 }

--- a/pkg/shared/families/malware/yara/config/config.go
+++ b/pkg/shared/families/malware/yara/config/config.go
@@ -15,7 +15,10 @@
 
 package config
 
+import "github.com/openclarity/yara-rule-server/pkg/config"
+
 type Config struct {
-	BinaryPath      string `yaml:"binary_path" mapstructure:"binary_path"`
-	CompiledRuleURL string `yaml:"compiled_rule_url" mapstructure:"compiled_rule_url"`
+	BinaryPath      string              `yaml:"binary_path" mapstructure:"binary_path"`
+	CompiledRuleURL string              `yaml:"compiled_rule_url" mapstructure:"compiled_rule_url"`
+	RuleSources     []config.RuleSource `yaml:"compiled_rule_url" mapstructure:"rule_sources"`
 }

--- a/pkg/shared/families/malware/yara/config/config.go
+++ b/pkg/shared/families/malware/yara/config/config.go
@@ -21,4 +21,5 @@ type Config struct {
 	BinaryPath      string              `yaml:"binary_path" mapstructure:"binary_path"`
 	CompiledRuleURL string              `yaml:"compiled_rule_url" mapstructure:"compiled_rule_url"`
 	RuleSources     []config.RuleSource `yaml:"compiled_rule_url" mapstructure:"rule_sources"`
+	YaracPath       string              `yaml:"yarac_path" mapstructure:"yarac_path"`
 }

--- a/pkg/shared/families/malware/yara/yara.go
+++ b/pkg/shared/families/malware/yara/yara.go
@@ -29,6 +29,9 @@ import (
 	"github.com/openclarity/kubeclarity/shared/pkg/utils"
 	log "github.com/sirupsen/logrus"
 
+	ruleServerConfig "github.com/openclarity/yara-rule-server/pkg/config"
+	"github.com/openclarity/yara-rule-server/pkg/rules"
+
 	"github.com/openclarity/vmclarity/pkg/shared/families/malware/common"
 	"github.com/openclarity/vmclarity/pkg/shared/families/malware/yara/config"
 	"github.com/openclarity/vmclarity/pkg/shared/families/malware/yara/util"
@@ -96,23 +99,38 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 	return nil
 }
 
-func getRuleFilePath(compiledRuleURL string, logger *log.Entry) (string, error) {
-	parsed, err := url.Parse(compiledRuleURL)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse Yara rule URL=%s: %w", compiledRuleURL, err)
+func getCompiledRuleFilePath(cfg config.Config, logger *log.Entry) (string, error) {
+	// If both compiled rule url and raw rule sources are defined we choose the compiled one.
+	if cfg.CompiledRuleURL != "" {
+		parsed, err := url.Parse(cfg.CompiledRuleURL)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse Yara rule URL=%s: %w", cfg.CompiledRuleURL, err)
+		}
+
+		switch parsed.Scheme {
+		case "file":
+			return parsed.Path, nil
+		case "http", "https":
+			return downloadCompiledRules(cfg.CompiledRuleURL, logger)
+		default:
+			return "", errors.New("unsupported Yara rules URL")
+		}
 	}
 
-	switch parsed.Scheme {
-	case "file":
-		return parsed.Path, nil
-	case "http", "https":
-		return downloadRules(compiledRuleURL, logger)
-	default:
-		return "", errors.New("unsupported Yara rules URL")
+	if len(cfg.RuleSources) != 0 {
+		if err := rules.DownloadAndCompile(&ruleServerConfig.Config{
+			RuleSources: cfg.RuleSources,
+			YaracPath:   cfg.YaracPath,
+		}, logger); err != nil {
+			return "", fmt.Errorf("failed to download and compile raw rules: %w", err)
+		}
+		return ruleServerConfig.RulePath, nil
 	}
+
+	return "", errors.New("neither compiled rule URL nor rule sources are defined")
 }
 
-func downloadRules(compiledRuleURL string, logger *log.Entry) (string, error) {
+func downloadCompiledRules(compiledRuleURL string, logger *log.Entry) (string, error) {
 	logger.Infof("Downloading Yara rules...")
 	out, err := os.CreateTemp(os.TempDir(), "compiledYaraRules")
 	if err != nil {
@@ -142,14 +160,15 @@ func downloadRules(compiledRuleURL string, logger *log.Entry) (string, error) {
 
 func New(c job_manager.IsConfig, logger *log.Entry, resultChan chan job_manager.Result) job_manager.Job {
 	conf := c.(*common.ScannersConfig) // nolint:forcetypeassert
+	logger = logger.Dup().WithField("scanner", ScannerName)
 	// Download compiled yara rule.
-	compiledRuleFile, err := getRuleFilePath(conf.Yara.CompiledRuleURL, logger)
+	compiledRuleFile, err := getCompiledRuleFilePath(conf.Yara, logger)
 	if err != nil {
 		logger.Errorf("Failed to get compiled rule file path: %v", err)
 	}
 	return &Scanner{
 		name:             ScannerName,
-		logger:           logger.Dup().WithField("scanner", ScannerName),
+		logger:           logger,
 		config:           conf.Yara,
 		resultChan:       resultChan,
 		compiledRuleFile: compiledRuleFile,


### PR DESCRIPTION
## Description

This PR adds support for the cli to download raw yara sources using the `yara-rule-server` package https://github.com/openclarity/yara-rule-server/blob/d4fcd75f7e2daaa0079dca6db23c79b07533269e/pkg/rules/rules.go#L32

At the moment some paths are contacts in the `yara-rule-server` code, so we need to update `yara-rule-server` in order to make the cache dir configurable. Issue: https://github.com/openclarity/yara-rule-server/issues/16

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
