### PR TITLE
fix: missing DirInfo and PodInfo OData schemas

### DIFF
--- a/pkg/apiserver/database/gorm/odata.go
+++ b/pkg/apiserver/database/gorm/odata.go
@@ -491,7 +491,7 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 			"scansCount":   odatasql.FieldMeta{FieldType: odatasql.NumberFieldType},
 			"assetInfo": odatasql.FieldMeta{
 				FieldType:             odatasql.ComplexFieldType,
-				ComplexFieldSchemas:   []string{"VMInfo", "ContainerInfo", "ContainerImageInfo"},
+				ComplexFieldSchemas:   []string{"VMInfo", "ContainerInfo", "ContainerImageInfo", "DirInfo", "PodInfo"},
 				DiscriminatorProperty: "objectType",
 			},
 			"summary": odatasql.FieldMeta{
@@ -571,6 +571,20 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 					ComplexFieldSchemas: []string{"Tag"},
 				},
 			},
+			"objectType": odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
+		},
+	},
+	"DirInfo": {
+		Fields: odatasql.Schema{
+			"dirName":    odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
+			"location":   odatasql.FieldMeta{FieldType: odatasql.DateTimeFieldType},
+			"objectType": odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
+		},
+	},
+	"PodInfo": {
+		Fields: odatasql.Schema{
+			"podName":    odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
+			"location":   odatasql.FieldMeta{FieldType: odatasql.DateTimeFieldType},
 			"objectType": odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
 		},
 	},


### PR DESCRIPTION
## Description

This PR adds the missing OData schema definitions for `DirInfo` and `PodInfo` because the openAPI definition contains these objects.

fixes: #738 

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
