### PR TITLE
fix(odatasql): Ensure that $filter works for complex types

### DIFF
--- a/pkg/apiserver/database/odatasql/query.go
+++ b/pkg/apiserver/database/odatasql/query.go
@@ -566,7 +566,7 @@ func buildWhereFromNav(sqlVariant jsonsql.Variant, schemaMetas map[string]Schema
 	case DateTimeFieldType:
 		return sqlVariant.CastToDateTime(sqlVariant.JSONExtractText(fieldSource, queryPath)), nil
 	case CollectionFieldType, RelationshipFieldType, ComplexFieldType:
-		fallthrough
+		return sqlVariant.JSONExtractText(fieldSource, queryPath), nil
 	default:
 		return "", fmt.Errorf("unable to directly extract field type %s, you might need a function like length() or to specify a specific field", fieldMeta.FieldType)
 	}

--- a/pkg/apiserver/database/odatasql/query_test.go
+++ b/pkg/apiserver/database/odatasql/query_test.go
@@ -139,6 +139,9 @@ type Car struct {
 
 	// Example time field
 	BuiltOn *time.Time `json:"BuiltOn"`
+
+	// Always null field
+	NullComplexField *Engine `json:"NullComplexField"`
 }
 
 // Gorm Table Definitions.
@@ -190,6 +193,11 @@ var carSchemaMetas = map[string]SchemaMeta{
 				},
 			},
 			"BuiltOn": {FieldType: DateTimeFieldType},
+			"NullComplexField": {
+				FieldType:             ComplexFieldType,
+				ComplexFieldSchemas:   []string{"Engine"},
+				DiscriminatorProperty: "ObjectType",
+			},
 		},
 	},
 	"Manufacturer": {
@@ -1263,6 +1271,30 @@ func TestBuildSQLQuery(t *testing.T) {
 			name: "eq filter comparing two fields",
 			args: args{
 				filterString: PointerTo("Manufacturer/Name eq Engine/Manufacturer/Name"),
+			},
+			want: []Car{
+				car1,
+				car2,
+				car3,
+				car4,
+			},
+		},
+		{
+			name: "if list ne null",
+			args: args{
+				filterString: PointerTo("Engine/Options/SubOptions ne null"),
+			},
+			want: []Car{
+				car1,
+				car2,
+				car3,
+				car4,
+			},
+		},
+		{
+			name: "if complex type eq null",
+			args: args{
+				filterString: PointerTo("NullComplexField eq null"),
 			},
 			want: []Car{
 				car1,


### PR DESCRIPTION
## Description

Sometimes we want to be able to $filter on the complex fields not just the leaf fields within them for example checking if they are null. The recent change to the odata validation meant that these were getting rejected.

Closes #737

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
