### PR TITLE
build: fix building bundles

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,10 @@ jobs:
     secrets: inherit
 
   build_and_push:
-    needs: verification
+    needs:
+      - verification
+      - artifacts
+      - publish_helm
     name: Build & Push
     uses: ./.github/workflows/reusable-build-and-push.yml
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,9 @@ jobs:
       - name: Create Azure Bicep manifest(s)
         env:
           VERSION: ${{ github.ref_name }}
-        run: make dist-bicep
+        run: |
+          apt update && apt install -y --no-install-recommends libicu-dev
+          make dist-bicep
 
       - name: Create Docker Compose manifest(s)
         env:

--- a/Makefile
+++ b/Makefile
@@ -316,12 +316,10 @@ $(DIST_DIR)/%/vmclarity-cli: $(shell find api) $(shell find cmd/vmclarity-cli) $
 		-o $@ cmd/$(notdir $@)/main.go
 
 $(DIST_DIR)/%/LICENSE: $(ROOT_DIR)/LICENSE
-	$(info --- Copy $(notdir $<) to $@)
-	@cp $< $@
+	cp -v $< $@
 
 $(DIST_DIR)/%/README.md: $(ROOT_DIR)/README.md
-	$(info --- Copy $(notdir $<) to $@)
-	@cp $< $@
+	cp -v $< $@
 
 CFN_DIR := $(INSTALLATION_DIR)/aws
 CFN_FILES := $(shell find $(CFN_DIR))
@@ -336,13 +334,13 @@ $(DIST_DIR)/aws-cloudformation-$(VERSION).tar.gz: $(DIST_DIR)/aws-cloudformation
 
 $(DIST_DIR)/aws-cloudformation-$(VERSION).bundle: $(CFN_FILES) | $(CFN_DIST_DIR)
 	$(info --- Generate Cloudformation bundle)
-	cp -R $(CFN_DIR)/ $(CFN_DIST_DIR)/
+	cp -vR $(CFN_DIR)/* $(CFN_DIST_DIR)/
 	sed -i -E 's@(ghcr\.io\/openclarity\/vmclarity\-(apiserver|cli|orchestrator|ui-backend|ui)):latest@\1:$(VERSION)@' $(CFN_DIST_DIR)/VmClarity.cfn
 	@touch $@
 
 $(CFN_DIST_DIR)/LICENSE: $(ROOT_DIR)/LICENSE | $(CFN_DIST_DIR)
 	$(info --- Copy $(notdir $@) to $@)
-	@cp $< $@
+	cp -v $< $@
 
 $(CFN_DIST_DIR):
 	@mkdir -p $@
@@ -360,15 +358,14 @@ $(DIST_DIR)/azure-bicep-$(VERSION).tar.gz: $(DIST_DIR)/azure-bicep-$(VERSION).bu
 
 $(DIST_DIR)/azure-bicep-$(VERSION).bundle: $(BICEP_FILES) $(BICEP_BIN) | $(BICEP_DIST_DIR)
 	$(info --- Generate Bicep bundle)
-	cp -R $(BICEP_DIR)/ $(BICEP_DIST_DIR)/
+	cp -vR $(BICEP_DIR)/* $(BICEP_DIST_DIR)/
 	sed -i -E 's@(ghcr\.io\/openclarity\/vmclarity\-(apiserver|cli|orchestrator|ui-backend|ui)):latest@\1:$(VERSION)@' \
 		$(BICEP_DIST_DIR)/*.bicep $(BICEP_DIST_DIR)/vmclarity-UI.json
 	$(BICEP_BIN) build $(BICEP_DIST_DIR)/vmclarity.bicep
 	@touch $@
 
 $(BICEP_DIST_DIR)/LICENSE: $(ROOT_DIR)/LICENSE | $(BICEP_DIST_DIR)
-	$(info --- Copy $(notdir $@) to $@)
-	@cp $< $@
+	cp -v $< $@
 
 $(BICEP_DIST_DIR):
 	@mkdir -p $@
@@ -386,14 +383,14 @@ $(DIST_DIR)/docker-compose-$(VERSION).tar.gz: $(DIST_DIR)/docker-compose-$(VERSI
 
 $(DIST_DIR)/docker-compose-$(VERSION).bundle: $(DOCKER_COMPOSE_FILES) | $(DOCKER_COMPOSE_DIST_DIR)
 	$(info --- Generate Docker Compose bundle)
-	cp -R $(DOCKER_COMPOSE_DIR)/ $(DOCKER_COMPOSE_DIST_DIR)/
+	cp -vR $(DOCKER_COMPOSE_DIR)/* $(DOCKER_COMPOSE_DIST_DIR)/
 	sed -i -E 's@(ghcr\.io\/openclarity\/vmclarity\-(apiserver|cli|orchestrator|ui-backend|ui)):latest@\1:$(VERSION)@' \
 		$(DOCKER_COMPOSE_DIST_DIR)/docker-compose.yml $(DOCKER_COMPOSE_DIST_DIR)/image_override.env
 	@touch $@
 
 $(DOCKER_COMPOSE_DIST_DIR)/LICENSE: $(ROOT_DIR)/LICENSE | $(DOCKER_COMPOSE_DIST_DIR)
 	$(info --- Copy $(notdir $@) to $@)
-	@cp $< $@
+	cp -v $< $@
 
 $(DOCKER_COMPOSE_DIST_DIR):
 	@mkdir -p $@
@@ -411,14 +408,13 @@ $(DIST_DIR)/gcp-deployment-$(VERSION).tar.gz: $(DIST_DIR)/gcp-deployment-$(VERSI
 
 $(DIST_DIR)/gcp-deployment-$(VERSION).bundle: $(GCP_DM_FILES) | $(GCP_DM_DIST_DIR)
 	$(info --- Generate Google Cloud Deployment bundle)
-	cp -R $(GCP_DM_DIR)/ $(GCP_DM_DIST_DIR)/
+	cp -vR $(GCP_DM_DIR)/* $(GCP_DM_DIST_DIR)/
 	sed -i -E 's@(ghcr\.io\/openclarity\/vmclarity\-(apiserver|cli|orchestrator|ui-backend|ui)):latest@\1:$(VERSION)@' \
 		$(GCP_DM_DIST_DIR)/vmclarity.py.schema $(GCP_DM_DIST_DIR)/components/vmclarity-server.py.schema
 	@touch $@
 
 $(GCP_DM_DIST_DIR)/LICENSE: $(ROOT_DIR)/LICENSE | $(GCP_DM_DIST_DIR)
-	$(info --- Copy $(notdir $@) to $@)
-	@cp $< $@
+	cp -v $< $@
 
 $(GCP_DM_DIST_DIR):
 	@mkdir -p $@
@@ -436,7 +432,7 @@ $(DIST_DIR)/vmclarity-$(VERSION:v%=%).tgz: $(DIST_DIR)/helm-vmclarity-chart-$(VE
 
 $(DIST_DIR)/helm-vmclarity-chart-$(VERSION:v%=%).bundle: $(HELM_CHART_FILES) bin/yq bin/helm-docs | $(HELM_CHART_DIST_DIR)
 	$(info --- Generate Helm Chart bundle)
-	cp -R $(HELM_CHART_DIR)/ $(HELM_CHART_DIST_DIR)/
+	cp -vR $(HELM_CHART_DIR)/* $(HELM_CHART_DIST_DIR)/
 	$(YQ_BIN) -i ' \
 	.apiserver.image.tag = "$(VERSION)" | \
 	.orchestrator.image.tag = "$(VERSION)" | \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ SHELL = /usr/bin/env bash -o pipefail
 
 BINARY_NAME ?= vmclarity
 VERSION ?= $(shell git rev-parse --short HEAD)
-SEMVER := $(VERSION:v%=%)
 DOCKER_REGISTRY ?= ghcr.io/openclarity
 DOCKER_IMAGE ?= $(DOCKER_REGISTRY)/$(BINARY_NAME)
 DOCKER_TAG ?= $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -356,7 +356,7 @@ $(DIST_DIR)/azure-bicep-$(VERSION).tar.gz: $(DIST_DIR)/azure-bicep-$(VERSION).bu
 	$(info --- Bundle $(BICEP_DIST_DIR) into $(notdir $@))
 	tar cv -f $@ -C $(BICEP_DIST_DIR) --use-compress-program='gzip -9' $(shell ls $(BICEP_DIST_DIR))
 
-$(DIST_DIR)/azure-bicep-$(VERSION).bundle: $(BICEP_FILES) $(BICEP_BIN) | $(BICEP_DIST_DIR)
+$(DIST_DIR)/azure-bicep-$(VERSION).bundle: $(BICEP_FILES) bin/bicep | $(BICEP_DIST_DIR)
 	$(info --- Generate Bicep bundle)
 	cp -vR $(BICEP_DIR)/* $(BICEP_DIST_DIR)/
 	sed -i -E 's@(ghcr\.io\/openclarity\/vmclarity\-(apiserver|cli|orchestrator|ui-backend|ui)):latest@\1:$(VERSION)@' \

--- a/Makefile
+++ b/Makefile
@@ -463,5 +463,5 @@ generate-release-notes: $(DIST_DIR)/RELEASE.md ## Generate Release Notes
 
 $(DIST_DIR)/RELEASE.md: $(DIST_DIR)/CHANGELOG.md
 
-$(DIST_DIR)/CHANGELOG.md: $(ROOT_DIR)/.git/refs/heads/$(shell git rev-parse --abbrev-ref HEAD) $(ROOT_DIR)/cliff.toml $(ROOT_DIR)/release.tmpl
+$(DIST_DIR)/CHANGELOG.md: $(ROOT_DIR)/.git/refs/heads/$(shell git rev-parse --abbrev-ref HEAD) $(ROOT_DIR)/cliff.toml $(ROOT_DIR)/release.tmpl bin/git-cliff
 	$(GITCLIFF_BIN) -vv --strip all --unreleased --tag $(VERSION) --output $@

--- a/Makefile
+++ b/Makefile
@@ -430,20 +430,14 @@ $(DIST_DIR)/vmclarity-$(VERSION:v%=%).tgz: $(DIST_DIR)/helm-vmclarity-chart-$(VE
 	$(info --- Bundle $(HELM_CHART_DIST_DIR) into $(notdir $@))
 	$(HELM_BIN) package $(HELM_CHART_DIST_DIR) --version "$(VERSION:v%=%)" --app-version "$(VERSION)" --destination $(DIST_DIR)
 
+
+
 $(DIST_DIR)/helm-vmclarity-chart-$(VERSION:v%=%).bundle: $(HELM_CHART_FILES) bin/yq bin/helm-docs | $(HELM_CHART_DIST_DIR)
 	$(info --- Generate Helm Chart bundle)
 	cp -vR $(HELM_CHART_DIR)/* $(HELM_CHART_DIST_DIR)/
-	$(YQ_BIN) -i ' \
-	.apiserver.image.tag = "$(VERSION)" | \
-	.orchestrator.image.tag = "$(VERSION)" | \
-	.orchestrator.scannerImage.tag = "$(VERSION)" | \
-	.ui.image.tag = "$(VERSION)" | \
-	.uibackend.image.tag = "$(VERSION)" \
-	' $(HELM_CHART_DIST_DIR)/values.yaml
-	$(YQ_BIN) -i ' \
-	.version = "$(VERSION:v%=%)" | \
-	.appVersion = "$(VERSION)" \
-	' $(HELM_CHART_DIST_DIR)/Chart.yaml
+	$(YQ_BIN) -i '.apiserver.image.tag = "$(VERSION)" | .orchestrator.image.tag = "$(VERSION)" | .orchestrator.scannerImage.tag = "$(VERSION)" | .ui.image.tag = "$(VERSION)" | .uibackend.image.tag = "$(VERSION)"' \
+	$(HELM_CHART_DIST_DIR)/values.yaml
+	$(YQ_BIN) -i '.version = "$(VERSION:v%=%)" | .appVersion = "$(VERSION)"' $(HELM_CHART_DIST_DIR)/Chart.yaml
 	$(HELMDOCS_BIN) --chart-search-root $(HELM_CHART_DIST_DIR)
 	@touch $@
 


### PR DESCRIPTION
## Description

* fix binary dependency targets for bundle builds (bicep, helm, release-notes)
* install ICU dependency for Bicep on Linux (GH Actions runner)
* use glob pattern for `cp` for copying source for bundles to overcome the difference of `cp`'s behavior on `macos` and `linux`.
* remove multi-line strings in Makefile as they are handled differently by `make` on `linux` and`macos`.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
