### PR TITLE
faet: bump exploit-db-server version

### DIFF
--- a/installation/aws/VmClarity.cfn
+++ b/installation/aws/VmClarity.cfn
@@ -442,7 +442,7 @@ Resources:
                     OrchestratorContainerImage: !If [ OrchestratorContainerImageOverridden, !Ref OrchestratorContainerImageOverride, "ghcr.io/openclarity/vmclarity-orchestrator:latest" ]
                     UIContainerImage: !If [ UIContainerImageOverridden, !Ref UIContainerImageOverride, "ghcr.io/openclarity/vmclarity-ui:latest" ]
                     UIBackendContainerImage: !If [ UIBackendContainerImageOverridden, !Ref UIBackendContainerImageOverride, "ghcr.io/openclarity/vmclarity-ui-backend:latest" ]
-                    ExploitDBServerContainerImage: !If [ExploitDBServerContainerImageOverridden, !Ref ExploitDBServerContainerImageOverride, "ghcr.io/openclarity/exploit-db-server:v0.2.3"]
+                    ExploitDBServerContainerImage: !If [ExploitDBServerContainerImageOverridden, !Ref ExploitDBServerContainerImageOverride, "ghcr.io/openclarity/exploit-db-server:v0.2.4"]
                     TrivyServerContainerImage: !If [TrivyServerContainerImageOverridden, !Ref TrivyServerContainerImageOverride, "docker.io/aquasec/trivy:0.41.0"]
                     GrypeServerContainerImage: !If [GrypeServerContainerImageOverridden, !Ref GrypeServerContainerImageOverride, "ghcr.io/openclarity/grype-server:v0.5.0"]
                     YaraRuleServerContainerImage: !If [YaraRuleServerContainerImageOverridden, !Ref YaraRuleServerContainerImageOverride, "ghcr.io/openclarity/yara-rule-server:v0.1.0"]
@@ -1142,7 +1142,7 @@ Parameters:
   ExploitDBServerContainerImageOverride:
     Description: >
       Name of the container image used for the exploit db server.
-      "ghcr.io/openclarity/exploit-db-server:v0.2.3" will be used if not overridden.
+      "ghcr.io/openclarity/exploit-db-server:v0.2.4" will be used if not overridden.
     Type: String
     Default: ''
   PostgresqlContainerImageOverride:

--- a/installation/azure/vmclarity-UI.json
+++ b/installation/azure/vmclarity-UI.json
@@ -236,7 +236,7 @@
                             "type": "Microsoft.Common.TextBox",
                             "label": "Exploit DB Container Image",
                             "subLabel": "",
-                            "defaultValue": "ghcr.io/openclarity/exploit-db-server:v0.2.3",
+                            "defaultValue": "ghcr.io/openclarity/exploit-db-server:v0.2.4",
                             "toolTip": "Exploit DB Container Image",
                             "constraints": {
                                 "required": false,

--- a/installation/azure/vmclarity.bicep
+++ b/installation/azure/vmclarity.bicep
@@ -45,7 +45,7 @@ param trivyServerContainerImage string = 'docker.io/aquasec/trivy:0.41.0'
 param grypeServerContainerImage string = 'ghcr.io/openclarity/grype-server:v0.5.0'
 
 @description ('Exploit DB Container Image')
-param exploitDBContainerImage string = 'ghcr.io/openclarity/exploit-db-server:v0.2.3'
+param exploitDBContainerImage string = 'ghcr.io/openclarity/exploit-db-server:v0.2.4'
 
 @description ('Freshclam Mirror Container Image')
 param freshclamMirrorContainerImage string = 'ghcr.io/openclarity/freshclam-mirror:v0.1.0'

--- a/installation/azure/vmclarity.json
+++ b/installation/azure/vmclarity.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.22.6.54827",
-      "templateHash": "17694030931778971546"
+      "templateHash": "2110931051111156252"
     }
   },
   "parameters": {
@@ -104,7 +104,7 @@
     },
     "exploitDBContainerImage": {
       "type": "string",
-      "defaultValue": "ghcr.io/openclarity/exploit-db-server:v0.2.3",
+      "defaultValue": "ghcr.io/openclarity/exploit-db-server:v0.2.4",
       "metadata": {
         "description": "Exploit DB Container Image"
       }
@@ -556,7 +556,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.22.6.54827",
-              "templateHash": "6352993321275244425"
+              "templateHash": "10691550025999765701"
             }
           },
           "parameters": {
@@ -674,7 +674,7 @@
             },
             "exploitDBContainerImage": {
               "type": "string",
-              "defaultValue": "ghcr.io/openclarity/exploit-db-server:v0.2.3",
+              "defaultValue": "ghcr.io/openclarity/exploit-db-server:v0.2.4",
               "metadata": {
                 "description": "Exploit DB Container Image"
               }

--- a/installation/azure/vmclarityDeployModule.bicep
+++ b/installation/azure/vmclarityDeployModule.bicep
@@ -52,7 +52,7 @@ param trivyServerContainerImage string = 'docker.io/aquasec/trivy:0.41.0'
 param grypeServerContainerImage string = 'ghcr.io/openclarity/grype-server:v0.5.0'
 
 @description ('Exploit DB Container Image')
-param exploitDBContainerImage string = 'ghcr.io/openclarity/exploit-db-server:v0.2.3'
+param exploitDBContainerImage string = 'ghcr.io/openclarity/exploit-db-server:v0.2.4'
 
 @description ('Freshclam Mirror Container Image')
 param freshclamMirrorContainerImage string = 'ghcr.io/openclarity/freshclam-mirror:v0.1.0'

--- a/installation/docker/docker-compose.yml
+++ b/installation/docker/docker-compose.yml
@@ -89,7 +89,7 @@ services:
         condition: on-failure
 
   exploit-db-server:
-    image: ${ExploitDBServerContainerImage:-ghcr.io/openclarity/exploit-db-server:v0.2.3}
+    image: ${ExploitDBServerContainerImage:-ghcr.io/openclarity/exploit-db-server:v0.2.4}
     ports:
       - "1326:1326"
     deploy:

--- a/installation/gcp/dm/components/vmclarity-server.py.schema
+++ b/installation/gcp/dm/components/vmclarity-server.py.schema
@@ -73,7 +73,7 @@ properties:
     description: The container image to use for the scanner
   exploitDBServerContainerImage:
     type: string
-    default: ghcr.io/openclarity/exploit-db-server:v0.2.3
+    default: ghcr.io/openclarity/exploit-db-server:v0.2.4
     description: The container image to use for the exploit db server
   trivyServerContainerImage:
     type: string

--- a/installation/gcp/dm/vmclarity.py.schema
+++ b/installation/gcp/dm/vmclarity.py.schema
@@ -65,7 +65,7 @@ properties:
     description: The container image to use for the scanner
   exploitDBServerContainerImage:
     type: string
-    default: ghcr.io/openclarity/exploit-db-server:v0.2.3
+    default: ghcr.io/openclarity/exploit-db-server:v0.2.4
     description: The container image to use for the exploit db server
   trivyServerContainerImage:
     type: string


### PR DESCRIPTION
## Description

following the fix in https://github.com/openclarity/exploit-db-server/pull/19 updating the version to the latest tag


