### PR TITLE
Fix asset fields on UI

### DIFF
--- a/ui/src/layout/Assets/AssetsTable.js
+++ b/ui/src/layout/Assets/AssetsTable.js
@@ -8,9 +8,12 @@ import { APIS } from 'utils/systemConsts';
 import { getFindingsColumnsConfigList, getVulnerabilitiesColumnConfigItem, getAssetColumnsFiltersConfig,
     findingsColumnsFiltersConfig, vulnerabilitiesCountersColumnsFiltersConfig, formatTagsToStringsList, formatDate} from 'utils/utils';
 import { useFilterDispatch, useFilterState, setFilters, FILTER_TYPES } from 'context/FiltersProvider';
+import { getAssetName } from './utils';
 
 const TABLE_TITLE = "assets";
 
+const NAME_SORT_IDS = ["assetInfo.instanceID", "assetInfo.podName", "assetInfo.dirName", "assetInfo.name", "assetInfo.containerName"];
+const LABEL_SORT_IDS = ["assetInfo.tags", "assetInfo.labels"];
 const LOCATION_SORT_IDS = ["assetInfo.location"];
 
 const ASSETS_FILTER_TYPE = FILTER_TYPES.ASSETS;
@@ -38,18 +41,18 @@ const AssetsTable = () => {
         {
             Header: "Name",
             id: "instanceID",
-            sortIds: ["assetInfo.instanceID"],
-            accessor: "assetInfo.instanceID"
+            sortIds: NAME_SORT_IDS,
+            accessor: (original) => getAssetName(original.assetInfo),
         },
         {
             Header: "Labels",
             id: "tags",
-            sortIds: ["assetInfo.tags"],
+            sortIds: LABEL_SORT_IDS,
             Cell: ({row}) => {
-                const {tags} = row.original.assetInfo;
+                const {tags, labels} = row.original.assetInfo;
                 
                 return (
-                    <ExpandableList items={formatTagsToStringsList(tags)} withTagWrap />
+                    <ExpandableList items={formatTagsToStringsList(tags ?? labels)} withTagWrap />
                 )
             },
             alignToTop: true

--- a/ui/src/layout/Assets/utils.js
+++ b/ui/src/layout/Assets/utils.js
@@ -1,0 +1,16 @@
+export function getAssetName(assetInfo) {
+    switch (assetInfo.objectType) {
+        case "VMInfo":
+            return assetInfo.instanceID;
+        case "PodInfo":
+            return assetInfo.podName;
+        case "DirInfo":
+            return assetInfo.dirName;
+        case "ContainerImageInfo":
+            return assetInfo.name;
+        case "ContainerInfo":
+            return assetInfo.containerName;
+        default:
+            return assetInfo.id;
+    }
+}


### PR DESCRIPTION
## Description

Fixes the presentation of name and labels fields on the assets page.
Also fixes the presentation of name, image and platform fields on the asset details page.
The asset details page was throwing an uncaught react error on the asset details page when the asset type was ContainerInfo. This issue is also fixed with this PR.

Fixes: https://github.com/openclarity/vmclarity/issues/763

NOTE:
This PR is fixing the issue above but the code will remain easily breakable with changes made to the API.
A bigger refactor would be required to make it easier to maintain and less error prone to future changes.
For example:
- separate presentation and data loading logic
- handle different asset types separately

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
