### PR TITLE
feat(ci): cleanup published dev container images

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Remove images for PR#${{ github.event.pull_request.number }}
         uses: snok/container-retention-policy@v2
         with:
-          image-names: vmclarity-apiserver,vmclarity-cli,vmclarity-ui-backend,vmclarity-ui
+          image-names: vmclarity-apiserver-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
           cut-off: One minute ago UTC
           timestamp-to-use: created_at
           account-type: org
@@ -36,7 +36,7 @@ jobs:
       - name: Remove stale images
         uses: snok/container-retention-policy@v2
         with:
-          image-names: vmclarity-apiserver,vmclarity-cli,vmclarity-ui-backend,vmclarity-ui
+          image-names: vmclarity-apiserver-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
           cut-off: 14 days ago UTC
           timestamp-to-use: created_at
           account-type: org

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -26,6 +26,9 @@ on:
         description: Prints output showing images which would be deleted but does not actually delete any images.
         default: true
 
+env:
+  images: vmclarity-apiserver-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
+
 permissions:
   packages: write
 
@@ -38,7 +41,7 @@ jobs:
       - name: Remove images for PR#${{ github.event.pull_request.number }}
         uses: snok/container-retention-policy@v2
         with:
-          image-names: vmclarity-apiserver-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
+          image-names: ${{ env.images }}
           cut-off: 1 second ago UTC
           timestamp-to-use: created_at
           account-type: org
@@ -55,7 +58,7 @@ jobs:
       - name: Remove stale images
         uses: snok/container-retention-policy@v2
         with:
-          image-names: vmclarity-apiserver-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
+          image-names: ${{ env.images }}
           cut-off: 14 days ago UTC
           timestamp-to-use: created_at
           account-type: org
@@ -72,8 +75,8 @@ jobs:
       - name: Remove stale images
         uses: snok/container-retention-policy@v2
         with:
-          image-names: vmclarity-apiserver-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
-          cut-off: $${{ inputs.cut-off }}
+          image-names: ${{ env.images }}
+          cut-off: ${{ inputs.cut-off }}
           timestamp-to-use: created_at
           account-type: org
           org-name: openclarity

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,0 +1,46 @@
+name: Container image cleanup
+
+on:
+  pull_request:
+    types:
+      - closed
+  schedule:
+    # At 06:00 on every day-of-week from Monday through Friday.
+    # https://crontab.guru/#0_6_*_*_1-5
+    - cron: '0 6 * * 1-5'
+  workflow_dispatch:
+
+jobs:
+  remove-images-for-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    name: Cleanup container images for Pull Request
+    steps:
+      - name: Remove images for PR#${{ github.event.pull_request.number }}
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: vmclarity-apiserver,vmclarity-cli,vmclarity-ui-backend,vmclarity-ui
+          cut-off: One minute ago UTC
+          timestamp-to-use: created_at
+          account-type: org
+          org-name: openclarity
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filter-tags: ${{ format( 'pr{0}-*', github.event.pull_request.number) }}
+          dry-run: true
+
+  scheduled-image-cleanup:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    name: Cleanup stale container images
+    steps:
+      - name: Remove stale images
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: vmclarity-apiserver,vmclarity-cli,vmclarity-ui-backend,vmclarity-ui
+          cut-off: 14 days ago UTC
+          timestamp-to-use: created_at
+          account-type: org
+          org-name: openclarity
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filter-include-untagged: true
+          dry-run: true

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,17 +1,36 @@
 name: Container image cleanup
 
 on:
-  pull_request:
-    types:
-      - closed
-  schedule:
-    # At 06:00 on every day-of-week from Monday through Friday.
-    # https://crontab.guru/#0_6_*_*_1-5
-    - cron: '0 6 * * 1-5'
+# FIXME(chrisgacsal): re-enable PR and scheduled trigger after successful testing
+#  pull_request:
+#    types:
+#      - closed
+#  schedule:
+#    # At 06:00 on every day-of-week from Monday through Friday.
+#    # https://crontab.guru/#0_6_*_*_1-5
+#    - cron: '0 6 * * 1-5'
   workflow_dispatch:
+    inputs:
+      cut-off:
+        required: false
+        type: string
+        description: |
+          The timezone-aware datetime you want to delete container versions that are older than.
+          The parsed datetime must contain a timezone.
+
+          The `dateparser` is ued to parse the cut-off specified. See: [dateparser](https://dateparser.readthedocs.io/en/latest/)
+        default: '14 days ago UTC'
+      dry-run:
+        required: false
+        type: boolean
+        description: Prints output showing images which would be deleted but does not actually delete any images.
+        default: true
+
+permissions:
+  packages: write
 
 jobs:
-  remove-images-for-pr:
+  pull-request:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     name: Cleanup container images for Pull Request
@@ -28,7 +47,7 @@ jobs:
           filter-tags: ${{ format( 'pr{0}-*', github.event.pull_request.number) }}
           dry-run: true
 
-  scheduled-image-cleanup:
+  schedule:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest
     name: Cleanup stale container images
@@ -44,3 +63,20 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           filter-include-untagged: true
           dry-run: true
+
+  dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    name: Cleanup stale container images
+    steps:
+      - name: Remove stale images
+        uses: snok/container-retention-policy@v2
+        with:
+          image-names: vmclarity-apiserver-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
+          cut-off: $${{ inputs.cut-off }}
+          timestamp-to-use: created_at
+          account-type: org
+          org-name: openclarity
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filter-include-untagged: true
+          dry-run: ${{ inputs.dry-run }}

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
         uses: snok/container-retention-policy@v2
         with:
           image-names: vmclarity-apiserver-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
-          cut-off: One minute ago UTC
+          cut-off: 1 second ago UTC
           timestamp-to-use: created_at
           account-type: org
           org-name: openclarity


### PR DESCRIPTION
## Description

* run workflow to clean up container images built for specific Pull Request
* schedule cleanup job for cleaning up old untagged and/or PR related container images pusblished to GHCR and older than 1 months

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
