### PR TITLE
feat(ci): use Actions cache for docker builds

### DIFF
--- a/.github/workflows/build-and-push-component.yaml
+++ b/.github/workflows/build-and-push-component.yaml
@@ -88,8 +88,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           file: ${{ inputs.dockerfile }}
           outputs: type=image,name=${{ inputs.image_name }},push-by-digest=true,name-canonical=true,push=${{ inputs.push }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           build-args: |
             VERSION=${{ inputs.image_tag }}
             BUILD_TIMESTAMP=${{ inputs.timestamp }}


### PR DESCRIPTION
## Description

Use Github Actions cache for storing Docker build cache.

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
