### PR TITLE
fix(ui): ensure that UI nginx routes to index.html as fallback

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -9,4 +9,6 @@ RUN npm run build
 
 FROM nginx:1.25.2
 
+COPY --from=site-build ["/app/ui-build/nginx.conf", "/etc/nginx/conf.d/default.conf"]
+
 COPY --from=site-build ["/app/ui-build/build", "/usr/share/nginx/html"]

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -1,0 +1,22 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}


### PR DESCRIPTION
## Description

As we're using virtual page routing in our UI, URLs which are unknown to nginx should redirect to the index.html so that they can be resolved by the React router.

Closes #819

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
