### PR TITLE
fix(ui): add empty list indication to dashboard widgets

### DIFF
--- a/ui/src/layout/Dashboard/FindingsTabsWidget/findings-tabs-widget.scss
+++ b/ui/src/layout/Dashboard/FindingsTabsWidget/findings-tabs-widget.scss
@@ -29,6 +29,10 @@
                 padding: 12px 0 5px 0;
                 overflow-wrap: anywhere;
             }
+
+            .empty-results-display-wrapper {
+                margin: 20px 0px;
+            }
         }
     }
 }

--- a/ui/src/layout/Dashboard/FindingsTabsWidget/index.js
+++ b/ui/src/layout/Dashboard/FindingsTabsWidget/index.js
@@ -25,17 +25,19 @@ const WidgetContent = ({data=[], getHeaderItems, getBodyItems, selectedId}) => {
             </thead>
             <tbody>
                 {
-                    displayData.map((item, index) => {
-                        return (
-                            <tr key={index}>
-                                {getBodyItems(selectedId).map(({dataKey, customDisplay: CustomDisplay}, index, items) => (
-                                    <td key={index} style={items.length - 1 === index ? {textAlign: "right"} : {}}>
-                                        {!!CustomDisplay ? <CustomDisplay {...item} /> : get(item, dataKey)}
-                                    </td>
-                                ))}
-                            </tr>
-                        )
-                    })
+                    displayData.length > 0 ?
+                        displayData.map((item, index) => {
+                            return (
+                                <tr key={index}>
+                                    {getBodyItems(selectedId).map(({dataKey, customDisplay: CustomDisplay}, index, items) => (
+                                        <td key={index} style={items.length - 1 === index ? {textAlign: "right"} : {}}>
+                                            {!!CustomDisplay ? <CustomDisplay {...item} /> : get(item, dataKey)}
+                                        </td>
+                                    ))}
+                                </tr>
+                            )
+                        })
+                        : <div className="empty-results-display-wrapper">No results available</div>
                 }
             </tbody>
         </table>


### PR DESCRIPTION
## Description

Fix for https://github.com/openclarity/vmclarity/issues/818

Add empty list indication to the findings impact and riskiest assets dashboard widgets. The type of the finding is not part of the message (e.g. `no results available for malwares`) as is it would require more refactor in the widget but we want to do bigger refactors in the whole ui so let's wait with that now.

![image](https://github.com/openclarity/vmclarity/assets/19503754/f60dfa06-d280-4d57-a556-8442c3260f63)
![image](https://github.com/openclarity/vmclarity/assets/19503754/eaf587ea-87a4-4ef2-8ac7-d403693cc4a9)



## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
