### PR TITLE
build: rm target dep for release note generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,5 +454,5 @@ $(DIST_DIR)/%.sha256sum: | $(DIST_DIR)
 .PHONY: generate-release-notes
 generate-release-notes: $(DIST_DIR)/CHANGELOG.md ## Generate Release Notes
 
-$(DIST_DIR)/CHANGELOG.md: $(ROOT_DIR)/cliff.toml bin/git-cliff
+$(DIST_DIR)/CHANGELOG.md: $(ROOT_DIR)/cliff.toml bin/git-cliff | $(DIST_DIR)
 	$(GITCLIFF_BIN) --config $(ROOT_DIR)/cliff.toml -vv --strip all --unreleased --tag $(VERSION) --output $@

--- a/Makefile
+++ b/Makefile
@@ -452,9 +452,7 @@ $(DIST_DIR)/%.sha256sum: | $(DIST_DIR)
 	shasum -a 256 $(basename $@) | sed "s@$(dir $@)@@" > $@
 
 .PHONY: generate-release-notes
-generate-release-notes: $(DIST_DIR)/RELEASE.md ## Generate Release Notes
+generate-release-notes: $(DIST_DIR)/CHANGELOG.md ## Generate Release Notes
 
-$(DIST_DIR)/RELEASE.md: $(DIST_DIR)/CHANGELOG.md
-
-$(DIST_DIR)/CHANGELOG.md: $(ROOT_DIR)/cliff.toml $(ROOT_DIR)/release.tmpl bin/git-cliff
+$(DIST_DIR)/CHANGELOG.md: $(ROOT_DIR)/cliff.toml bin/git-cliff
 	$(GITCLIFF_BIN) --config $(ROOT_DIR)/cliff.toml -vv --strip all --unreleased --tag $(VERSION) --output $@

--- a/Makefile
+++ b/Makefile
@@ -456,5 +456,5 @@ generate-release-notes: $(DIST_DIR)/RELEASE.md ## Generate Release Notes
 
 $(DIST_DIR)/RELEASE.md: $(DIST_DIR)/CHANGELOG.md
 
-$(DIST_DIR)/CHANGELOG.md: $(ROOT_DIR)/.git/refs/heads/$(shell git rev-parse --abbrev-ref HEAD) $(ROOT_DIR)/cliff.toml $(ROOT_DIR)/release.tmpl bin/git-cliff
-	$(GITCLIFF_BIN) -vv --strip all --unreleased --tag $(VERSION) --output $@
+$(DIST_DIR)/CHANGELOG.md: $(ROOT_DIR)/cliff.toml $(ROOT_DIR)/release.tmpl bin/git-cliff
+	$(GITCLIFF_BIN) --config $(ROOT_DIR)/cliff.toml -vv --strip all --unreleased --tag $(VERSION) --output $@


### PR DESCRIPTION
## Description

Remove target dependency responsible for detecting git repo changes used for regenerating release notes whenever new commit is created as it does not work in CI.

Need to research a better way to detect local changes which work detect states to trigger re-run of release notes target in Makefile.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
