### PR TITLE
fix: lynis testDB path

### DIFF
--- a/pkg/shared/families/misconfiguration/lynis/scanner.go
+++ b/pkg/shared/families/misconfiguration/lynis/scanner.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/openclarity/kubeclarity/shared/pkg/job_manager"
@@ -135,15 +136,15 @@ func (a *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 			a.sendResults(retResults, fmt.Errorf("failed to run command: %w", err))
 			return
 		}
-		lynisDBDir := string(out)
+		lynisDBDir := filepath.Clean(strings.TrimSpace(string(out)))
 
-		testdb, err := NewTestDB(a.logger, lynisDBDir)
+		testDB, err := NewTestDB(a.logger, lynisDBDir)
 		if err != nil {
 			a.sendResults(retResults, fmt.Errorf("failed to load lynis test DB: %w", err))
 			return
 		}
 
-		reportParser := NewReportParser(testdb)
+		reportParser := NewReportParser(testDB)
 		retResults.Misconfigurations, err = reportParser.ParseLynisReport(userInput, reportPath)
 		if err != nil {
 			a.sendResults(retResults, fmt.Errorf("failed to parse report file %v: %w", reportPath, err))

--- a/pkg/shared/families/misconfiguration/lynis/testdb.go
+++ b/pkg/shared/families/misconfiguration/lynis/testdb.go
@@ -19,7 +19,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -48,7 +48,7 @@ type TestDB struct {
 func NewTestDB(logger *log.Entry, lynisDBDir string) (*TestDB, error) {
 	// Comes from the Lynis install:
 	// https://github.com/CISOfy/lynis/blob/master/db/tests.db
-	lynisTestDBPath := path.Join(lynisDBDir, "tests.db")
+	lynisTestDBPath := filepath.Join(lynisDBDir, "tests.db")
 	if _, err := os.Stat(lynisTestDBPath); err != nil {
 		return nil, fmt.Errorf("failed to find DB @ %v: %w", lynisTestDBPath, err)
 	}


### PR DESCRIPTION
## Description

The `lynis show dbdir` command returns the path to the test database directory where the output string has a trailing newline character which is not removed before generating the path for the `tests.db` file. This results a bogus file path like `/usr/local/lynis/db /tests.db` and triggers an error as the `tests.db` file is not accessable.

This fix make sure that the command output is sanitized by removing leading/trailing whitespaces and the path is cleaned before using it to assemble the file path for `tests.db`.

Switch to `filepath` from `path` for working with filesystem paths as the latter is not meant to be used with OS filesystem paths.

Also rename `testdb` variable to `testDB` in order to make it aligned with Go naming convention.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
