### PR TITLE
ci: fix permission for PR linter workflow

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -8,6 +8,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  pull-requests: write
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
## Description

Add missing `pull-request: write` permission to `semantic-pr` workflow.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
