### PR TITLE
fix: chkrootkit binary detection

### DIFF
--- a/pkg/shared/families/rootkits/chkrootkit/chkrootkit.go
+++ b/pkg/shared/families/rootkits/chkrootkit/chkrootkit.go
@@ -18,7 +18,6 @@ package chkrootkit
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 
 	"github.com/openclarity/kubeclarity/shared/pkg/job_manager"
@@ -57,23 +56,17 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 			return
 		}
 
-		// validate that chkrootkit binary exists
-		if _, err := os.Stat(s.config.BinaryPath); err != nil {
-			s.sendResults(retResults, fmt.Errorf("failed to find binary in %v: %w", s.config.BinaryPath, err))
-			return
-		}
-
 		// Locate chkrootkit binary
 		if s.config.BinaryPath == "" {
 			s.config.BinaryPath = ChkrootkitBinary
 		}
 
-		yaraBinaryPath, err := exec.LookPath(s.config.BinaryPath)
+		chkrootkitBinaryPath, err := exec.LookPath(s.config.BinaryPath)
 		if err != nil {
 			s.sendResults(retResults, fmt.Errorf("failed to lookup executable %s: %w", s.config.BinaryPath, err))
 			return
 		}
-		s.logger.Debugf("found chkrootkit binary at: %s", yaraBinaryPath)
+		s.logger.Debugf("found chkrootkit binary at: %s", chkrootkitBinaryPath)
 
 		fsPath, cleanup, err := familiesutils.ConvertInputToFilesystem(context.TODO(), sourceType, userInput)
 		if err != nil {
@@ -88,7 +81,7 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 		}
 
 		// nolint:gosec
-		cmd := exec.Command(s.config.BinaryPath, args...)
+		cmd := exec.Command(chkrootkitBinaryPath, args...)
 		s.logger.Infof("running chkrootkit command: %v", cmd.String())
 		out, err := sharedutils.RunCommand(cmd)
 		if err != nil {


### PR DESCRIPTION
## Description

Fallback to the default binary instead of failing if the path for the chkrootkit brinary is not set in the configuration. Fail only if the binary is not available on $PATH either.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
