### PR TITLE
fix(ui): rename "Asset Query" to "Scope"

### DIFF
--- a/ui/src/layout/Scans/Configurations/ConfigurationsTable/index.js
+++ b/ui/src/layout/Scans/Configurations/ConfigurationsTable/index.js
@@ -114,7 +114,7 @@ const ConfigurationsTable = () => {
                         {...OPERATORS.endswith},
                         {...OPERATORS.contains, valueItems: [], creatable: true}
                     ]},
-                    {value: "scanTemplate.scope", label: "Asset Query", operators: [
+                    {value: "scanTemplate.scope", label: "Scope", operators: [
                         {...OPERATORS.eq, valueItems: [], creatable: true},
                         {...OPERATORS.ne, valueItems: [], creatable: true},
                         {...OPERATORS.startswith},

--- a/ui/src/layout/Scans/Scans/ScansTable.js
+++ b/ui/src/layout/Scans/Scans/ScansTable.js
@@ -110,7 +110,7 @@ const ScansTable = () => {
                     {...OPERATORS.endswith},
                     {...OPERATORS.contains, valueitems: [], creatable: true}
                 ]},
-                {value: "scope", label: "Asset Query", operators: [
+                {value: "scope", label: "Scope", operators: [
                     {...OPERATORS.eq, valueitems: [], creatable: true},
                     {...OPERATORS.ne, valueitems: [], creatable: true},
                     {...OPERATORS.startswith},


### PR DESCRIPTION
## Description

Fixes https://github.com/openclarity/vmclarity/issues/821

Rename "Asset Query" to "Scope" as requested in the related issue.

Screenshots:
<img width="1271" alt="Screenshot 2023-11-02 at 14 10 11" src="https://github.com/openclarity/vmclarity/assets/19503754/baff243c-be97-4b64-a17b-29d05c712a7c">
<img width="1271" alt="Screenshot 2023-11-02 at 14 09 59" src="https://github.com/openclarity/vmclarity/assets/19503754/89389a67-8d0e-4d81-91bd-755d03f73d62">


## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
