### PR TITLE
feat(orchestrator): implement provider registration

### DIFF
--- a/installation/docker/docker-compose.yml
+++ b/installation/docker/docker-compose.yml
@@ -43,6 +43,9 @@ services:
       - type: bind
         source: /var/run/docker.sock
         target: /var/run/docker.sock
+      - type: volume
+        source: provider-registration-data
+        target: /var/opt/vmclarity
     healthcheck:
       test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8082/healthz/ready || exit 1
       interval: 10s
@@ -201,6 +204,7 @@ configs:
 
 volumes:
   apiserver-db-data:
+  provider-registration-data:
   grype-server-db:
 
 networks:

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -105,6 +105,11 @@ func New(ctx context.Context, config *Config) (*Orchestrator, error) {
 		return nil, fmt.Errorf("failed to initialize provider. Provider=%s: %w", config.ProviderKind, err)
 	}
 
+	err = p.Register(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register provider. Provider=%s: %w", config.ProviderKind, err)
+	}
+
 	return NewWithProvider(config, p, backendClient)
 }
 

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -100,7 +100,7 @@ func New(ctx context.Context, config *Config) (*Orchestrator, error) {
 		return nil, fmt.Errorf("failed to create a backend client: %w", err)
 	}
 
-	p, err := NewProvider(ctx, config.ProviderKind)
+	p, err := NewProvider(ctx, config.ProviderKind, backendClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize provider. Provider=%s: %w", config.ProviderKind, err)
 	}
@@ -132,20 +132,20 @@ func (o *Orchestrator) Stop(ctx context.Context) {
 
 // nolint:wrapcheck
 // NewProvider returns an initialized provider.Provider based on the kind models.CloudProvider.
-func NewProvider(ctx context.Context, kind models.CloudProvider) (provider.Provider, error) {
+func NewProvider(ctx context.Context, kind models.CloudProvider, b *backendclient.BackendClient) (provider.Provider, error) {
 	switch kind {
 	case models.Azure:
-		return azure.New(ctx)
+		return azure.New(ctx, b)
 	case models.Docker:
-		return docker.New(ctx)
+		return docker.New(ctx, b)
 	case models.AWS:
-		return aws.New(ctx)
+		return aws.New(ctx, b)
 	case models.GCP:
-		return gcp.New(ctx)
+		return gcp.New(ctx, b)
 	case models.External:
-		return external.New(ctx)
+		return external.New(ctx, b)
 	case models.Kubernetes:
-		return kubernetes.New(ctx)
+		return kubernetes.New(ctx, b)
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", kind)
 	}

--- a/pkg/orchestrator/provider/aws/client.go
+++ b/pkg/orchestrator/provider/aws/client.go
@@ -943,3 +943,7 @@ func (c *Client) ListAllRegions(ctx context.Context) ([]Region, error) {
 
 	return ret, nil
 }
+
+func (c *Client) Register(ctx context.Context) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/orchestrator/provider/aws/client.go
+++ b/pkg/orchestrator/provider/aws/client.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openclarity/vmclarity/pkg/orchestrator/provider"
 	"github.com/openclarity/vmclarity/pkg/orchestrator/provider/aws/scanestimation"
 	"github.com/openclarity/vmclarity/pkg/orchestrator/provider/cloudinit"
+	"github.com/openclarity/vmclarity/pkg/shared/backendclient"
 	"github.com/openclarity/vmclarity/pkg/shared/log"
 	"github.com/openclarity/vmclarity/pkg/shared/utils"
 )
@@ -41,9 +42,10 @@ type Client struct {
 	ec2Client     *ec2.Client
 	scanEstimator *scanestimation.ScanEstimator
 	config        *Config
+	backendClient *backendclient.BackendClient
 }
 
-func New(ctx context.Context) (*Client, error) {
+func New(ctx context.Context, b *backendclient.BackendClient) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("invalid configuration. Provider=AWS: %w", err)
@@ -54,7 +56,8 @@ func New(ctx context.Context) (*Client, error) {
 	}
 
 	awsClient := Client{
-		config: config,
+		config:        config,
+		backendClient: b,
 	}
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx)

--- a/pkg/orchestrator/provider/azure/client.go
+++ b/pkg/orchestrator/provider/azure/client.go
@@ -324,3 +324,7 @@ func createImageURN(reference *armcompute.ImageReference) string {
 	}
 	return *reference.Publisher + "/" + *reference.Offer + "/" + *reference.SKU + "/" + *reference.Version
 }
+
+func (c *Client) Register(ctx context.Context) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/orchestrator/provider/azure/client.go
+++ b/pkg/orchestrator/provider/azure/client.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/pkg/orchestrator/provider"
+	"github.com/openclarity/vmclarity/pkg/shared/backendclient"
 	"github.com/openclarity/vmclarity/pkg/shared/log"
 	"github.com/openclarity/vmclarity/pkg/shared/utils"
 )
@@ -47,10 +48,11 @@ type Client struct {
 	disksClient      *armcompute.DisksClient
 	interfacesClient *armnetwork.InterfacesClient
 
-	azureConfig *Config
+	azureConfig   *Config
+	backendClient *backendclient.BackendClient
 }
 
-func New(_ context.Context) (*Client, error) {
+func New(_ context.Context, b *backendclient.BackendClient) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
@@ -62,7 +64,8 @@ func New(_ context.Context) (*Client, error) {
 	}
 
 	client := Client{
-		azureConfig: config,
+		azureConfig:   config,
+		backendClient: b,
 	}
 
 	cred, err := azidentity.NewManagedIdentityCredential(nil)

--- a/pkg/orchestrator/provider/azure/client.go
+++ b/pkg/orchestrator/provider/azure/client.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -41,6 +42,7 @@ const (
 )
 
 type Client struct {
+	uuid             string
 	cred             azcore.TokenCredential
 	rgClient         *armresources.ResourceGroupsClient
 	vmClient         *armcompute.VirtualMachinesClient
@@ -326,5 +328,22 @@ func createImageURN(reference *armcompute.ImageReference) string {
 }
 
 func (c *Client) Register(ctx context.Context) error {
-	return fmt.Errorf("not implemented")
+	// TODO(paralta) When persistent storage is available, check if the provider is already registered.
+	// If not registered, post the provider and store the received UUID.
+	apiProvider, err := c.backendClient.PostProvider(
+		ctx,
+		models.Provider{
+			DisplayName: utils.PointerTo(string(c.Kind())),
+			Status: &models.ProviderStatus{
+				State:              models.ProviderStatusStateUnknown,
+				Reason:             models.NoHeartbeatReceived,
+				LastTransitionTime: time.Now(),
+			},
+		})
+	if err != nil {
+		return fmt.Errorf("failed to post provider: %w", err)
+	}
+
+	c.uuid = *apiProvider.Id
+	return nil
 }

--- a/pkg/orchestrator/provider/docker/client.go
+++ b/pkg/orchestrator/provider/docker/client.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/pkg/orchestrator/provider"
+	"github.com/openclarity/vmclarity/pkg/shared/backendclient"
 	"github.com/openclarity/vmclarity/pkg/shared/families"
 	"github.com/openclarity/vmclarity/pkg/shared/log"
 )
@@ -43,11 +44,12 @@ import (
 var mountPointPath = "/mnt/snapshot"
 
 type Client struct {
-	dockerClient *client.Client
-	config       *Config
+	dockerClient  *client.Client
+	config        *Config
+	backendClient *backendclient.BackendClient
 }
 
-func New(_ context.Context) (*Client, error) {
+func New(_ context.Context, b *backendclient.BackendClient) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("invalid configuration. Provider=%s: %w", models.Docker, err)
@@ -59,8 +61,9 @@ func New(_ context.Context) (*Client, error) {
 	}
 
 	return &Client{
-		dockerClient: dockerClient,
-		config:       config,
+		dockerClient:  dockerClient,
+		config:        config,
+		backendClient: b,
 	}, nil
 }
 

--- a/pkg/orchestrator/provider/docker/client.go
+++ b/pkg/orchestrator/provider/docker/client.go
@@ -490,3 +490,7 @@ func convertTags(tags map[string]string) *[]models.Tag {
 	}
 	return &ret
 }
+
+func (c *Client) Register(ctx context.Context) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/orchestrator/provider/external/client.go
+++ b/pkg/orchestrator/provider/external/client.go
@@ -26,15 +26,17 @@ import (
 	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/pkg/orchestrator/provider"
 	provider_service "github.com/openclarity/vmclarity/pkg/orchestrator/provider/external/proto"
+	"github.com/openclarity/vmclarity/pkg/shared/backendclient"
 )
 
 type Client struct {
 	providerClient provider_service.ProviderClient
 	config         *Config
 	conn           *grpc.ClientConn
+	backendClient  *backendclient.BackendClient
 }
 
-func New(_ context.Context) (*Client, error) {
+func New(_ context.Context, b *backendclient.BackendClient) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
@@ -46,7 +48,8 @@ func New(_ context.Context) (*Client, error) {
 	}
 
 	client := Client{
-		config: config,
+		config:        config,
+		backendClient: b,
 	}
 
 	var opts []grpc.DialOption

--- a/pkg/orchestrator/provider/external/client.go
+++ b/pkg/orchestrator/provider/external/client.go
@@ -151,3 +151,7 @@ func (c *Client) RemoveAssetScan(ctx context.Context, config *provider.ScanJobCo
 	}
 	return nil
 }
+
+func (c *Client) Register(ctx context.Context) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/orchestrator/provider/gcp/client.go
+++ b/pkg/orchestrator/provider/gcp/client.go
@@ -35,6 +35,7 @@ import (
 )
 
 type Client struct {
+	uuid            string
 	snapshotsClient *compute.SnapshotsClient
 	disksClient     *compute.DisksClient
 	instancesClient *compute.InstancesClient
@@ -391,5 +392,22 @@ func getKeyValue(str string) (string, string) {
 }
 
 func (c *Client) Register(ctx context.Context) error {
-	return fmt.Errorf("not implemented")
+	// TODO(paralta) When persistent storage is available, check if the provider is already registered.
+	// If not registered, post the provider and store the received UUID.
+	apiProvider, err := c.backendClient.PostProvider(
+		ctx,
+		models.Provider{
+			DisplayName: utils.PointerTo(string(c.Kind())),
+			Status: &models.ProviderStatus{
+				State:              models.ProviderStatusStateUnknown,
+				Reason:             models.NoHeartbeatReceived,
+				LastTransitionTime: time.Now(),
+			},
+		})
+	if err != nil {
+		return fmt.Errorf("failed to post provider: %w", err)
+	}
+
+	c.uuid = *apiProvider.Id
+	return nil
 }

--- a/pkg/orchestrator/provider/gcp/client.go
+++ b/pkg/orchestrator/provider/gcp/client.go
@@ -389,3 +389,7 @@ func getKeyValue(str string) (string, string) {
 	}
 	return str, ""
 }
+
+func (c *Client) Register(ctx context.Context) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/orchestrator/provider/gcp/client.go
+++ b/pkg/orchestrator/provider/gcp/client.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/pkg/orchestrator/provider"
+	"github.com/openclarity/vmclarity/pkg/shared/backendclient"
 	"github.com/openclarity/vmclarity/pkg/shared/log"
 	"github.com/openclarity/vmclarity/pkg/shared/utils"
 )
@@ -39,10 +40,11 @@ type Client struct {
 	instancesClient *compute.InstancesClient
 	regionsClient   *compute.RegionsClient
 
-	gcpConfig *Config
+	gcpConfig     *Config
+	backendClient *backendclient.BackendClient
 }
 
-func New(ctx context.Context) (*Client, error) {
+func New(ctx context.Context, b *backendclient.BackendClient) (*Client, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load configuration: %w", err)
@@ -54,7 +56,8 @@ func New(ctx context.Context) (*Client, error) {
 	}
 
 	client := Client{
-		gcpConfig: config,
+		gcpConfig:     config,
+		backendClient: b,
 	}
 
 	regionsClient, err := compute.NewRegionsRESTClient(ctx)

--- a/pkg/orchestrator/provider/helpers.go
+++ b/pkg/orchestrator/provider/helpers.go
@@ -1,0 +1,72 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/openclarity/vmclarity/pkg/shared/log"
+)
+
+func ReadFile(ctx context.Context, path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to open file: %w", err)
+	}
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			log.GetLoggerFromContextOrDiscard(ctx).Errorf("failed to close file: %s", err.Error())
+		}
+	}()
+
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to get file info: %w", err)
+	}
+
+	fileSize := fileInfo.Size()
+	buffer := make([]byte, fileSize)
+
+	_, err = file.Read(buffer)
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	return buffer, nil
+}
+
+func WriteFile(ctx context.Context, path string, data []byte) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create file: %w", err)
+	}
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			log.GetLoggerFromContextOrDiscard(ctx).Errorf("failed to close file: %s", err.Error())
+		}
+	}()
+
+	_, err = file.Write(data)
+	if err != nil {
+		return fmt.Errorf("failed to write to file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/orchestrator/provider/kubernetes/provider.go
+++ b/pkg/orchestrator/provider/kubernetes/provider.go
@@ -95,3 +95,7 @@ func (p *Provider) RunAssetScan(context.Context, *provider.ScanJobConfig) error 
 func (p *Provider) RemoveAssetScan(context.Context, *provider.ScanJobConfig) error {
 	return fmt.Errorf("not implemented")
 }
+
+func (p *Provider) Register(ctx context.Context) error {
+	return fmt.Errorf("not implemented")
+}

--- a/pkg/orchestrator/provider/kubernetes/provider.go
+++ b/pkg/orchestrator/provider/kubernetes/provider.go
@@ -25,16 +25,18 @@ import (
 
 	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/pkg/orchestrator/provider"
+	"github.com/openclarity/vmclarity/pkg/shared/backendclient"
 )
 
 type Provider struct {
-	clientset kubernetes.Interface
-	config    *Config
+	clientset     kubernetes.Interface
+	config        *Config
+	backendClient *backendclient.BackendClient
 }
 
 var _ provider.Provider = &Provider{}
 
-func New(ctx context.Context) (provider.Provider, error) {
+func New(ctx context.Context, b *backendclient.BackendClient) (provider.Provider, error) {
 	config, err := NewConfig()
 	if err != nil {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
@@ -65,8 +67,9 @@ func New(ctx context.Context) (provider.Provider, error) {
 	}
 
 	return &Provider{
-		clientset: clientset,
-		config:    config,
+		clientset:     clientset,
+		config:        config,
+		backendClient: b,
 	}, nil
 }
 

--- a/pkg/orchestrator/provider/types.go
+++ b/pkg/orchestrator/provider/types.go
@@ -25,9 +25,15 @@ type Provider interface {
 	// Kind returns models.CloudProvider
 	Kind() models.CloudProvider
 
+	Registerer
 	Discoverer
 	Estimator
 	Scanner
+}
+
+type Registerer interface {
+	// Register registers the provider to the backend API server by posting with a registration ID.
+	Register(context.Context) error
 }
 
 type Discoverer interface {


### PR DESCRIPTION
## Description

Implement https://github.com/openclarity/vmclarity/issues/780

* Currently the provider is not an independent service and communication with the backend (apiserver) service is done via the orchestrator, so for now add the backend client to each provider.
* When an IAM service is available, a bootstrap token will be given to each provider and it will use it perform registration with the apiserver service from which it will get a authentication token that will be used to communicate with this service. For now, just post the provider to the apiserver service and receive back an UUID which will be used as authentication token.
* While persistent storage is not available for most providers, for the docker provider a persistent volume can be easily implemented and the "current registration method" illustrated in the following diagram is implemented here.

<img width="1007" alt="Screenshot 2023-10-18 at 15 01 48" src="https://github.com/openclarity/vmclarity/assets/46568597/9a75e502-3d0a-4d06-94d7-cc2400e16f04">

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
