### PR TITLE
fix(scan estimation): reconcile timeout state to failed

### DIFF
--- a/pkg/orchestrator/scanestimationwatcher/watcher.go
+++ b/pkg/orchestrator/scanestimationwatcher/watcher.go
@@ -131,7 +131,7 @@ func (w *Watcher) Reconcile(ctx context.Context, event ScanEstimationReconcileEv
 	}
 
 	if scanEstimation.IsTimedOut(w.scanEstimationTimeout) {
-		scanEstimation.State.State = utils.PointerTo(models.ScanEstimationStateStateAborted)
+		scanEstimation.State.State = utils.PointerTo(models.ScanEstimationStateStateFailed)
 		scanEstimation.State.StateMessage = utils.PointerTo("ScanEstimation has been timed out")
 		scanEstimation.State.StateReason = utils.PointerTo(models.ScanEstimationStateStateReasonTimedOut)
 


### PR DESCRIPTION

## Description

Currently, when ScanEstimation is timed out, we move its state to Aborted. 
This prevent it from ever going into Failed state and getting cleaned out.

This fix moves timeout scan estimation into Failed state (same as in Scan reconciler/watcher)

## Type of Change

[ *] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

