### PR TITLE
feat(orchestrator): adopt new provider in config and discoverer

### DIFF
--- a/e2e/report.go
+++ b/e2e/report.go
@@ -61,7 +61,13 @@ func DumpAPIData(ctx ginkgo.SpecContext, client *backendclient.BackendClient, co
 	ginkgo.GinkgoWriter.Println(formatter.F("{{red}}[FAILED] Report API Data:{{/}}"))
 
 	if config.allAPIObjects {
-		config.objects = append(config.objects, APIObject{"asset", ""}, APIObject{"scanConfigs", ""}, APIObject{"scans", ""})
+		config.objects = append(
+			config.objects,
+			APIObject{"asset", ""},
+			APIObject{"scanConfigs", ""},
+			APIObject{"scans", ""},
+			APIObject{"provider", ""},
+		)
 	}
 
 	for _, object := range config.objects {
@@ -107,6 +113,20 @@ func DumpAPIData(ctx ginkgo.SpecContext, client *backendclient.BackendClient, co
 			buf, err := json.MarshalIndent(*scans.Items, "", "\t")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.GinkgoWriter.Printf("Scan: %s\n", string(buf))
+
+		case "provider":
+			var params models.GetProvidersParams
+			if object.filter == "" {
+				params = models.GetProvidersParams{}
+			} else {
+				params = models.GetProvidersParams{Filter: utils.PointerTo(object.filter)}
+			}
+			providers, err := client.GetProviders(ctx, params)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			buf, err := json.MarshalIndent(*providers.Items, "", "\t")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.GinkgoWriter.Printf("Provider: %s\n", string(buf))
 		}
 	}
 }

--- a/pkg/orchestrator/assetscanestimationwatcher/config.go
+++ b/pkg/orchestrator/assetscanestimationwatcher/config.go
@@ -31,7 +31,7 @@ const (
 
 type Config struct {
 	Backend          *backendclient.BackendClient
-	Provider         provider.Provider
+	Provider         *provider.Provider
 	PollPeriod       time.Duration
 	ReconcileTimeout time.Duration
 }
@@ -41,7 +41,7 @@ func (c Config) WithBackendClient(b *backendclient.BackendClient) Config {
 	return c
 }
 
-func (c Config) WithProviderClient(p provider.Provider) Config {
+func (c Config) WithProviderClient(p *provider.Provider) Config {
 	c.Provider = p
 	return c
 }

--- a/pkg/orchestrator/assetscanestimationwatcher/watcher.go
+++ b/pkg/orchestrator/assetscanestimationwatcher/watcher.go
@@ -47,7 +47,7 @@ func New(c Config) *Watcher {
 
 type Watcher struct {
 	backend          *backendclient.BackendClient
-	provider         provider.Provider
+	provider         *provider.Provider
 	pollPeriod       time.Duration
 	reconcileTimeout time.Duration
 
@@ -256,7 +256,7 @@ func (w *Watcher) reconcilePending(ctx context.Context, assetScanEstimation *mod
 	stats := w.getLatestAssetScanStats(ctx, asset)
 	startTime := time.Now()
 
-	estimation, err := w.provider.Estimate(ctx, stats, asset, assetScanEstimation.AssetScanTemplate)
+	estimation, err := (*w.provider).Estimate(ctx, stats, asset, assetScanEstimation.AssetScanTemplate)
 
 	endTime := time.Now()
 

--- a/pkg/orchestrator/assetscanwatcher/config.go
+++ b/pkg/orchestrator/assetscanwatcher/config.go
@@ -30,7 +30,7 @@ const (
 
 type Config struct {
 	Backend          *backendclient.BackendClient
-	Provider         provider.Provider
+	Provider         *provider.Provider
 	PollPeriod       time.Duration
 	ReconcileTimeout time.Duration
 	ScannerConfig    ScannerConfig
@@ -42,7 +42,7 @@ func (c Config) WithBackendClient(b *backendclient.BackendClient) Config {
 	return c
 }
 
-func (c Config) WithProviderClient(p provider.Provider) Config {
+func (c Config) WithProviderClient(p *provider.Provider) Config {
 	c.Provider = p
 	return c
 }

--- a/pkg/orchestrator/assetscanwatcher/watcher.go
+++ b/pkg/orchestrator/assetscanwatcher/watcher.go
@@ -49,7 +49,7 @@ func New(c Config) *Watcher {
 
 type Watcher struct {
 	backend          *backendclient.BackendClient
-	provider         provider.Provider
+	provider         *provider.Provider
 	scannerConfig    ScannerConfig
 	pollPeriod       time.Duration
 	reconcileTimeout time.Duration
@@ -266,7 +266,7 @@ func (w *Watcher) reconcileScheduled(ctx context.Context, assetScan *models.Asse
 		return fmt.Errorf("failed to create ScanJobConfig for AssetScan. AssetScan=%s: %w", assetScanID, err)
 	}
 
-	err = w.provider.RunAssetScan(ctx, jobConfig)
+	err = (*w.provider).RunAssetScan(ctx, jobConfig)
 
 	var fatalError provider.FatalError
 	var retryableError provider.RetryableError
@@ -369,7 +369,7 @@ func (w *Watcher) cleanupResources(ctx context.Context, assetScan *models.AssetS
 			return fmt.Errorf("failed to create ScanJobConfig for AssetScan. AssetScanID=%s: %w", assetScanID, err)
 		}
 
-		err = w.provider.RemoveAssetScan(ctx, jobConfig)
+		err = (*w.provider).RemoveAssetScan(ctx, jobConfig)
 
 		var fatalError provider.FatalError
 		var retryableError provider.RetryableError

--- a/pkg/orchestrator/discovery/config.go
+++ b/pkg/orchestrator/discovery/config.go
@@ -28,7 +28,7 @@ const (
 
 type Config struct {
 	Backend           *backendclient.BackendClient
-	Provider          provider.Provider
+	Provider          *provider.Provider
 	DiscoveryInterval time.Duration
 }
 
@@ -37,7 +37,7 @@ func (c Config) WithBackendClient(b *backendclient.BackendClient) Config {
 	return c
 }
 
-func (c Config) WithProviderClient(p provider.Provider) Config {
+func (c Config) WithProviderClient(p *provider.Provider) Config {
 	c.Provider = p
 	return c
 }

--- a/pkg/orchestrator/discovery/discoverer.go
+++ b/pkg/orchestrator/discovery/discoverer.go
@@ -35,7 +35,7 @@ const (
 
 type Discoverer struct {
 	backendClient  *backendclient.BackendClient
-	providerClient provider.Provider
+	providerClient *provider.Provider
 }
 
 func New(config Config) *Discoverer {
@@ -68,7 +68,7 @@ func (d *Discoverer) Start(ctx context.Context) {
 func (d *Discoverer) DiscoverAndCreateAssets(ctx context.Context) error {
 	discoveryTime := time.Now()
 
-	discoverer := d.providerClient.DiscoverAssets(ctx)
+	discoverer := (*d.providerClient).DiscoverAssets(ctx)
 
 	errs := []error{}
 	failedPatchAssets := make(map[string]struct{})

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -101,9 +101,13 @@ func New(ctx context.Context, config *Config) (*Orchestrator, error) {
 	}
 
 	// TODO(paralta) Provider initialization needs to be removed from here once Providers are split from Orchestrator (Issue #643).
-	p, err := NewProvider(ctx, config.Provider)
+	apiProvider, err := backendClient.PostProvider(ctx, config.Provider)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize provider. Provider=%s: %w", *config.Provider.DisplayName, err)
+		return nil, fmt.Errorf("failed to post provider: %w", err)
+	}
+	p, err := NewProvider(ctx, *apiProvider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize provider. Provider=%s: %w", *apiProvider.DisplayName, err)
 	}
 
 	return NewWithProvider(config, p, backendClient)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -100,9 +100,10 @@ func New(ctx context.Context, config *Config) (*Orchestrator, error) {
 		return nil, fmt.Errorf("failed to create a backend client: %w", err)
 	}
 
-	p, err := NewProvider(ctx, config.ProviderKind)
+	// TODO(paralta) Provider initialization needs to be removed from here once Providers are split from Orchestrator (Issue #643).
+	p, err := NewProvider(ctx, config.Provider)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize provider. Provider=%s: %w", config.ProviderKind, err)
+		return nil, fmt.Errorf("failed to initialize provider. Provider=%s: %w", *config.Provider.DisplayName, err)
 	}
 
 	return NewWithProvider(config, p, backendClient)
@@ -132,21 +133,21 @@ func (o *Orchestrator) Stop(ctx context.Context) {
 
 // nolint:wrapcheck
 // NewProvider returns an initialized provider.Provider based on the kind models.CloudProvider.
-func NewProvider(ctx context.Context, kind models.CloudProvider) (provider.Provider, error) {
-	switch kind {
-	case models.Azure:
+func NewProvider(ctx context.Context, provider models.Provider) (provider.Provider, error) {
+	switch *provider.DisplayName {
+	case string(models.Azure):
 		return azure.New(ctx)
-	case models.Docker:
+	case string(models.Docker):
 		return docker.New(ctx)
-	case models.AWS:
+	case string(models.AWS):
 		return aws.New(ctx)
-	case models.GCP:
+	case string(models.GCP):
 		return gcp.New(ctx)
-	case models.External:
+	case string(models.External):
 		return external.New(ctx)
-	case models.Kubernetes:
+	case string(models.Kubernetes):
 		return kubernetes.New(ctx)
 	default:
-		return nil, fmt.Errorf("unsupported provider: %s", kind)
+		return nil, fmt.Errorf("unsupported provider: %s", *provider.DisplayName)
 	}
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -105,7 +105,7 @@ func New(ctx context.Context, config *Config) (*Orchestrator, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to post provider: %w", err)
 	}
-	p, err := NewProvider(ctx, *apiProvider)
+	p, err := NewProvider(ctx, apiProvider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize provider. Provider=%s: %w", *apiProvider.DisplayName, err)
 	}
@@ -137,21 +137,21 @@ func (o *Orchestrator) Stop(ctx context.Context) {
 
 // nolint:wrapcheck
 // NewProvider returns an initialized provider.Provider based on the kind models.CloudProvider.
-func NewProvider(ctx context.Context, provider models.Provider) (provider.Provider, error) {
-	switch *provider.DisplayName {
+func NewProvider(ctx context.Context, p *models.Provider) (provider.Provider, error) {
+	switch *p.DisplayName {
 	case string(models.Azure):
-		return azure.New(ctx)
+		return azure.New(ctx, p)
 	case string(models.Docker):
-		return docker.New(ctx)
+		return docker.New(ctx, p)
 	case string(models.AWS):
-		return aws.New(ctx)
+		return aws.New(ctx, p)
 	case string(models.GCP):
-		return gcp.New(ctx)
+		return gcp.New(ctx, p)
 	case string(models.External):
-		return external.New(ctx)
+		return external.New(ctx, p)
 	case string(models.Kubernetes):
 		return kubernetes.New(ctx)
 	default:
-		return nil, fmt.Errorf("unsupported provider: %s", *provider.DisplayName)
+		return nil, fmt.Errorf("unsupported provider: %s", *p.DisplayName)
 	}
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -69,7 +69,7 @@ func Run(ctx context.Context, config *Config) error {
 // NewWithProvider returns an Orchestrator initialized using the p provider.Provider.
 // Use this method when Orchestrator needs to rely on custom provider.Provider implementation.
 // E.g. End-to-End testing.
-func NewWithProvider(config *Config, p provider.Provider, b *backendclient.BackendClient) (*Orchestrator, error) {
+func NewWithProvider(config *Config, p *provider.Provider, b *backendclient.BackendClient) (*Orchestrator, error) {
 	scanConfigWatcherConfig := config.ScanConfigWatcherConfig.WithBackendClient(b)
 	discoveryConfig := config.DiscoveryConfig.WithBackendClient(b).WithProviderClient(p)
 	scanWatcherConfig := config.ScanWatcherConfig.WithBackendClient(b).WithProviderClient(p)
@@ -110,7 +110,7 @@ func New(ctx context.Context, config *Config) (*Orchestrator, error) {
 		return nil, fmt.Errorf("failed to initialize provider. Provider=%s: %w", *apiProvider.DisplayName, err)
 	}
 
-	return NewWithProvider(config, p, backendClient)
+	return NewWithProvider(config, &p, backendClient)
 }
 
 // Start makes the Orchestrator to start all Controller(s).

--- a/pkg/orchestrator/provider/aws/client.go
+++ b/pkg/orchestrator/provider/aws/client.go
@@ -41,9 +41,10 @@ type Client struct {
 	ec2Client     *ec2.Client
 	scanEstimator *scanestimation.ScanEstimator
 	config        *Config
+	provider      *models.Provider
 }
 
-func New(ctx context.Context) (*Client, error) {
+func New(ctx context.Context, provider *models.Provider) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("invalid configuration. Provider=AWS: %w", err)
@@ -54,7 +55,8 @@ func New(ctx context.Context) (*Client, error) {
 	}
 
 	awsClient := Client{
-		config: config,
+		config:   config,
+		provider: provider,
 	}
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)
@@ -71,6 +73,10 @@ func New(ctx context.Context) (*Client, error) {
 
 func (c Client) Kind() models.CloudProvider {
 	return models.AWS
+}
+
+func (c Client) Object() *models.Provider {
+	return c.provider
 }
 
 func (c *Client) Estimate(ctx context.Context, assetScanStats models.AssetScanStats, asset *models.Asset, assetScanTemplate *models.AssetScanTemplate) (*models.Estimation, error) {

--- a/pkg/orchestrator/provider/azure/client.go
+++ b/pkg/orchestrator/provider/azure/client.go
@@ -48,9 +48,10 @@ type Client struct {
 	interfacesClient *armnetwork.InterfacesClient
 
 	azureConfig Config
+	provider    *models.Provider
 }
 
-func New(_ context.Context) (*Client, error) {
+func New(_ context.Context, provider *models.Provider) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
@@ -63,6 +64,7 @@ func New(_ context.Context) (*Client, error) {
 
 	client := Client{
 		azureConfig: config,
+		provider:    provider,
 	}
 
 	cred, err := azidentity.NewManagedIdentityCredential(nil)
@@ -95,6 +97,10 @@ func New(_ context.Context) (*Client, error) {
 
 func (c Client) Kind() models.CloudProvider {
 	return models.Azure
+}
+
+func (c Client) Object() *models.Provider {
+	return c.provider
 }
 
 func (c *Client) Estimate(ctx context.Context, stats models.AssetScanStats, asset *models.Asset, assetScanTemplate *models.AssetScanTemplate) (*models.Estimation, error) {

--- a/pkg/orchestrator/provider/docker/client.go
+++ b/pkg/orchestrator/provider/docker/client.go
@@ -45,9 +45,10 @@ var mountPointPath = "/mnt/snapshot"
 type Client struct {
 	dockerClient *client.Client
 	config       *Config
+	provider     *models.Provider
 }
 
-func New(_ context.Context) (*Client, error) {
+func New(_ context.Context, provider *models.Provider) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("invalid configuration. Provider=%s: %w", models.Docker, err)
@@ -61,11 +62,16 @@ func New(_ context.Context) (*Client, error) {
 	return &Client{
 		dockerClient: dockerClient,
 		config:       config,
+		provider:     provider,
 	}, nil
 }
 
 func (c *Client) Kind() models.CloudProvider {
 	return models.Docker
+}
+
+func (c Client) Object() *models.Provider {
+	return c.provider
 }
 
 func (c *Client) Estimate(ctx context.Context, stats models.AssetScanStats, asset *models.Asset, assetScanTemplate *models.AssetScanTemplate) (*models.Estimation, error) {

--- a/pkg/orchestrator/provider/external/client.go
+++ b/pkg/orchestrator/provider/external/client.go
@@ -32,9 +32,10 @@ type Client struct {
 	providerClient provider_service.ProviderClient
 	config         *Config
 	conn           *grpc.ClientConn
+	provider       *models.Provider
 }
 
-func New(_ context.Context) (*Client, error) {
+func New(_ context.Context, provider *models.Provider) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
@@ -46,7 +47,8 @@ func New(_ context.Context) (*Client, error) {
 	}
 
 	client := Client{
-		config: config,
+		config:   config,
+		provider: provider,
 	}
 
 	var opts []grpc.DialOption
@@ -65,6 +67,10 @@ func New(_ context.Context) (*Client, error) {
 
 func (c Client) Kind() models.CloudProvider {
 	return models.External
+}
+
+func (c Client) Object() *models.Provider {
+	return c.provider
 }
 
 func (c *Client) Estimate(ctx context.Context, stats models.AssetScanStats, asset *models.Asset, assetScanTemplate *models.AssetScanTemplate) (*models.Estimation, error) {

--- a/pkg/orchestrator/provider/gcp/client.go
+++ b/pkg/orchestrator/provider/gcp/client.go
@@ -40,9 +40,10 @@ type Client struct {
 	regionsClient   *compute.RegionsClient
 
 	gcpConfig Config
+	provider  *models.Provider
 }
 
-func New(ctx context.Context) (*Client, error) {
+func New(ctx context.Context, provider *models.Provider) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
@@ -55,6 +56,7 @@ func New(ctx context.Context) (*Client, error) {
 
 	client := Client{
 		gcpConfig: config,
+		provider:  provider,
 	}
 
 	regionsClient, err := compute.NewRegionsRESTClient(ctx)
@@ -86,6 +88,10 @@ func New(ctx context.Context) (*Client, error) {
 
 func (c Client) Kind() models.CloudProvider {
 	return models.GCP
+}
+
+func (c Client) Object() *models.Provider {
+	return c.provider
 }
 
 func (c *Client) Estimate(ctx context.Context, stats models.AssetScanStats, asset *models.Asset, assetScanTemplate *models.AssetScanTemplate) (*models.Estimation, error) {

--- a/pkg/orchestrator/provider/kubernetes/provider.go
+++ b/pkg/orchestrator/provider/kubernetes/provider.go
@@ -74,6 +74,10 @@ func (p *Provider) Kind() models.CloudProvider {
 	return models.Kubernetes
 }
 
+func (p *Provider) Object() *models.Provider {
+	return &models.Provider{}
+}
+
 func (p *Provider) Estimate(ctx context.Context, stats models.AssetScanStats, asset *models.Asset, assetScanTemplate *models.AssetScanTemplate) (*models.Estimation, error) {
 	return &models.Estimation{}, provider.FatalErrorf("Not Implemented")
 }

--- a/pkg/orchestrator/provider/types.go
+++ b/pkg/orchestrator/provider/types.go
@@ -24,6 +24,7 @@ import (
 type Provider interface {
 	// Kind returns models.CloudProvider
 	Kind() models.CloudProvider
+	Object() *models.Provider
 
 	Discoverer
 	Estimator

--- a/pkg/orchestrator/scanestimationwatcher/config.go
+++ b/pkg/orchestrator/scanestimationwatcher/config.go
@@ -31,7 +31,7 @@ const (
 
 type Config struct {
 	Backend               *backendclient.BackendClient
-	Provider              provider.Provider
+	Provider              *provider.Provider
 	PollPeriod            time.Duration
 	ReconcileTimeout      time.Duration
 	ScanEstimationTimeout time.Duration
@@ -42,7 +42,7 @@ func (c Config) WithBackendClient(b *backendclient.BackendClient) Config {
 	return c
 }
 
-func (c Config) WithProviderClient(p provider.Provider) Config {
+func (c Config) WithProviderClient(p *provider.Provider) Config {
 	c.Provider = p
 	return c
 }

--- a/pkg/orchestrator/scanestimationwatcher/watcher.go
+++ b/pkg/orchestrator/scanestimationwatcher/watcher.go
@@ -50,7 +50,7 @@ func New(c Config) *Watcher {
 
 type Watcher struct {
 	backend               *backendclient.BackendClient
-	provider              provider.Provider
+	provider              *provider.Provider
 	pollPeriod            time.Duration
 	reconcileTimeout      time.Duration
 	scanEstimationTimeout time.Duration

--- a/pkg/orchestrator/scanwatcher/config.go
+++ b/pkg/orchestrator/scanwatcher/config.go
@@ -30,7 +30,7 @@ const (
 
 type Config struct {
 	Backend          *backendclient.BackendClient
-	Provider         provider.Provider
+	Provider         *provider.Provider
 	PollPeriod       time.Duration
 	ReconcileTimeout time.Duration
 	ScanTimeout      time.Duration
@@ -41,7 +41,7 @@ func (c Config) WithBackendClient(b *backendclient.BackendClient) Config {
 	return c
 }
 
-func (c Config) WithProviderClient(p provider.Provider) Config {
+func (c Config) WithProviderClient(p *provider.Provider) Config {
 	c.Provider = p
 	return c
 }

--- a/pkg/orchestrator/scanwatcher/watcher.go
+++ b/pkg/orchestrator/scanwatcher/watcher.go
@@ -49,7 +49,7 @@ func New(c Config) *Watcher {
 
 type Watcher struct {
 	backend          *backendclient.BackendClient
-	provider         provider.Provider
+	provider         *provider.Provider
 	pollPeriod       time.Duration
 	reconcileTimeout time.Duration
 	scanTimeout      time.Duration

--- a/pkg/shared/backendclient/client.go
+++ b/pkg/shared/backendclient/client.go
@@ -935,25 +935,25 @@ func (b *BackendClient) PostFinding(ctx context.Context, finding models.Finding)
 func (b *BackendClient) PostProvider(ctx context.Context, provider models.Provider) (*models.Provider, error) {
 	resp, err := b.apiClient.PostProvidersWithResponse(ctx, provider)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create an provider: %w", err)
+		return nil, fmt.Errorf("failed to create a provider: %w", err)
 	}
 	switch resp.StatusCode() {
 	case http.StatusCreated:
 		if resp.JSON201 == nil {
-			return nil, fmt.Errorf("failed to create an provider: empty body. status code=%v", http.StatusCreated)
+			return nil, fmt.Errorf("failed to create a provider: empty body. status code=%v", http.StatusCreated)
 		}
 		return resp.JSON201, nil
 	case http.StatusBadRequest:
 		if resp.JSON400 != nil && resp.JSON400.Message != nil {
-			return nil, fmt.Errorf("failed to create an provider. status code=%v: %v", resp.StatusCode(), *resp.JSON400.Message)
+			return nil, fmt.Errorf("failed to create a provider. status code=%v: %v", resp.StatusCode(), *resp.JSON400.Message)
 		}
-		return nil, fmt.Errorf("failed to create an provider. status code=%v", resp.StatusCode())
+		return nil, fmt.Errorf("failed to create a provider. status code=%v", resp.StatusCode())
 	case http.StatusConflict:
 		if resp.JSON409 == nil {
-			return nil, fmt.Errorf("failed to create an provider: empty body. status code=%v", http.StatusConflict)
+			return nil, fmt.Errorf("failed to create a provider: empty body. status code=%v", http.StatusConflict)
 		}
 		if resp.JSON409.Provider == nil {
-			return nil, fmt.Errorf("failed to create an provider: no provider data. status code=%v", http.StatusConflict)
+			return nil, fmt.Errorf("failed to create a provider: no provider data. status code=%v", http.StatusConflict)
 		}
 		return nil, ProviderConflictError{
 			ConflictingProvider: resp.JSON409.Provider,
@@ -961,9 +961,9 @@ func (b *BackendClient) PostProvider(ctx context.Context, provider models.Provid
 		}
 	default:
 		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
-			return nil, fmt.Errorf("failed to create an provider. status code=%v: %v", resp.StatusCode(), *resp.JSONDefault.Message)
+			return nil, fmt.Errorf("failed to create a provider. status code=%v: %v", resp.StatusCode(), *resp.JSONDefault.Message)
 		}
-		return nil, fmt.Errorf("failed to create an provider. status code=%v", resp.StatusCode())
+		return nil, fmt.Errorf("failed to create a provider. status code=%v", resp.StatusCode())
 	}
 }
 


### PR DESCRIPTION
## Description

https://github.com/openclarity/vmclarity/issues/640

* Update orchestrator to use new provider API object in configuration
* Get provider from environment variable and post it to DB
* Add provider ID to asset once discovered or rediscovered

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
