### PR TITLE
build: strip v prefix from Helm Chart version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,7 @@ dist-helm-chart: $(DIST_DIR)/vmclarity-$(VERSION).tgz $(DIST_DIR)/vmclarity-$(VE
 
 $(DIST_DIR)/vmclarity-$(VERSION).tgz: $(DIST_DIR)/helm-vmclarity-chart-$(VERSION).bundle | $(HELM_CHART_DIST_DIR)
 	$(info --- Bundle $(HELM_CHART_DIST_DIR) into $(notdir $@))
-	$(HELM_BIN) package $(HELM_CHART_DIST_DIR) --version "$(VERSION)" --app-version "$(VERSION)" --destination $(DIST_DIR)
+	$(HELM_BIN) package $(HELM_CHART_DIST_DIR) --version "$(VERSION:v%=%)" --app-version "$(VERSION)" --destination $(DIST_DIR)
 
 $(DIST_DIR)/helm-vmclarity-chart-$(VERSION).bundle: $(HELM_CHART_FILES) $(YQ_BIN) | $(HELM_CHART_DIST_DIR)
 	$(info --- Generate Helm Chart bundle)
@@ -444,7 +444,7 @@ $(DIST_DIR)/helm-vmclarity-chart-$(VERSION).bundle: $(HELM_CHART_FILES) $(YQ_BIN
 	.uibackend.image.tag = "$(VERSION)" \
 	' $(HELM_CHART_DIST_DIR)/values.yaml
 	$(YQ_BIN) -i ' \
-	.version = "$(VERSION)" | \
+	.version = "$(VERSION:v%=%)" | \
 	.appVersion = "$(VERSION)" \
 	' $(HELM_CHART_DIST_DIR)/Chart.yaml
 	$(HELMDOCS_BIN) --chart-search-root $(HELM_CHART_DIST_DIR)


### PR DESCRIPTION
## Description

Remove `v` prefix from Helm Chart `version` in order to conform `semver` spec.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
