### PR TITLE
fix(ui): fix asset scans page not loading issue

### DIFF
--- a/ui/src/components/VulnerabilitiesDisplay/index.js
+++ b/ui/src/components/VulnerabilitiesDisplay/index.js
@@ -30,7 +30,7 @@ export const VULNERABILITY_SEVERITY_ITEMS = {
         color: SEVERITY_ITEMS.HIGH.color,
         innerTextColor: "white"
     },
-    meditotalMediumVulnerabilitiesum: {
+    totalMediumVulnerabilities: {
         totalKey: "totalMediumVulnerabilities",
         countKey: "mediumVulnerabilitiesCount",
         title: "Medium",


### PR DESCRIPTION
## Description

Fix value in VULNERABILITY_SEVERITY_ITEMS that prevented the page to load.
See this error message as reference:
![Screenshot 2023-10-30 at 13 01 42](https://github.com/openclarity/vmclarity/assets/19503754/615e0692-25ae-4a95-bdc0-c6a27a6d278d)


## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
