### PR TITLE
test(uibackend): add e2e tests for ui backend 

### DIFF
--- a/e2e/suite_test.go
+++ b/e2e/suite_test.go
@@ -30,12 +30,20 @@ import (
 	"github.com/openclarity/vmclarity/e2e/testenv/types"
 	"github.com/openclarity/vmclarity/pkg/shared/backendclient"
 	"github.com/openclarity/vmclarity/pkg/shared/log"
+	"github.com/openclarity/vmclarity/pkg/shared/uibackendclient"
 )
 
 var (
-	testEnv types.Environment
-	client  *backendclient.BackendClient
-	config  *types.Config
+	testEnv  types.Environment
+	client   *backendclient.BackendClient
+	uiClient *uibackendclient.UIBackendClient
+	config   *types.Config
+)
+
+const (
+	dockerVMclarityAPIServerServiceName = "apiserver"
+	dockerVMclarityUIBackendServiceName = "uibackend"
+	dockerVMclarityUIBackendPort        = "8890"
 )
 
 func TestEndToEnd(t *testing.T) {
@@ -76,10 +84,16 @@ func beforeSuite(ctx context.Context) {
 		return ready
 	}, time.Second*5).Should(gomega.BeTrue())
 
-	u, err := testEnv.VMClarityAPIURL()
+	u, err := testEnv.GetServiceURL(dockerVMclarityAPIServerServiceName, "")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	client, err = backendclient.Create(fmt.Sprintf("%s://%s/%s", u.Scheme, u.Host, u.Path))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	u, err = testEnv.GetServiceURL(dockerVMclarityUIBackendServiceName, dockerVMclarityUIBackendPort)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	uiClient, err = uibackendclient.Create(fmt.Sprintf("%s://%s/%s", u.Scheme, u.Host, u.Path))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 }
 

--- a/e2e/testenv/docker/docker-compose.override.yml
+++ b/e2e/testenv/docker/docker-compose.override.yml
@@ -1,7 +1,4 @@
 services:
-  uibackend:
-    ports:
-      - "8890:8890"
   alpine:
     image: alpine:3.18.2
     command: ["sleep", "infinity"]

--- a/e2e/testenv/docker/docker-compose.override.yml
+++ b/e2e/testenv/docker/docker-compose.override.yml
@@ -1,4 +1,7 @@
 services:
+  uibackend:
+    ports:
+      - "8890:8890"
   alpine:
     image: alpine:3.18.2
     command: ["sleep", "infinity"]

--- a/e2e/testenv/docker/docker.go
+++ b/e2e/testenv/docker/docker.go
@@ -194,12 +194,12 @@ func (e *DockerEnv) Services() []string {
 	return services
 }
 
-func (e *DockerEnv) GetServiceURL(serviceName string, port string) (*url.URL, error) {
+func (e *DockerEnv) GetGatewayServiceURL() (*url.URL, error) {
 	var service types.ServiceConfig
 	var ok bool
 
 	for _, srv := range e.project.Services {
-		if srv.Name == serviceName {
+		if srv.Name == "gateway" {
 			service = srv
 			ok = true
 			break
@@ -207,16 +207,14 @@ func (e *DockerEnv) GetServiceURL(serviceName string, port string) (*url.URL, er
 	}
 
 	if !ok {
-		return nil, errors.Errorf("container with name %s is not available", serviceName)
+		return nil, errors.Errorf("container with name gateway is not available")
 	}
 
 	if len(service.Ports) < 1 {
-		return nil, errors.Errorf("container with name %s has no ports published", serviceName)
+		return nil, errors.Errorf("container with name gateway has no ports published")
 	}
 
-	if port == "" {
-		port = service.Ports[0].Published
-	}
+	port := service.Ports[0].Published
 	hostIP := service.Ports[0].HostIP
 	if hostIP == "" {
 		hostIP = "127.0.0.1"

--- a/e2e/testenv/docker/docker.go
+++ b/e2e/testenv/docker/docker.go
@@ -37,9 +37,8 @@ import (
 )
 
 const (
-	dockerVMclarityAPIServerServiceName = "apiserver"
-	dockerStateRunning                  = "running"
-	dockerHealthStateHealthy            = "healthy"
+	dockerStateRunning       = "running"
+	dockerHealthStateHealthy = "healthy"
 )
 
 type ContextKeyType string
@@ -195,28 +194,30 @@ func (e *DockerEnv) Services() []string {
 	return services
 }
 
-func (e *DockerEnv) VMClarityAPIURL() (*url.URL, error) {
-	var vmClarityBackend types.ServiceConfig
+func (e *DockerEnv) GetServiceURL(serviceName string, port string) (*url.URL, error) {
+	var service types.ServiceConfig
 	var ok bool
 
 	for _, srv := range e.project.Services {
-		if srv.Name == dockerVMclarityAPIServerServiceName {
-			vmClarityBackend = srv
+		if srv.Name == serviceName {
+			service = srv
 			ok = true
 			break
 		}
 	}
 
 	if !ok {
-		return nil, errors.Errorf("container with name %s is not available", dockerVMclarityAPIServerServiceName)
+		return nil, errors.Errorf("container with name %s is not available", serviceName)
 	}
 
-	if len(vmClarityBackend.Ports) < 1 {
-		return nil, errors.Errorf("container with name %s has no ports published", dockerVMclarityAPIServerServiceName)
+	if len(service.Ports) < 1 {
+		return nil, errors.Errorf("container with name %s has no ports published", serviceName)
 	}
 
-	port := vmClarityBackend.Ports[0].Published
-	hostIP := vmClarityBackend.Ports[0].HostIP
+	if port == "" {
+		port = service.Ports[0].Published
+	}
+	hostIP := service.Ports[0].HostIP
 	if hostIP == "" {
 		hostIP = "127.0.0.1"
 	}

--- a/e2e/testenv/types/types.go
+++ b/e2e/testenv/types/types.go
@@ -43,9 +43,9 @@ type Environment interface {
 	ServiceLogs(ctx context.Context, services []string, startTime time.Time, stdout, stderr io.Writer) error
 	// Services returns a list of services for the environment.
 	Services() []string
-	// GetServiceURL returns the URL for communicating with a VMClarity service.
+	// GetGatewayServiceURL returns the URL for communicating with a VMClarity gateway service.
 	// Returns error if it fails to determine the URL.
-	GetServiceURL(serviceName string, port string) (*url.URL, error)
+	GetGatewayServiceURL() (*url.URL, error)
 	// Context updates the provided ctx with environment specific data like with initialized client data allowing tests
 	// to interact with the underlying infrastructure.
 	Context(ctx context.Context) context.Context

--- a/e2e/testenv/types/types.go
+++ b/e2e/testenv/types/types.go
@@ -43,7 +43,7 @@ type Environment interface {
 	ServiceLogs(ctx context.Context, services []string, startTime time.Time, stdout, stderr io.Writer) error
 	// Services returns a list of services for the environment.
 	Services() []string
-	// GetServiceURL returns the URL for communicating with a VMClarity srrvice.
+	// GetServiceURL returns the URL for communicating with a VMClarity service.
 	// Returns error if it fails to determine the URL.
 	GetServiceURL(serviceName string, port string) (*url.URL, error)
 	// Context updates the provided ctx with environment specific data like with initialized client data allowing tests

--- a/e2e/testenv/types/types.go
+++ b/e2e/testenv/types/types.go
@@ -43,9 +43,9 @@ type Environment interface {
 	ServiceLogs(ctx context.Context, services []string, startTime time.Time, stdout, stderr io.Writer) error
 	// Services returns a list of services for the environment.
 	Services() []string
-	// VMClarityAPIURL returns the URL for communicating with VMClarity API.
+	// GetServiceURL returns the URL for communicating with a VMClarity srrvice.
 	// Returns error if it fails to determine the URL.
-	VMClarityAPIURL() (*url.URL, error)
+	GetServiceURL(serviceName string, port string) (*url.URL, error)
 	// Context updates the provided ctx with environment specific data like with initialized client data allowing tests
 	// to interact with the underlying infrastructure.
 	Context(ctx context.Context) context.Context

--- a/pkg/shared/uibackendclient/client.go
+++ b/pkg/shared/uibackendclient/client.go
@@ -1,0 +1,60 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uibackendclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/openclarity/vmclarity/pkg/uibackend/api/client"
+	"github.com/openclarity/vmclarity/pkg/uibackend/api/models"
+)
+
+type UIBackendClient struct {
+	apiClient client.ClientWithResponsesInterface
+}
+
+func Create(serverAddress string) (*UIBackendClient, error) {
+	apiClient, err := client.NewClientWithResponses(serverAddress)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create VMClarity API client. serverAddress=%v: %w", serverAddress, err)
+	}
+
+	return &UIBackendClient{
+		apiClient: apiClient,
+	}, nil
+}
+
+func (b *UIBackendClient) GetDashboardRiskiestAssets(ctx context.Context) (*models.RiskiestAssets, error) {
+	resp, err := b.apiClient.GetDashboardRiskiestAssetsWithResponse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dashboard riskiest assets: %w", err)
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusOK:
+		if resp.JSON200 == nil {
+			return nil, fmt.Errorf("failed to get dashboard riskiest assets: empty body")
+		}
+		return resp.JSON200, nil
+	default:
+		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
+			return nil, fmt.Errorf("failed to get dashboard riskiest assets: status code=%v: %v", resp.StatusCode(), *resp.JSONDefault.Message)
+		}
+		return nil, fmt.Errorf("failed to get dashboard riskiest assets: status code=%v", resp.StatusCode())
+	}
+}

--- a/pkg/shared/uibackendclient/client.go
+++ b/pkg/shared/uibackendclient/client.go
@@ -58,3 +58,63 @@ func (b *UIBackendClient) GetDashboardRiskiestAssets(ctx context.Context) (*mode
 		return nil, fmt.Errorf("failed to get dashboard riskiest assets: status code=%v", resp.StatusCode())
 	}
 }
+
+func (b *UIBackendClient) GetDashboardRiskiestRegions(ctx context.Context) (*models.RiskiestRegions, error) {
+	resp, err := b.apiClient.GetDashboardRiskiestRegionsWithResponse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dashboard riskiest regions: %w", err)
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusOK:
+		if resp.JSON200 == nil {
+			return nil, fmt.Errorf("failed to get dashboard riskiest regions: empty body")
+		}
+		return resp.JSON200, nil
+	default:
+		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
+			return nil, fmt.Errorf("failed to get dashboard riskiest regions: status code=%v: %v", resp.StatusCode(), *resp.JSONDefault.Message)
+		}
+		return nil, fmt.Errorf("failed to get dashboard riskiest regions: status code=%v", resp.StatusCode())
+	}
+}
+
+func (b *UIBackendClient) GetDashboardFindingsImpact(ctx context.Context) (*models.FindingsImpact, error) {
+	resp, err := b.apiClient.GetDashboardFindingsImpactWithResponse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dashboard findings trends: %w", err)
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusOK:
+		if resp.JSON200 == nil {
+			return nil, fmt.Errorf("failed to get dashboard findings trends: empty body")
+		}
+		return resp.JSON200, nil
+	default:
+		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
+			return nil, fmt.Errorf("failed to get dashboard findings trends: status code=%v: %v", resp.StatusCode(), *resp.JSONDefault.Message)
+		}
+		return nil, fmt.Errorf("failed to get dashboard findings trends: status code=%v", resp.StatusCode())
+	}
+}
+
+func (b *UIBackendClient) GetDashboardFindingsTrends(ctx context.Context, params models.GetDashboardFindingsTrendsParams) (*[]models.FindingTrends, error) {
+	resp, err := b.apiClient.GetDashboardFindingsTrendsWithResponse(ctx, &params)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dashboard findings trends: %w", err)
+	}
+
+	switch resp.StatusCode() {
+	case http.StatusOK:
+		if resp.JSON200 == nil {
+			return nil, fmt.Errorf("failed to get dashboard findings trends: empty body")
+		}
+		return resp.JSON200, nil
+	default:
+		if resp.JSONDefault != nil && resp.JSONDefault.Message != nil {
+			return nil, fmt.Errorf("failed to get dashboard findings trends: status code=%v: %v", resp.StatusCode(), *resp.JSONDefault.Message)
+		}
+		return nil, fmt.Errorf("failed to get dashboard findings trends: status code=%v", resp.StatusCode())
+	}
+}


### PR DESCRIPTION
## Description

https://github.com/openclarity/vmclarity/issues/751

* Change e2e tests to use gateway
* Add a uibackend client similar to backend client 
* Extend default scan test (which exports some non-zero vulnerability results) to test uibackend dashboards

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
