### PR TITLE
fix(ui): use replace navigation when needed

### DIFF
--- a/ui/src/components/TabbedPage/index.js
+++ b/ui/src/components/TabbedPage/index.js
@@ -36,7 +36,7 @@ const TabbedPage= ({items, redirectTo, basePath, headerCustomDisplay, withInnerP
                             <Route key={id} path={isIndex ? undefined : `${path}/*`} index={isIndex} element={<Component />} />
                         ))
                     }
-                    {!!redirectTo && <Route path="" element={<Navigate to={redirectTo} />} />}
+                    {!!redirectTo && <Route path="" element={<Navigate to={redirectTo} replace />} />}
                 </Route>
             </Routes>
         </div>

--- a/ui/src/components/TablePage/index.js
+++ b/ui/src/components/TablePage/index.js
@@ -48,14 +48,14 @@ const TablePage = (props) => {
             } catch(error) {
                 console.log("invalid filters");
 
-                setSearchParams({});
+                setSearchParams({}, { replace: true });
             }
         }
     }, [initialized, searchParams, filtersDispatch, setSearchParams]);
 
     useEffect(() => {
         const {customDisplay, ...cleanSystemFilters} = systemFilters;
-        setSearchParams({filters: JSON.stringify({filterType, systemFilterType, tableFilters, systemFilters: cleanSystemFilters, customFilters})});
+        setSearchParams({filters: JSON.stringify({filterType, systemFilterType, tableFilters, systemFilters: cleanSystemFilters, customFilters})}, { replace: true });
     }, [filterType, systemFilterType, tableFilters, systemFilters, customFilters, setSearchParams]);
 
     if (!initialized) {


### PR DESCRIPTION
## Description

Fixes https://github.com/openclarity/vmclarity/issues/802
The browser's back button didn't work when we opened any of the table view pages.
Use replace navigation for search param changes and redirections to fix this issue.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
