### PR TITLE
test(e2e): replace default families scan with full families scan

### DIFF
--- a/e2e/abort_scan_test.go
+++ b/e2e/abort_scan_test.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe("Aborting a scan", func() {
 	ginkgo.Context("which is running", func() {
 		ginkgo.It("should stop successfully", func(ctx ginkgo.SpecContext) {
 			ginkgo.By("applying a scan configuration")
-			apiScanConfig, err := client.PostScanConfig(ctx, GetDefaultScanConfig())
+			apiScanConfig, err := client.PostScanConfig(ctx, GetFullScanConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("updating scan configuration to run now")

--- a/e2e/fail_scan_test.go
+++ b/e2e/fail_scan_test.go
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe("Detecting scan failures", func() {
 			apiScanConfig, err := client.PostScanConfig(
 				ctx,
 				GetCustomScanConfig(
-					&DefaultScanFamiliesConfig,
+					&FullScanFamiliesConfig,
 					"assetInfo/labels/any(t: t/key eq 'notexisting' and t/value eq 'label')",
 					600,
 				))
@@ -90,7 +90,7 @@ var _ = ginkgo.Describe("Detecting scan failures", func() {
 			apiScanConfig, err := client.PostScanConfig(
 				ctx,
 				GetCustomScanConfig(
-					&DefaultScanFamiliesConfig,
+					&FullScanFamiliesConfig,
 					DefaultScope,
 					2,
 				))

--- a/e2e/full_scan_test.go
+++ b/e2e/full_scan_test.go
@@ -26,13 +26,13 @@ import (
 	"github.com/openclarity/vmclarity/pkg/shared/utils"
 )
 
-var _ = ginkgo.Describe("Running a default scan (SBOM, vulnerabilities and exploits)", func() {
+var _ = ginkgo.Describe("Running a full scan (exploits, info finder, malware, misconfigurations, rootkits, SBOM, secrets and vulnerabilities)", func() {
 	reportFailedConfig := ReportFailedConfig{}
 
 	ginkgo.Context("which scans a docker container", func() {
 		ginkgo.It("should finish successfully", func(ctx ginkgo.SpecContext) {
 			ginkgo.By("applying a scan configuration")
-			apiScanConfig, err := client.PostScanConfig(ctx, GetDefaultScanConfig())
+			apiScanConfig, err := client.PostScanConfig(ctx, GetFullScanConfig())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("updating scan configuration to run now")
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("Running a default scan (SBOM, vulnerabilities and explo
 				scans, err = client.GetScans(ctx, scanParams)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				return len(*scans.Items) == 1
-			}, time.Second*120, time.Second).Should(gomega.BeTrue())
+			}, DefaultTimeout*10, time.Second).Should(gomega.BeTrue())
 		})
 	})
 

--- a/e2e/helpers.go
+++ b/e2e/helpers.go
@@ -29,11 +29,26 @@ const (
 	DefaultTimeout time.Duration = 60 * time.Second
 )
 
-var DefaultScanFamiliesConfig = models.ScanFamiliesConfig{
+var FullScanFamiliesConfig = models.ScanFamiliesConfig{
 	Exploits: &models.ExploitsConfig{
 		Enabled: utils.PointerTo(true),
 	},
+	InfoFinder: &models.InfoFinderConfig{
+		Enabled: utils.PointerTo(true),
+	},
+	Malware: &models.MalwareConfig{
+		Enabled: utils.PointerTo(true),
+	},
+	Misconfigurations: &models.MisconfigurationsConfig{
+		Enabled: utils.PointerTo(true),
+	},
+	Rootkits: &models.RootkitsConfig{
+		Enabled: utils.PointerTo(true),
+	},
 	Sbom: &models.SBOMConfig{
+		Enabled: utils.PointerTo(true),
+	},
+	Secrets: &models.SecretsConfig{
 		Enabled: utils.PointerTo(true),
 	},
 	Vulnerabilities: &models.VulnerabilitiesConfig{
@@ -41,9 +56,9 @@ var DefaultScanFamiliesConfig = models.ScanFamiliesConfig{
 	},
 }
 
-func GetDefaultScanConfig() models.ScanConfig {
+func GetFullScanConfig() models.ScanConfig {
 	return GetCustomScanConfig(
-		&DefaultScanFamiliesConfig,
+		&FullScanFamiliesConfig,
 		DefaultScope,
 		600, // nolint:gomnd
 	)


### PR DESCRIPTION
## Description

Replace the default families scan test case with a full families scan test case. This PR is blocked and CI will fail until the issues with the rootkits, misconfigurations and malware families are fixed.

* Rootkit fix https://github.com/openclarity/vmclarity/pull/883
* Misconfiguration fix https://github.com/openclarity/vmclarity/pull/886
* Malware https://github.com/openclarity/vmclarity/pull/888 https://github.com/openclarity/vmclarity/pull/892

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
