### PR TITLE
refactor: cli tools

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,7 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG VMCLARITY_TOOLS_BASE=ghcr.io/openclarity/vmclarity-tools-base:v0.4.0@sha256:8431af10930dddadaf7365e8610ac8f8f62dd4be01928dba6bc16d50f152a12b
-
+ARG VMCLARITY_TOOLS_BASE=ghcr.io/openclarity/vmclarity-tools-base:v0.5.1@sha256:43a1d8d9fed33e0561edb8d422a1b2645633e0ec9055519aac070186fb1ce770
 # xx is a helper for cross-compilation
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.3.0@sha256:904fe94f236d36d65aeb5a2462f88f2c537b8360475f6342e7599194f291fb7e AS xx
 

--- a/pkg/cli/state/testdata/effective-config.json
+++ b/pkg/cli/state/testdata/effective-config.json
@@ -65,7 +65,7 @@
     "Inputs": null,
     "ScannersConfig": {
       "Lynis": {
-        "InstallPath": ""
+        "BinaryPath": ""
       }
     }
   },

--- a/pkg/orchestrator/assetscanwatcher/config.go
+++ b/pkg/orchestrator/assetscanwatcher/config.go
@@ -99,8 +99,8 @@ type ScannerConfig struct {
 	// The freshclam mirror url to use if it's enabled
 	AlternativeFreshclamMirrorURL string
 
-	// The location where Lynis is installed in the scanner image
-	LynisInstallPath string
+	// The Lynis binary path in the scanner image container
+	LynisBinaryPath string
 
 	// The chkrootkit binary path in the scanner image container.
 	ChkrootkitBinaryPath string

--- a/pkg/orchestrator/assetscanwatcher/families.go
+++ b/pkg/orchestrator/assetscanwatcher/families.go
@@ -188,7 +188,7 @@ func withMisconfigurationConfig(config *models.MisconfigurationsConfig, opts *Sc
 			ScannersConfig: misconfiguration.ScannersConfig{
 				// TODO(sambetts) Add scanner configurations here as we add them like Lynis
 				Lynis: misconfiguration.LynisConfig{
-					InstallPath: opts.LynisInstallPath,
+					BinaryPath: opts.LynisBinaryPath,
 				},
 			},
 		}

--- a/pkg/orchestrator/assetscanwatcher/families.go
+++ b/pkg/orchestrator/assetscanwatcher/families.go
@@ -167,7 +167,7 @@ func withMalwareConfig(config *models.MalwareConfig, opts *ScannerConfig) Famili
 					AlternativeFreshclamMirrorURL: opts.AlternativeFreshclamMirrorURL,
 				},
 				Yara: yaraconfig.Config{
-					BinaryPath:      opts.YaraBinaryPath,
+					YaraBinaryPath:  opts.YaraBinaryPath,
 					CompiledRuleURL: opts.YaraRuleServerAddress,
 				},
 			},

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -122,8 +122,6 @@ type Config struct {
 func setConfigDefaults() {
 	viper.SetDefault(HealthCheckAddress, ":8082")
 	viper.SetDefault(DeleteJobPolicy, string(assetscanwatcher.DeleteJobPolicyAlways))
-	// https://github.com/openclarity/vmclarity-tools-base/blob/main/Dockerfile#L33
-	viper.SetDefault(GitleaksBinaryPath, "/artifacts/gitleaks")
 	viper.SetDefault(TrivyServerTimeout, DefaultTrivyServerTimeout)
 	viper.SetDefault(GrypeServerTimeout, DefaultGrypeServerTimeout)
 	viper.SetDefault(ScanConfigPollingInterval, scanconfigwatcher.DefaultPollInterval.String())

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -128,9 +128,6 @@ func setConfigDefaults() {
 	viper.SetDefault(LynisInstallPath, "/artifacts/lynis")
 	// https://github.com/openclarity/vmclarity-tools-base/blob/main/Dockerfile
 	viper.SetDefault(ChkrootkitBinaryPath, "/artifacts/chkrootkit")
-	viper.SetDefault(ClamBinaryPath, "clamscan")
-	viper.SetDefault(FreshclamBinaryPath, "freshclam")
-	viper.SetDefault(YaraBinaryPath, "yara")
 	viper.SetDefault(TrivyServerTimeout, DefaultTrivyServerTimeout)
 	viper.SetDefault(GrypeServerTimeout, DefaultGrypeServerTimeout)
 	viper.SetDefault(ScanConfigPollingInterval, scanconfigwatcher.DefaultPollInterval.String())

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -46,7 +46,7 @@ const (
 	ClamBinaryPath                = "CLAM_BINARY_PATH"
 	FreshclamBinaryPath           = "FRESHCLAM_BINARY_PATH"
 	AlternativeFreshclamMirrorURL = "ALTERNATIVE_FRESHCLAM_MIRROR_URL"
-	LynisInstallPath              = "LYNIS_INSTALL_PATH"
+	LynisBinaryPath               = "LYNIS_BINARY_PATH"
 	ScannerAPIServerAddress       = "SCANNER_VMCLARITY_APISERVER_ADDRESS"
 	ExploitDBAddress              = "EXPLOIT_DB_ADDRESS"
 	TrivyServerAddress            = "TRIVY_SERVER_ADDRESS"
@@ -124,8 +124,6 @@ func setConfigDefaults() {
 	viper.SetDefault(DeleteJobPolicy, string(assetscanwatcher.DeleteJobPolicyAlways))
 	// https://github.com/openclarity/vmclarity-tools-base/blob/main/Dockerfile#L33
 	viper.SetDefault(GitleaksBinaryPath, "/artifacts/gitleaks")
-	// https://github.com/openclarity/vmclarity-tools-base/blob/main/Dockerfile#L35
-	viper.SetDefault(LynisInstallPath, "/artifacts/lynis")
 	// https://github.com/openclarity/vmclarity-tools-base/blob/main/Dockerfile
 	viper.SetDefault(ChkrootkitBinaryPath, "/artifacts/chkrootkit")
 	viper.SetDefault(TrivyServerTimeout, DefaultTrivyServerTimeout)
@@ -219,7 +217,7 @@ func LoadConfig() (*Config, error) {
 				ScannerImage:                  viper.GetString(ScannerContainerImage),
 				ScannerBackendAddress:         scannerAPIServerAddress,
 				GitleaksBinaryPath:            viper.GetString(GitleaksBinaryPath),
-				LynisInstallPath:              viper.GetString(LynisInstallPath),
+				LynisBinaryPath:               viper.GetString(LynisBinaryPath),
 				ExploitsDBAddress:             exploitDBAddress,
 				ClamBinaryPath:                viper.GetString(ClamBinaryPath),
 				FreshclamBinaryPath:           viper.GetString(FreshclamBinaryPath),

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -124,8 +124,6 @@ func setConfigDefaults() {
 	viper.SetDefault(DeleteJobPolicy, string(assetscanwatcher.DeleteJobPolicyAlways))
 	// https://github.com/openclarity/vmclarity-tools-base/blob/main/Dockerfile#L33
 	viper.SetDefault(GitleaksBinaryPath, "/artifacts/gitleaks")
-	// https://github.com/openclarity/vmclarity-tools-base/blob/main/Dockerfile
-	viper.SetDefault(ChkrootkitBinaryPath, "/artifacts/chkrootkit")
 	viper.SetDefault(TrivyServerTimeout, DefaultTrivyServerTimeout)
 	viper.SetDefault(GrypeServerTimeout, DefaultGrypeServerTimeout)
 	viper.SetDefault(ScanConfigPollingInterval, scanconfigwatcher.DefaultPollInterval.String())

--- a/pkg/shared/families/malware/clam/clam.go
+++ b/pkg/shared/families/malware/clam/clam.go
@@ -35,7 +35,11 @@ import (
 	sharedutils "github.com/openclarity/vmclarity/pkg/shared/utils"
 )
 
-const ScannerName = "clam"
+const (
+	ScannerName     = "clam"
+	ClamScanBinary  = "clamscan"
+	FreshClamBinary = "freshclam"
+)
 
 type Scanner struct {
 	name       string
@@ -44,6 +48,7 @@ type Scanner struct {
 	resultChan chan job_manager.Result
 }
 
+// nolint: cyclop
 func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 	go func() {
 		retResults := common.Results{
@@ -57,8 +62,29 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 			return
 		}
 
-		s.logger.Debugf("freshclam binary path: %s", s.config.FreshclamBinaryPath)
-		s.logger.Debugf("clamscan binary path: %s", s.config.ClamScanBinaryPath)
+		// Locate freshclam binary
+		if s.config.FreshclamBinaryPath == "" {
+			s.config.FreshclamBinaryPath = FreshClamBinary
+		}
+
+		freshClamPath, err := exec.LookPath(s.config.FreshclamBinaryPath)
+		if err != nil {
+			s.sendResults(retResults, fmt.Errorf("failed to lookup executable %s: %w", s.config.FreshclamBinaryPath, err))
+			return
+		}
+		s.logger.Debugf("found freshclam binary at: %s", freshClamPath)
+
+		// Locate clamscan binary
+		if s.config.ClamScanBinaryPath == "" {
+			s.config.ClamScanBinaryPath = ClamScanBinary
+		}
+
+		clamScanPath, err := exec.LookPath(s.config.ClamScanBinaryPath)
+		if err != nil {
+			s.sendResults(retResults, fmt.Errorf("failed to lookup executable %s: %w", s.config.ClamScanBinaryPath, err))
+			return
+		}
+		s.logger.Debugf("found clamscan binary at: %s", clamScanPath)
 
 		s.logger.Infof("Running freshclam...")
 		// Handle alternative freshclam mirror
@@ -74,7 +100,7 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 
 		// Execute freshclam command
 		// nolint:gosec
-		freshclamCommand := exec.Command(s.config.FreshclamBinaryPath)
+		freshclamCommand := exec.Command(freshClamPath)
 		freshclamOut, err := sharedutils.RunCommand(freshclamCommand)
 		if err != nil {
 			s.sendResults(retResults, fmt.Errorf("failed to run freshclam command: %s", err.Error()))
@@ -95,7 +121,7 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 		s.logger.Infof("Running clamscan...")
 		// Execute the clamscan command
 		// nolint:gosec
-		clamScanCommand := exec.Command(s.config.ClamScanBinaryPath, args...)
+		clamScanCommand := exec.Command(clamScanPath, args...)
 		out, err := sharedutils.RunCommand(clamScanCommand)
 		if err != nil {
 			/* If the error is that malware was found, this is not an actual error, Clam returns

--- a/pkg/shared/families/malware/yara/config/config.go
+++ b/pkg/shared/families/malware/yara/config/config.go
@@ -18,10 +18,9 @@ package config
 import "github.com/openclarity/yara-rule-server/pkg/config"
 
 type Config struct {
-	BinaryPath      string              `yaml:"binary_path" mapstructure:"binary_path"`
+	YaraBinaryPath  string              `yaml:"yara_binary_path" mapstructure:"yara_binary_path"`
 	CompiledRuleURL string              `yaml:"compiled_rule_url" mapstructure:"compiled_rule_url"`
 	RuleSources     []config.RuleSource `yaml:"rule_sources" mapstructure:"rule_sources"`
-	// TODO(chrisgacsal): YaracPath parameter seems to be unused so we might want to remove it
-	YaracPath string `yaml:"yarac_path" mapstructure:"yarac_path"`
-	CacheDir  string `yaml:"cache_dir" mapstructure:"cache_dir"`
+	YaracBinaryPath string              `yaml:"yarac_binary_path" mapstructure:"yarac_binary_path"`
+	CacheDir        string              `yaml:"cache_dir" mapstructure:"cache_dir"`
 }

--- a/pkg/shared/families/malware/yara/config/config.go
+++ b/pkg/shared/families/malware/yara/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	BinaryPath      string              `yaml:"binary_path" mapstructure:"binary_path"`
 	CompiledRuleURL string              `yaml:"compiled_rule_url" mapstructure:"compiled_rule_url"`
 	RuleSources     []config.RuleSource `yaml:"rule_sources" mapstructure:"rule_sources"`
-	YaracPath       string              `yaml:"yarac_path" mapstructure:"yarac_path"`
-	CacheDir        string              `yaml:"cache_dir" mapstructure:"cache_dir"`
+	// TODO(chrisgacsal): YaracPath parameter seems to be unused so we might want to remove it
+	YaracPath string `yaml:"yarac_path" mapstructure:"yarac_path"`
+	CacheDir  string `yaml:"cache_dir" mapstructure:"cache_dir"`
 }

--- a/pkg/shared/families/malware/yara/yara.go
+++ b/pkg/shared/families/malware/yara/yara.go
@@ -45,6 +45,7 @@ import (
 const (
 	ScannerName = "yara"
 	YaraBinary  = "yara"
+	YaracBinary = "yarac"
 )
 
 type Scanner struct {
@@ -70,18 +71,18 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 		}
 
 		// Locate yara binary
-		if s.config.BinaryPath == "" {
-			s.config.BinaryPath = YaraBinary
+		if s.config.YaraBinaryPath == "" {
+			s.config.YaraBinaryPath = YaraBinary
 		}
 
-		yaraBinaryPath, err := exec.LookPath(s.config.BinaryPath)
+		yaraBinaryPath, err := exec.LookPath(s.config.YaraBinaryPath)
 		if err != nil {
-			s.sendResults(retResults, fmt.Errorf("failed to lookup executable %s: %w", s.config.BinaryPath, err))
+			s.sendResults(retResults, fmt.Errorf("failed to lookup executable %s: %w", s.config.YaraBinaryPath, err))
 			return
 		}
 		s.logger.Debugf("found yara binary at: %s", yaraBinaryPath)
 
-		s.logger.Debugf("Yara rules URL: %s", s.config.BinaryPath)
+		s.logger.Debugf("Yara rules URL: %s", s.config.CompiledRuleURL)
 		s.logger.Debugf("Yara rules file path: %s", s.compiledRuleFile)
 
 		fsPath, cleanup, err := familiesutils.ConvertInputToFilesystem(context.TODO(), sourceType, userInput)
@@ -170,6 +171,7 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 	return nil
 }
 
+// nolint: cyclop
 func getCompiledRuleFilePath(cfg config.Config, logger *logrus.Entry) (string, error) {
 	// If both compiled rule url and raw rule sources are defined we choose the compiled one.
 	if cfg.CompiledRuleURL != "" {
@@ -186,9 +188,23 @@ func getCompiledRuleFilePath(cfg config.Config, logger *logrus.Entry) (string, e
 		default:
 			return "", errors.New("unsupported Yara rules URL")
 		}
-	} else if len(cfg.RuleSources) != 0 {
+	}
+
+	if len(cfg.RuleSources) != 0 {
 		var err error
 		cacheDir := cfg.CacheDir
+
+		// Locate yarac binary
+		if cfg.YaracBinaryPath == "" {
+			cfg.YaracBinaryPath = YaracBinary
+		}
+
+		yaracBinaryPath, err := exec.LookPath(cfg.YaracBinaryPath)
+		if err != nil {
+			return "", fmt.Errorf("failed to lookup executable %s: %w", cfg.YaracBinaryPath, err)
+		}
+		logger.Debugf("found yara binary at: %s", yaracBinaryPath)
+
 		if cacheDir == "" {
 			cacheDir, err = createCacheDir()
 			if err != nil {
@@ -197,7 +213,7 @@ func getCompiledRuleFilePath(cfg config.Config, logger *logrus.Entry) (string, e
 		}
 		if err = rules.DownloadAndCompile(&ruleServerConfig.Config{
 			RuleSources: cfg.RuleSources,
-			YaracPath:   cfg.YaracPath,
+			YaracPath:   yaracBinaryPath,
 			CacheDir:    cacheDir,
 		}, logger); err != nil {
 			return "", fmt.Errorf("failed to download and compile raw rules: %w", err)

--- a/pkg/shared/families/malware/yara/yara.go
+++ b/pkg/shared/families/malware/yara/yara.go
@@ -44,6 +44,7 @@ import (
 
 const (
 	ScannerName = "yara"
+	YaraBinary  = "yara"
 )
 
 type Scanner struct {
@@ -68,7 +69,18 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 			return
 		}
 
-		s.logger.Debugf("Yara binary path: %s", s.config.BinaryPath)
+		// Locate yara binary
+		if s.config.BinaryPath == "" {
+			s.config.BinaryPath = YaraBinary
+		}
+
+		yaraBinaryPath, err := exec.LookPath(s.config.BinaryPath)
+		if err != nil {
+			s.sendResults(retResults, fmt.Errorf("failed to lookup executable %s: %w", s.config.BinaryPath, err))
+			return
+		}
+		s.logger.Debugf("found yara binary at: %s", yaraBinaryPath)
+
 		s.logger.Debugf("Yara rules URL: %s", s.config.BinaryPath)
 		s.logger.Debugf("Yara rules file path: %s", s.compiledRuleFile)
 
@@ -121,7 +133,7 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 
 		// Execute the yara command
 		// nolint:gosec
-		yaraCommand := exec.Command(s.config.BinaryPath, args...)
+		yaraCommand := exec.Command(yaraBinaryPath, args...)
 		err = sharedutils.RunCommandAndParseOutputLineByLine(yaraCommand, parserFunc, errCheckFunc)
 		if err != nil {
 			s.sendResults(retResults, fmt.Errorf("failed to run yara command: %w", err))

--- a/pkg/shared/families/misconfiguration/lynis/reportParser_test.go
+++ b/pkg/shared/families/misconfiguration/lynis/reportParser_test.go
@@ -28,7 +28,7 @@ import (
 func TestNewReportParser(t *testing.T) {
 	logger, _ := logrusTest.NewNullLogger()
 	logEntry := logger.WithField("test", "valueToMisconfiguration")
-	testdb, err := NewTestDB(logEntry, "./testdata")
+	testdb, err := NewTestDB(logEntry, "./testdata/db")
 	if err != nil {
 		t.Fatalf("Unable to load test db: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestNewReportParser(t *testing.T) {
 func TestReportParser_ParseLynisReport(t *testing.T) {
 	logger, _ := logrusTest.NewNullLogger()
 	logEntry := logger.WithField("test", "valueToMisconfiguration")
-	testdb, err := NewTestDB(logEntry, "./testdata")
+	testdb, err := NewTestDB(logEntry, "./testdata/db")
 	if err != nil {
 		t.Fatalf("Unable to load test db: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestReportParser_ParseLynisReport(t *testing.T) {
 func TestReportParser_parseLynisReportLine(t *testing.T) {
 	logger, _ := logrusTest.NewNullLogger()
 	logEntry := logger.WithField("test", "valueToMisconfiguration")
-	testdb, err := NewTestDB(logEntry, "./testdata")
+	testdb, err := NewTestDB(logEntry, "./testdata/db")
 	if err != nil {
 		t.Fatalf("Unable to load test db: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestReportParser_parseLynisReportLine(t *testing.T) {
 func TestReportParser_valueToMisconfiguration(t *testing.T) {
 	logger, _ := logrusTest.NewNullLogger()
 	logEntry := logger.WithField("test", "valueToMisconfiguration")
-	testdb, err := NewTestDB(logEntry, "./testdata")
+	testdb, err := NewTestDB(logEntry, "./testdata/db")
 	if err != nil {
 		t.Fatalf("Unable to load test db: %v", err)
 	}
@@ -438,7 +438,7 @@ func (t *TestScanner) Err() error {
 func TestReportParser_scanLynisReportFile(t *testing.T) {
 	logger, _ := logrusTest.NewNullLogger()
 	logEntry := logger.WithField("test", "valueToMisconfiguration")
-	testdb, err := NewTestDB(logEntry, "./testdata")
+	testdb, err := NewTestDB(logEntry, "./testdata/db")
 	if err != nil {
 		t.Fatalf("Unable to load test db: %v", err)
 	}

--- a/pkg/shared/families/misconfiguration/lynis/testdb.go
+++ b/pkg/shared/families/misconfiguration/lynis/testdb.go
@@ -45,8 +45,15 @@ type TestDB struct {
 	tests testdb
 }
 
-func NewTestDB(logger *log.Entry, lynisInstallPath string) (*TestDB, error) {
-	tests, err := parseTestsFromInstallPath(logger, lynisInstallPath)
+func NewTestDB(logger *log.Entry, lynisDBDir string) (*TestDB, error) {
+	// Comes from the Lynis install:
+	// https://github.com/CISOfy/lynis/blob/master/db/tests.db
+	lynisTestDBPath := path.Join(lynisDBDir, "tests.db")
+	if _, err := os.Stat(lynisTestDBPath); err != nil {
+		return nil, fmt.Errorf("failed to find DB @ %v: %w", lynisTestDBPath, err)
+	}
+
+	tests, err := parseTestsFromDBPath(logger, lynisTestDBPath)
 	if err != nil {
 		return nil, fmt.Errorf("unable to initialise lynis test DB: %w", err)
 	}
@@ -66,17 +73,6 @@ func (a *TestDB) GetDescriptionForTestID(testid string) string {
 		return entry.Description
 	}
 	return unknown
-}
-
-func parseTestsFromInstallPath(logger *log.Entry, lynisInstallPath string) (testdb, error) {
-	// Comes from the Lynis install:
-	// https://github.com/CISOfy/lynis/blob/master/db/tests.db
-	lynisDBPath := path.Join(lynisInstallPath, "db", "tests.db")
-	if _, err := os.Stat(lynisDBPath); err != nil {
-		return nil, fmt.Errorf("failed to find DB @ %v: %w", lynisDBPath, err)
-	}
-
-	return parseTestsFromDBPath(logger, lynisDBPath)
 }
 
 func parseTestsFromDBPath(logger *log.Entry, lynisDBPath string) (testdb, error) {

--- a/pkg/shared/families/misconfiguration/lynis/testdb_test.go
+++ b/pkg/shared/families/misconfiguration/lynis/testdb_test.go
@@ -29,8 +29,8 @@ func TestNewTestDB(t *testing.T) {
 	logEntry := logger.WithField("test", "valueToMisconfiguration")
 
 	type args struct {
-		logger           *log.Entry
-		lynisInstallPath string
+		logger     *log.Entry
+		lynisDBDir string
 	}
 	tests := []struct {
 		name    string
@@ -41,8 +41,8 @@ func TestNewTestDB(t *testing.T) {
 		{
 			name: "sanity",
 			args: args{
-				logger:           logEntry,
-				lynisInstallPath: "./testdata/simpledb",
+				logger:     logEntry,
+				lynisDBDir: "./testdata/simpledb/db",
 			},
 			want: &TestDB{
 				tests: testdb{
@@ -72,16 +72,16 @@ func TestNewTestDB(t *testing.T) {
 		{
 			name: "missing db file",
 			args: args{
-				logger:           logEntry,
-				lynisInstallPath: "./testdata/does-not-exist",
+				logger:     logEntry,
+				lynisDBDir: "./testdata/does-not-exist",
 			},
 			wantErr: true,
 		},
 		{
 			name: "malformed db file",
 			args: args{
-				logger:           logEntry,
-				lynisInstallPath: "./testdata/baddb",
+				logger:     logEntry,
+				lynisDBDir: "./testdata/baddb/db",
 			},
 			want: &TestDB{
 				tests: testdb{
@@ -107,7 +107,7 @@ func TestNewTestDB(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewTestDB(tt.args.logger, tt.args.lynisInstallPath)
+			got, err := NewTestDB(tt.args.logger, tt.args.lynisDBDir)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewTestDB() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -224,97 +224,6 @@ func TestTestDB_GetDescriptionForTestID(t *testing.T) {
 			got := a.GetDescriptionForTestID(tt.args.testid)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("TestDB.GetDescriptionForTestID() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func Test_parseTestsFromInstallPath(t *testing.T) {
-	logger, _ := logrusTest.NewNullLogger()
-	logEntry := logger.WithField("test", "valueToMisconfiguration")
-
-	type args struct {
-		logger           *log.Entry
-		lynisInstallPath string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    testdb
-		wantErr bool
-	}{
-		{
-			name: "sanity",
-			args: args{
-				logger:           logEntry,
-				lynisInstallPath: "./testdata/simpledb",
-			},
-			want: testdb{
-				"ACCT-2754": {
-					Category:    "security",
-					Description: "Check for available FreeBSD accounting information",
-				},
-				"ACCT-2760": {
-					Category:    "security",
-					Description: "Check for available OpenBSD accounting information",
-				},
-				"ACCT-9622": {
-					Category:    "security",
-					Description: "Check for available Linux accounting information",
-				},
-				"ACCT-9626": {
-					Category:    "security",
-					Description: "Check for sysstat accounting data",
-				},
-				"ACCT-9628": {
-					Category:    "security",
-					Description: "Check for auditd",
-				},
-			},
-		},
-		{
-			name: "missing db file",
-			args: args{
-				logger:           logEntry,
-				lynisInstallPath: "./testdata/does-not-exist",
-			},
-			wantErr: true,
-		},
-		{
-			name: "malformed db file",
-			args: args{
-				logger:           logEntry,
-				lynisInstallPath: "./testdata/baddb",
-			},
-			want: testdb{
-				"ACCT-2754": {
-					Category:    "security",
-					Description: "Check for available FreeBSD accounting information",
-				},
-				"ACCT-2760": {
-					Category:    "security",
-					Description: "Check for available OpenBSD accounting information",
-				},
-				"ACCT-9622": {
-					Category:    "security",
-					Description: "Check for available Linux accounting information",
-				},
-				"ACCT-9626": {
-					Category:    "security",
-					Description: "Check for sysstat accounting data",
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseTestsFromInstallPath(tt.args.logger, tt.args.lynisInstallPath)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("parseTestsFromInstallPath() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("parseTestsFromInstallPath() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/shared/families/misconfiguration/types/config.go
+++ b/pkg/shared/families/misconfiguration/types/config.go
@@ -40,5 +40,5 @@ type ScannersConfig struct {
 func (ScannersConfig) IsConfig() {}
 
 type LynisConfig struct {
-	InstallPath string `yaml:"install_path" mapstructure:"install_path"`
+	BinaryPath string `yaml:"binary_path" mapstructure:"binary_path"`
 }

--- a/pkg/shared/families/rootkits/chkrootkit/chkrootkit.go
+++ b/pkg/shared/families/rootkits/chkrootkit/chkrootkit.go
@@ -32,7 +32,10 @@ import (
 	sharedutils "github.com/openclarity/vmclarity/pkg/shared/utils"
 )
 
-const ScannerName = "chkrootkit"
+const (
+	ScannerName      = "chkrootkit"
+	ChkrootkitBinary = "chkrootkit"
+)
 
 type Scanner struct {
 	name       string
@@ -59,6 +62,18 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 			s.sendResults(retResults, fmt.Errorf("failed to find binary in %v: %w", s.config.BinaryPath, err))
 			return
 		}
+
+		// Locate chkrootkit binary
+		if s.config.BinaryPath == "" {
+			s.config.BinaryPath = ChkrootkitBinary
+		}
+
+		yaraBinaryPath, err := exec.LookPath(s.config.BinaryPath)
+		if err != nil {
+			s.sendResults(retResults, fmt.Errorf("failed to lookup executable %s: %w", s.config.BinaryPath, err))
+			return
+		}
+		s.logger.Debugf("found chkrootkit binary at: %s", yaraBinaryPath)
 
 		fsPath, cleanup, err := familiesutils.ConvertInputToFilesystem(context.TODO(), sourceType, userInput)
 		if err != nil {


### PR DESCRIPTION
## Description

* bump `vmclarity-tools-base` to `v0.5.1` for CLI container image
* refactor families to:
  * use executable names as default if the path for them is not provided in the families config
  * always perform executable lookup before invoking them
  * remove defaulting for binary paths from Orchestrator config

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[x] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## TODO
- [x] rebase on `main` after the #827 got merged