### PR TITLE
fix(ci): image push on merge to main

### DIFF
--- a/.github/workflows/build-and-push-component.yaml
+++ b/.github/workflows/build-and-push-component.yaml
@@ -62,9 +62,8 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          tags: ghcr.io/openclarity/${{ inputs.image_name }}:${{ inputs.image_tag }}
           file: ${{ inputs.dockerfile }}
-          outputs: type=image,name=${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
+          outputs: type=image,name=ghcr.io/openclarity/${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           build-args: |
@@ -115,8 +114,8 @@ jobs:
         run: |
           # shellcheck disable=SC2046
           docker buildx imagetools create --tag "${{ inputs.image_tag }}" \
-            $(printf '${{ inputs.image_name }}@sha256:%s ' *)
+            $(printf 'ghcr.io/openclarity/${{ inputs.image_name }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ inputs.image_name }}:${{ inputs.image_tag }} 
+          docker buildx imagetools inspect ghcr.io/openclarity/${{ inputs.image_name }}:${{ inputs.image_tag }} 


### PR DESCRIPTION
## Description

Fix broken container image push to registry. Docker errors out if both pushing image by digest and by tag are requested. They are mutually exclusive.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
