### PR TITLE
fix(postgres): Ensure that we use the correct JSON sql for delete by ID

### DIFF
--- a/pkg/apiserver/database/gorm/common.go
+++ b/pkg/apiserver/database/gorm/common.go
@@ -41,8 +41,11 @@ func getExistingObjByID(db *gorm.DB, schema, objID string, obj interface{}) erro
 }
 
 func deleteObjByID(db *gorm.DB, objID string, obj interface{}) error {
-	jsonQuotedID := fmt.Sprintf("\"%s\"", objID)
-	if err := db.Where("`Data` -> '$.id' = ?", jsonQuotedID).Delete(obj).Error; err != nil {
+	query := fmt.Sprintf("%s = %s",
+		SQLVariant.JSONExtract("Data", "$.id"),
+		SQLVariant.JSONQuote(fmt.Sprintf("'%s'", objID)),
+	)
+	if err := db.Where(query).Delete(obj).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return types.ErrNotFound
 		}


### PR DESCRIPTION
## Description

The code in deleteById was not using the SQLVariant logic to switch between the Postgres and SQLite versions of JSON extract and JSON quote this resulted in a 500 error when deleting an object through the API.

This commit switches to use the SQLVariant variable to generate the correct SQL command to query the ID.

Closes #820

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
