### PR TITLE
Update port

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For a detailed installation guide, please see [AWS](installation/aws/README.md).
 
    * On AWS, Azure or GCP, open an SSH tunnel to VMClarity VM server
      ```
-     ssh -N -L 8080:localhost:80 -i  "<Path to the SSH key specified during install>" ubuntu@<VmClarity SSH Address copied during install>
+     ssh -N -L 8080:localhost:8888 -i  "<Path to the SSH key specified during install>" ubuntu@<VmClarity SSH Address copied during install>
      ```
 
    * On Kubernetes port-forward vmclarity-gateway service:


### PR DESCRIPTION


## Description

Update the dashboard port in port-forwarding command 

After deploying the CF stack, I tried to access the dashboard and failed. I found out the dashboard is accessible on port 8888 instead of 80

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[x] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
