### PR TITLE
feat(ci): re-enable end-to-end testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
 
   e2e:
     needs: build
-    name: End-to-End test
+    name: End-to-End
     uses: ./.github/workflows/reusable-end-to-end-testing.yml
     with:
       image_tag: ${{ format('pr{0}-{1}', github.event.pull_request.number, github.sha) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,14 @@ jobs:
       use_release_repository: false
       post_image_tags: true
 
+  e2e:
+    needs: build
+    name: End-to-End test
+    uses: ./.github/workflows/reusable-end-to-end-testing.yml
+    with:
+      image_tag: ${{ format('pr{0}-{1}', github.event.pull_request.number, github.sha) }}
+      use_release_repository: false
+
   success:
     needs:
       - build

--- a/.github/workflows/reusable-build-and-push.yml
+++ b/.github/workflows/reusable-build-and-push.yml
@@ -25,99 +25,93 @@ on:
           Only works if the event type is `pull_request`.
 
 jobs:
-  build-vars:
+  timestamp:
     runs-on: ubuntu-latest
     outputs:
-      timestamp: ${{ steps.build-vars.outputs.timestamp }}
-      apiserver-image: ${{ steps.build-vars.outputs.apiserver-image }}
-      orchestrator-image: ${{ steps.build-vars.outputs.orchestrator-image }}
-      ui-backend-image: ${{ steps.build-vars.outputs.ui-backend-image }}
-      ui-image: ${{ steps.build-vars.outputs.ui-image }}
-      cli-image: ${{ steps.build-vars.outputs.cli-image }}
+      timestamp: ${{ steps.timestamp.outputs.timestamp }}
     steps:
-      - name: Set build variables
-        id: build-vars
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set timestamp
+        id: timestamp
         run: |
           ##
           ## Set timestamp variable
           ##
           
           echo "timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
-          
-          ##
-          ## Determine the image name suffix based on the release type
-          ##
-          
-          registry=ghcr.io/openclarity/
-          suffix=-dev
-          
-          if [ "${{ inputs.use_release_repository }}" == "true" ]; then
-            suffix=
-          fi
-          
-          {
-            echo "apiserver-image=${registry}vmclarity-apiserver${suffix}"
-            echo "orchestrator-image=${registry}vmclarity-orchestrator${suffix}"
-            echo "ui-backend-image=${registry}vmclarity-ui-backend${suffix}"
-            echo "ui-image=${registry}vmclarity-ui${suffix}"
-            echo "cli-image=${registry}vmclarity-cli${suffix}"
-          } >> "$GITHUB_OUTPUT"
+
+  images:
+    uses: ./.github/workflows/reusable-image-names.yml
+    with:
+      use_release_repository: ${{ inputs.use_release_repository }}
 
   vmclarity-apiserver:
-    needs: build-vars
+    needs:
+      - images
+      - timestamp
     uses: ./.github/workflows/build-and-push-component.yaml
     with:
       dockerfile: Dockerfile.apiserver
-      image_name: ${{ needs.build-vars.outputs.apiserver-image }}
+      image_name: ${{ needs.images.outputs.apiserver-image }}
       image_tag: ${{ inputs.image_tag }}
       push: ${{ inputs.push }}
-      timestamp: ${{ needs.build-vars.outputs.timestamp }}
+      timestamp: ${{ needs.timestamp.outputs.timestamp }}
 
   vmclarity-orchestrator:
-    needs: build-vars
+    needs:
+      - images
+      - timestamp
     uses: ./.github/workflows/build-and-push-component.yaml
     with:
       dockerfile: Dockerfile.orchestrator
-      image_name: ${{ needs.build-vars.outputs.orchestrator-image }}
+      image_name: ${{ needs.images.outputs.orchestrator-image }}
       image_tag: ${{ inputs.image_tag }}
       push: ${{ inputs.push }}
-      timestamp: ${{ needs.build-vars.outputs.timestamp }}
+      timestamp: ${{ needs.timestamp.outputs.timestamp }}
 
   vmclarity-ui-backend:
-    needs: build-vars
+    needs:
+      - images
+      - timestamp
     uses: ./.github/workflows/build-and-push-component.yaml
     with:
       dockerfile: Dockerfile.uibackend
-      image_name: ${{ needs.build-vars.outputs.ui-backend-image }}
+      image_name: ${{ needs.images.outputs.ui-backend-image }}
       image_tag: ${{ inputs.image_tag }}
       push: ${{ inputs.push }}
-      timestamp: ${{ needs.build-vars.outputs.timestamp }}
+      timestamp: ${{ needs.timestamp.outputs.timestamp }}
 
   vmclarity-ui:
-    needs: build-vars
+    needs:
+      - images
+      - timestamp
     uses: ./.github/workflows/build-and-push-component.yaml
     with:
       dockerfile: Dockerfile.ui
-      image_name: ${{ needs.build-vars.outputs.ui-image }}
+      image_name: ${{ needs.images.outputs.ui-image }}
       image_tag: ${{ inputs.image_tag }}
       push: ${{ inputs.push }}
-      timestamp: ${{ needs.build-vars.outputs.timestamp }}
+      timestamp: ${{ needs.timestamp.outputs.timestamp }}
 
   vmclarity-cli:
-    needs: build-vars
+    needs:
+      - images
+      - timestamp
     uses: ./.github/workflows/build-and-push-component.yaml
     with:
       dockerfile: Dockerfile.cli
-      image_name: ${{ needs.build-vars.outputs.cli-image }}
+      image_name: ${{ needs.images.outputs.cli-image }}
       image_tag: ${{ inputs.image_tag }}
       push: ${{ inputs.push }}
-      timestamp: ${{ needs.build-vars.outputs.timestamp }}
+      timestamp: ${{ needs.timestamp.outputs.timestamp }}
 
   post-images:
     if: github.event_name == 'pull_request' && inputs.post_image_tags
     runs-on: ubuntu-latest
     needs:
-      - build-vars
+      - images
       - vmclarity-apiserver
       - vmclarity-orchestrator
       - vmclarity-ui-backend
@@ -135,9 +129,9 @@ jobs:
             Hey!
             
             Your images are ready:
-            * `${{ format('{0}:{1}', needs.build-vars.outputs.apiserver-image, inputs.image_tag) }}`
-            * `${{ format('{0}:{1}', needs.build-vars.outputs.orchestrator-image, inputs.image_tag) }}`
-            * `${{ format('{0}:{1}', needs.build-vars.outputs.ui-backend-image, inputs.image_tag) }}`
-            * `${{ format('{0}:{1}', needs.build-vars.outputs.ui-image, inputs.image_tag) }}`
-            * `${{ format('{0}:{1}', needs.build-vars.outputs.cli-image, inputs.image_tag) }}`
+            * `${{ format('{0}:{1}', needs.images.outputs.apiserver-image, inputs.image_tag) }}`
+            * `${{ format('{0}:{1}', needs.images.outputs.orchestrator-image, inputs.image_tag) }}`
+            * `${{ format('{0}:{1}', needs.images.outputs.ui-backend-image, inputs.image_tag) }}`
+            * `${{ format('{0}:{1}', needs.images.outputs.ui-image, inputs.image_tag) }}`
+            * `${{ format('{0}:{1}', needs.images.outputs.cli-image, inputs.image_tag) }}`
 

--- a/.github/workflows/reusable-end-to-end-testing.yml
+++ b/.github/workflows/reusable-end-to-end-testing.yml
@@ -1,4 +1,4 @@
-name: End-toEnd testing
+name: End-to-End testing
 
 on:
   workflow_call:
@@ -14,49 +14,31 @@ on:
         default: false
 
 jobs:
-  test-vars:
-    runs-on: ubuntu-latest
-    outputs:
-      apiserver-image: ${{ steps.images.outputs.apiserver-image }}
-      orchestrator-image: ${{ steps.images.outputs.orchestrator-image }}
-      ui-backend-image: ${{ steps.images.outputs.ui-backend-image }}
-      ui-image: ${{ steps.images.outputs.ui-image }}
-      cli-image: ${{ steps.images.outputs.cli-image }}
-    steps:
-      - name: Set container image names
-        id: images
-        run: |
-          ##
-          ## Determine the image name suffix based on the release type
-          ##
-  
-          registry=ghcr.io/openclarity/
-          suffix=-dev
-  
-          if [ "${{ inputs.use_release_repository }}" == "true" ]; then
-            suffix=
-          fi
-  
-          {
-            echo "apiserver-image=${registry}vmclarity-apiserver${suffix}"
-            echo "orchestrator-image=${registry}vmclarity-orchestrator${suffix}"
-            echo "ui-backend-image=${registry}vmclarity-ui-backend${suffix}"
-            echo "ui-image=${registry}vmclarity-ui${suffix}"
-            echo "cli-image=${registry}vmclarity-cli${suffix}"
-          } >> "$GITHUB_OUTPUT"
+  images:
+    uses: ./.github/workflows/reusable-image-names.yml
+    with:
+      use_release_repository: ${{ inputs.use_release_repository }}
 
-  e2e:
+  run:
     runs-on: ubuntu-latest
-    needs: test-vars
+    needs: images
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          cache-dependency-path: "**/*.sum"
+          go-version-file: 'e2e/go.mod'
+
       - name: Run end to end tests
         env:
-          DOCKER_TAG: ${{ inputs.image_tag }}
-          APIServerContainerImage: ${{ needs.test-vars.outputs.apiserver-image }}
-          OrchestratorContainerImage: ${{ needs.test-vars.outputs.orchestrator-image }}
-          UIContainerImage: ${{ needs.test-vars.outputs.ui-backend-image }}
-          UIBackendContainerImage: ${{ needs.test-vars.outputs.ui-image }}
-          ScannerContainerImage: ${{ needs.test-vars.outputs.cli-image }}
+          APIServerContainerImage:  ${{ format('{0}:{1}', needs.images.outputs.apiserver-image, inputs.image_tag) }}
+          OrchestratorContainerImage: ${{ format('{0}:{1}', needs.images.outputs.orchestrator-image, inputs.image_tag) }}
+          UIContainerImage: ${{ format('{0}:{1}', needs.images.outputs.ui-backend-image, inputs.image_tag) }}
+          UIBackendContainerImage: ${{ format('{0}:{1}', needs.images.outputs.ui-image, inputs.image_tag) }}
+          ScannerContainerImage: ${{ format('{0}:{1}', needs.images.outputs.cli-image, inputs.image_tag) }}
         run: |
           cd e2e \
           && go test -v -failfast -test.v -test.paniconexit0 -timeout 2h -ginkgo.v .

--- a/.github/workflows/reusable-end-to-end-testing.yml
+++ b/.github/workflows/reusable-end-to-end-testing.yml
@@ -1,0 +1,62 @@
+name: End-toEnd testing
+
+on:
+  workflow_call:
+    inputs:
+      image_tag:
+        required: true
+        type: string
+        description: 'Image tag to build and push.'
+      use_release_repository:
+        required: false
+        type: boolean
+        description: 'If set to true the image published to the release repository is used otherwise the development.'
+        default: false
+
+jobs:
+  test-vars:
+    runs-on: ubuntu-latest
+    outputs:
+      apiserver-image: ${{ steps.images.outputs.apiserver-image }}
+      orchestrator-image: ${{ steps.images.outputs.orchestrator-image }}
+      ui-backend-image: ${{ steps.images.outputs.ui-backend-image }}
+      ui-image: ${{ steps.images.outputs.ui-image }}
+      cli-image: ${{ steps.images.outputs.cli-image }}
+    steps:
+      - name: Set container image names
+        id: images
+        run: |
+          ##
+          ## Determine the image name suffix based on the release type
+          ##
+  
+          registry=ghcr.io/openclarity/
+          suffix=-dev
+  
+          if [ "${{ inputs.use_release_repository }}" == "true" ]; then
+            suffix=
+          fi
+  
+          {
+            echo "apiserver-image=${registry}vmclarity-apiserver${suffix}"
+            echo "orchestrator-image=${registry}vmclarity-orchestrator${suffix}"
+            echo "ui-backend-image=${registry}vmclarity-ui-backend${suffix}"
+            echo "ui-image=${registry}vmclarity-ui${suffix}"
+            echo "cli-image=${registry}vmclarity-cli${suffix}"
+          } >> "$GITHUB_OUTPUT"
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: test-vars
+    steps:
+      - name: Run end to end tests
+        env:
+          DOCKER_TAG: ${{ inputs.image_tag }}
+          APIServerContainerImage: ${{ needs.test-vars.outputs.apiserver-image }}
+          OrchestratorContainerImage: ${{ needs.test-vars.outputs.orchestrator-image }}
+          UIContainerImage: ${{ needs.test-vars.outputs.ui-backend-image }}
+          UIBackendContainerImage: ${{ needs.test-vars.outputs.ui-image }}
+          ScannerContainerImage: ${{ needs.test-vars.outputs.cli-image }}
+        run: |
+          cd e2e \
+          && go test -v -failfast -test.v -test.paniconexit0 -timeout 2h -ginkgo.v .

--- a/.github/workflows/reusable-end-to-end-testing.yml
+++ b/.github/workflows/reusable-end-to-end-testing.yml
@@ -36,8 +36,8 @@ jobs:
         env:
           APIServerContainerImage:  ${{ format('{0}:{1}', needs.images.outputs.apiserver-image, inputs.image_tag) }}
           OrchestratorContainerImage: ${{ format('{0}:{1}', needs.images.outputs.orchestrator-image, inputs.image_tag) }}
-          UIContainerImage: ${{ format('{0}:{1}', needs.images.outputs.ui-backend-image, inputs.image_tag) }}
-          UIBackendContainerImage: ${{ format('{0}:{1}', needs.images.outputs.ui-image, inputs.image_tag) }}
+          UIContainerImage: ${{ format('{0}:{1}', needs.images.outputs.ui-image, inputs.image_tag) }}
+          UIBackendContainerImage: ${{ format('{0}:{1}', needs.images.outputs.ui-backend-image, inputs.image_tag) }}
           ScannerContainerImage: ${{ format('{0}:{1}', needs.images.outputs.cli-image, inputs.image_tag) }}
         run: |
           cd e2e \

--- a/.github/workflows/reusable-image-names.yml
+++ b/.github/workflows/reusable-image-names.yml
@@ -1,0 +1,66 @@
+name: Container Image Names
+
+on:
+  workflow_call:
+    inputs:
+      registry_name:
+        required: false
+        type: string
+        description: 'Registry name used for container image names. Default is `ghcr.io/openclarity`.'
+        default: ghcr.io/openclarity
+      use_release_repository:
+        required: false
+        type: boolean
+        description: 'If set to true the image published to the release repository is used otherwise the development.'
+        default: false
+    outputs:
+      apiserver-image:
+        value: ${{ jobs.images.outputs.apiserver-image }}
+        description: 'Name of the container image for VMClarity API Server'
+      orchestrator-image:
+        value: ${{ jobs.images.outputs.orchestrator-image }}
+        description: 'Name of the contaienr image for VMClarity Orchestrator'
+      ui-backend-image:
+        value: ${{ jobs.images.outputs.ui-backend-image }}
+        description: 'Name of the container image for VMClarity UI Backend Server'
+      ui-image:
+        value: ${{ jobs.images.outputs.ui-image }}
+        description: 'Name of the container image for VMClarity UI Server'
+      cli-image:
+        value: ${{ jobs.images.outputs.cli-image }}
+        description: 'Name of the container image for VMClarity CLI'
+
+jobs:
+  images:
+    runs-on: ubuntu-latest
+    outputs:
+      apiserver-image: ${{ steps.images.outputs.apiserver-image }}
+      orchestrator-image: ${{ steps.images.outputs.orchestrator-image }}
+      ui-backend-image: ${{ steps.images.outputs.ui-backend-image }}
+      ui-image: ${{ steps.images.outputs.ui-image }}
+      cli-image: ${{ steps.images.outputs.cli-image }}
+    steps:
+      - name: Set container image names
+        id: images
+        run: |
+          ##
+          ## Determine the image name suffix based on the release type
+          ##
+
+          # Remove trailing slash characters(s)
+          # shellcheck disable=SC2001
+          registry="$(sed -e 's@/*$@@' <<< ${{ inputs.registry_name }})"
+          
+          # Set image nam suffix
+          suffix=-dev
+          if [ "${{ inputs.use_release_repository }}" == "true" ]; then
+            suffix=
+          fi
+
+          {
+            echo "apiserver-image=${registry}/vmclarity-apiserver${suffix}"
+            echo "orchestrator-image=${registry}/vmclarity-orchestrator${suffix}"
+            echo "ui-backend-image=${registry}/vmclarity-ui-backend${suffix}"
+            echo "ui-image=${registry}/vmclarity-ui${suffix}"
+            echo "cli-image=${registry}/vmclarity-cli${suffix}"
+          } >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Description

* re-enable End-to-End testing in CI pipeline
* move image name generation into a reusable component

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
