### PR TITLE
ci: use PAT token for dev image cleanup

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,14 +1,13 @@
 name: Container image cleanup
 
 on:
-# FIXME(chrisgacsal): re-enable PR and scheduled trigger after successful testing
-#  pull_request:
-#    types:
-#      - closed
-#  schedule:
-#    # At 06:00 on every day-of-week from Monday through Friday.
-#    # https://crontab.guru/#0_6_*_*_1-5
-#    - cron: '0 6 * * 1-5'
+  pull_request:
+    types:
+      - closed
+  schedule:
+    # At minute 0 on every day-of-week from Monday through Friday.
+    # https://crontab.guru/#0_*_*_*_1-5
+    - cron: '0 * * * 1-5'
   workflow_dispatch:
     inputs:
       cut-off:
@@ -46,7 +45,7 @@ jobs:
           timestamp-to-use: created_at
           account-type: org
           org-name: openclarity
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           filter-tags: ${{ format( 'pr{0}-*', github.event.pull_request.number) }}
           dry-run: true
 
@@ -63,7 +62,7 @@ jobs:
           timestamp-to-use: created_at
           account-type: org
           org-name: openclarity
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           filter-include-untagged: true
           dry-run: true
 
@@ -80,6 +79,6 @@ jobs:
           timestamp-to-use: created_at
           account-type: org
           org-name: openclarity
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           filter-include-untagged: true
           dry-run: ${{ inputs.dry-run }}


### PR DESCRIPTION
## Description

CI job responsible for removing stale dev container images requires a Personal Access Token to fetch images and their version from GH API.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
