### PR TITLE
fix(ui): calculate completed scans count correctly

### DIFF
--- a/ui/src/layout/Dashboard/CounterDisplay/index.js
+++ b/ui/src/layout/Dashboard/CounterDisplay/index.js
@@ -1,16 +1,28 @@
-import React from 'react';
+import React, {useMemo} from 'react';
 import { useFetch } from 'hooks';
 import { formatNumber } from 'utils/utils';
 
 import './counter-display.scss';
 
 const CounterDisplay = ({url, title, background}) => {
-    const [{data, error, loading}] = useFetch(url, {queryParams: {"$count": true, "$top": 1, "$select": "id"}});
-    
+    const [{data, error, loading}] = useFetch(url, {queryParams: {"$select": "state"}});
+
+    const completedScans = useMemo(() => {
+        let ret = 0;
+
+        data?.items.forEach((element) => {
+            if (element.state === "Aborted" || element.state === "Failed" || element.state === "Done") {
+                ret++
+            }
+        })
+
+        return ret
+    }, [data])
+
     return (
         <div className="dashboard-counter" style={{background}}>
-            {loading || error ? "" : 
-                <div className="dashboard-counter-content"><div className="dashboard-counter-count">{formatNumber(data.count)}</div>{` ${title}`}</div>
+            {loading || error ? "" :
+                <div className="dashboard-counter-content"><div className="dashboard-counter-count">{formatNumber(completedScans)}</div>{` ${title}`}</div>
             }
         </div>
     )

--- a/ui/src/layout/Dashboard/CounterDisplay/index.js
+++ b/ui/src/layout/Dashboard/CounterDisplay/index.js
@@ -44,5 +44,3 @@ export const CounterDisplay = ({url, title, background}) => {
         </div>
     )
 }
-
-export default CounterDisplay;

--- a/ui/src/layout/Dashboard/CounterDisplay/index.js
+++ b/ui/src/layout/Dashboard/CounterDisplay/index.js
@@ -1,32 +1,26 @@
 import React, {useMemo} from 'react';
-import { useFetch } from 'hooks';
-import { formatNumber } from 'utils/utils';
+import {useFetch} from 'hooks';
+import {formatNumber} from 'utils/utils';
 
 import COLORS from "../../../utils/scss_variables.module.scss";
-import { APIS } from "../../../utils/systemConsts";
+import {APIS} from "../../../utils/systemConsts";
 
 import './counter-display.scss';
 
 export const ScanCounterDisplay = () => {
     const [{data, error, loading}] = useFetch(APIS.SCANS, {queryParams: {"$select": "state"}});
 
-    const completedScans = useMemo(() => {
-        let ret = 0;
-
-        data?.items.forEach((element) => {
-            if (element.state === "Aborted" || element.state === "Failed" || element.state === "Done") {
-                ret++
-            }
-        })
-
-        return ret
-    }, [data])
+    const completedScans = useMemo(
+        () => data?.items.filter((item) => ['Aborted', 'Failed', 'Done'].includes(item.state)).length ?? 0,
+        [data]
+    )
 
     return (
         <div className="dashboard-counter" style={{background: COLORS["color-gradient-green"]}}>
             {loading || error ? "" :
                 <div className="dashboard-counter-content">
-                    <div className="dashboard-counter-count">{formatNumber(completedScans)}</div> Completed scans
+                    <div className="dashboard-counter-count">{formatNumber(completedScans)}</div>
+                    Completed scans
                 </div>
             }
         </div>
@@ -39,7 +33,9 @@ export const CounterDisplay = ({url, title, background}) => {
     return (
         <div className="dashboard-counter" style={{background}}>
             {loading || error ? "" :
-                <div className="dashboard-counter-content"><div className="dashboard-counter-count">{formatNumber(data.count)}</div>{` ${title}`}</div>
+                <div className="dashboard-counter-content">
+                    <div className="dashboard-counter-count">{formatNumber(data.count)}</div>
+                    {` ${title}`}</div>
             }
         </div>
     )

--- a/ui/src/layout/Dashboard/CounterDisplay/index.js
+++ b/ui/src/layout/Dashboard/CounterDisplay/index.js
@@ -2,10 +2,13 @@ import React, {useMemo} from 'react';
 import { useFetch } from 'hooks';
 import { formatNumber } from 'utils/utils';
 
+import COLORS from "../../../utils/scss_variables.module.scss";
+import { APIS } from "../../../utils/systemConsts";
+
 import './counter-display.scss';
 
-const CounterDisplay = ({url, title, background}) => {
-    const [{data, error, loading}] = useFetch(url, {queryParams: {"$select": "state"}});
+export const ScanCounterDisplay = () => {
+    const [{data, error, loading}] = useFetch(APIS.SCANS, {queryParams: {"$select": "state"}});
 
     const completedScans = useMemo(() => {
         let ret = 0;
@@ -20,9 +23,23 @@ const CounterDisplay = ({url, title, background}) => {
     }, [data])
 
     return (
+        <div className="dashboard-counter" style={{background: COLORS["color-gradient-green"]}}>
+            {loading || error ? "" :
+                <div className="dashboard-counter-content">
+                    <div className="dashboard-counter-count">{formatNumber(completedScans)}</div> Completed scans
+                </div>
+            }
+        </div>
+    )
+}
+
+export const CounterDisplay = ({url, title, background}) => {
+    const [{data, error, loading}] = useFetch(url, {queryParams: {"$count": true, "$top": 1, "$select": "id"}});
+
+    return (
         <div className="dashboard-counter" style={{background}}>
             {loading || error ? "" :
-                <div className="dashboard-counter-content"><div className="dashboard-counter-count">{formatNumber(completedScans)}</div>{` ${title}`}</div>
+                <div className="dashboard-counter-content"><div className="dashboard-counter-count">{formatNumber(data.count)}</div>{` ${title}`}</div>
             }
         </div>
     )

--- a/ui/src/layout/Dashboard/CounterDisplay/index.js
+++ b/ui/src/layout/Dashboard/CounterDisplay/index.js
@@ -8,18 +8,23 @@ import {APIS} from "../../../utils/systemConsts";
 import './counter-display.scss';
 
 export const ScanCounterDisplay = () => {
-    const [{data, error, loading}] = useFetch(APIS.SCANS, {queryParams: {"$select": "state"}});
-
-    const completedScans = useMemo(
-        () => data?.items.filter((item) => ['Aborted', 'Failed', 'Done'].includes(item.state)).length ?? 0,
-        [data]
-    )
+    const [{data, error, loading}] = useFetch(
+        APIS.SCANS,
+        {
+            queryParams: {
+                "$count": true,
+                "$top": 1,
+                "$select": "id",
+                "$filter": "state eq 'Aborted' or state eq 'Failed' or state eq 'Done'",
+            }
+        }
+    );
 
     return (
         <div className="dashboard-counter" style={{background: COLORS["color-gradient-green"]}}>
             {loading || error ? "" :
                 <div className="dashboard-counter-content">
-                    <div className="dashboard-counter-count">{formatNumber(completedScans)}</div>
+                    <div className="dashboard-counter-count">{formatNumber(data.count)}</div>
                     Completed scans
                 </div>
             }

--- a/ui/src/layout/Dashboard/index.js
+++ b/ui/src/layout/Dashboard/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useFetch } from 'hooks';
 import Loader from 'components/Loader';
 import { APIS } from 'utils/systemConsts';
-import CounterDisplay from './CounterDisplay';
+import { CounterDisplay, ScanCounterDisplay } from './CounterDisplay';
 import FindingsTrendsWidget from './FindingsTrendsWidget';
 import RiskiestRegionsWidget from './RiskiestRegionsWidget';
 import RiskiestAssetsWidget from './RiskiestAssetsWidget';
@@ -14,9 +14,8 @@ import COLORS from 'utils/scss_variables.module.scss';
 import './dashboard.scss';
 
 const COUNTERS_CONFIG = [
-    {url: APIS.SCANS, title: "Completed scans", background: COLORS["color-gradient-green"]},
     {url: APIS.ASSETS, title: "Assets", background: COLORS["color-gradient-blue"]},
-    {url: APIS.FINDINGS, title: "Risky findings", background: COLORS["color-gradient-yellow"]}
+    {url: APIS.FINDINGS, title: "Findings", background: COLORS["color-gradient-yellow"]}
 ];
 
 const Dashboard = () => {
@@ -36,6 +35,7 @@ const Dashboard = () => {
 
     return (
         <div className="dashboard-page-wrapper">
+            <ScanCounterDisplay />
             {
                 COUNTERS_CONFIG.map(({url, title, background}, index) => (
                     <CounterDisplay key={index} url={url} title={title} background={background} />


### PR DESCRIPTION
## Description

Fix for: https://github.com/openclarity/vmclarity/issues/894
On the Dashboard menu the `Completed scans` widgets shows every scan not only the completed ones.
This PR fixes this issue by checking the scans for their state property.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
