### PR TITLE
ci: enable dev image cleanup

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -47,7 +47,7 @@ jobs:
           org-name: openclarity
           token: ${{ secrets.PAT }}
           filter-tags: ${{ format( 'pr{0}-*', github.event.pull_request.number) }}
-          dry-run: true
+          dry-run: false
 
   schedule:
     if: github.event_name == 'schedule'
@@ -58,13 +58,13 @@ jobs:
         uses: snok/container-retention-policy@v2
         with:
           image-names: ${{ env.images }}
-          cut-off: 14 days ago UTC
+          cut-off: 7 days ago UTC
           timestamp-to-use: created_at
           account-type: org
           org-name: openclarity
           token: ${{ secrets.PAT }}
           filter-include-untagged: true
-          dry-run: true
+          dry-run: false
 
   dispatch:
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Description

Enable CI workflow for deleting stale images older than 7 days and after PRs are closed.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
