### PR TITLE
ci: remove installing ICU on runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,9 +91,7 @@ jobs:
       - name: Create Azure Bicep manifest(s)
         env:
           VERSION: ${{ github.ref_name }}
-        run: |
-          apt update && apt install -y --no-install-recommends libicu-dev
-          make dist-bicep
+        run: make dist-bicep
 
       - name: Create Docker Compose manifest(s)
         env:


### PR DESCRIPTION
## Description

Remove installing `libicu-dev` as it is preinstalled on Ubuntu runners for Github Actions.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
