### PR TITLE
fix: CLI command name

### DIFF
--- a/cmd/vmclarity-cli/root/root.go
+++ b/cmd/vmclarity-cli/root/root.go
@@ -30,7 +30,7 @@ import (
 
 // RootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:          "vmclarity",
+	Use:          "vmclarity-cli",
 	Short:        "VMClarity",
 	Long:         `VMClarity`,
 	Version:      version.String(),


### PR DESCRIPTION
## Description

Similar to https://github.com/openclarity/kubeclarity/pull/533

I think the command name should be `vmclarity-cli` because the prebuilt binary name is `vmclarity-cli`.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
