### PR TITLE
fix(uibackend): repeated items in impact dashboard

### DIFF
--- a/pkg/orchestrator/assetscanprocessor/exploits.go
+++ b/pkg/orchestrator/assetscanprocessor/exploits.go
@@ -45,7 +45,7 @@ func (asp *AssetScanProcessor) getExistingExploitFindingsForScan(ctx context.Con
 			return existingMap, fmt.Errorf("unable to get exploit finding info: %w", err)
 		}
 
-		key := findingkey.GenerateExploitFindingUniqueKey(info)
+		key := findingkey.GenerateExploitKey(info).String()
 		if _, ok := existingMap[key]; ok {
 			return existingMap, fmt.Errorf("found multiple matching existing findings for exploit %v", key)
 		}
@@ -111,7 +111,7 @@ func (asp *AssetScanProcessor) reconcileResultExploitsToFindings(ctx context.Con
 				finding.InvalidatedOn = &newerTime
 			}
 
-			key := findingkey.GenerateExploitFindingUniqueKey(itemFindingInfo)
+			key := findingkey.GenerateExploitKey(itemFindingInfo).String()
 			if id, ok := existingMap[key]; ok {
 				err = asp.client.PatchFinding(ctx, id, finding)
 				if err != nil {

--- a/pkg/orchestrator/assetscanprocessor/vulnerabilities.go
+++ b/pkg/orchestrator/assetscanprocessor/vulnerabilities.go
@@ -45,7 +45,7 @@ func (asp *AssetScanProcessor) reconcileResultVulnerabilitiesToFindings(ctx cont
 		return fmt.Errorf("failed to check for existing finding: %w", err)
 	}
 
-	existingMap := map[findingkey.VulKey]string{}
+	existingMap := map[findingkey.VulnerabilityKey]string{}
 	for _, finding := range *existingFindings.Items {
 		vuln, err := (*finding.FindingInfo).AsVulnerabilityFindingInfo()
 		if err != nil {

--- a/pkg/shared/findingkey/common.go
+++ b/pkg/shared/findingkey/common.go
@@ -29,19 +29,19 @@ func GenerateFindingKey(findingInfo *models.Finding_FindingInfo) (string, error)
 
 	switch info := value.(type) {
 	case models.ExploitFindingInfo:
-		return GenerateExploitKey(info).String(), nil
+		return GenerateExploitKey(info).ExploitString(), nil
 	case models.VulnerabilityFindingInfo:
-		return GenerateVulnerabilityKey(info).String(), nil
+		return GenerateVulnerabilityKey(info).VulnerabilityString(), nil
 	case models.MalwareFindingInfo:
-		return GenerateMalwareKey(info).String(), nil
+		return GenerateMalwareKey(info).MalwareString(), nil
 	case models.MisconfigurationFindingInfo:
-		return GenerateMisconfigurationKey(info).String(), nil
+		return GenerateMisconfigurationKey(info).MisconfigurationString(), nil
 	case models.RootkitFindingInfo:
-		return GenerateRootkitKey(info).String(), nil
+		return GenerateRootkitKey(info).RootkitString(), nil
 	case models.SecretFindingInfo:
-		return GenerateSecretKey(info).String(), nil
+		return GenerateSecretKey(info).SecretString(), nil
 	case models.PackageFindingInfo:
-		return GeneratePackageKey(info).String(), nil
+		return GeneratePackageKey(info).PackageString(), nil
 	default:
 		return "", fmt.Errorf("unsupported finding info type %T", value)
 	}

--- a/pkg/shared/findingkey/common.go
+++ b/pkg/shared/findingkey/common.go
@@ -29,7 +29,7 @@ func GenerateFindingKey(findingInfo *models.Finding_FindingInfo) (string, error)
 
 	switch info := value.(type) {
 	case models.ExploitFindingInfo:
-		return GenerateExploitFindingUniqueKey(info), nil
+		return GenerateExploitKey(info).String(), nil
 	case models.VulnerabilityFindingInfo:
 		return GenerateVulnerabilityKey(info).String(), nil
 	case models.MalwareFindingInfo:

--- a/pkg/shared/findingkey/common_test.go
+++ b/pkg/shared/findingkey/common_test.go
@@ -81,7 +81,7 @@ func TestGenerateFindingKey(t *testing.T) {
 			args: args{
 				findingInfo: createFindingInfo(t, exploitFindingInfo),
 			},
-			want:    GenerateExploitFindingUniqueKey(exploitFindingInfo),
+			want:    GenerateExploitKey(exploitFindingInfo).String(),
 			wantErr: false,
 		},
 		{

--- a/pkg/shared/findingkey/common_test.go
+++ b/pkg/shared/findingkey/common_test.go
@@ -81,7 +81,7 @@ func TestGenerateFindingKey(t *testing.T) {
 			args: args{
 				findingInfo: createFindingInfo(t, exploitFindingInfo),
 			},
-			want:    GenerateExploitKey(exploitFindingInfo).String(),
+			want:    GenerateExploitKey(exploitFindingInfo).ExploitString(),
 			wantErr: false,
 		},
 		{
@@ -89,7 +89,7 @@ func TestGenerateFindingKey(t *testing.T) {
 			args: args{
 				findingInfo: createFindingInfo(t, vulFindingInfo),
 			},
-			want:    GenerateVulnerabilityKey(vulFindingInfo).String(),
+			want:    GenerateVulnerabilityKey(vulFindingInfo).VulnerabilityString(),
 			wantErr: false,
 		},
 		{
@@ -97,7 +97,7 @@ func TestGenerateFindingKey(t *testing.T) {
 			args: args{
 				findingInfo: createFindingInfo(t, malwareFindingInfo),
 			},
-			want:    GenerateMalwareKey(malwareFindingInfo).String(),
+			want:    GenerateMalwareKey(malwareFindingInfo).MalwareString(),
 			wantErr: false,
 		},
 		{
@@ -105,7 +105,7 @@ func TestGenerateFindingKey(t *testing.T) {
 			args: args{
 				findingInfo: createFindingInfo(t, miscFindingInfo),
 			},
-			want:    GenerateMisconfigurationKey(miscFindingInfo).String(),
+			want:    GenerateMisconfigurationKey(miscFindingInfo).MisconfigurationString(),
 			wantErr: false,
 		},
 		{
@@ -113,7 +113,7 @@ func TestGenerateFindingKey(t *testing.T) {
 			args: args{
 				findingInfo: createFindingInfo(t, rootkitFindingInfo),
 			},
-			want:    GenerateRootkitKey(rootkitFindingInfo).String(),
+			want:    GenerateRootkitKey(rootkitFindingInfo).RootkitString(),
 			wantErr: false,
 		},
 		{
@@ -121,7 +121,7 @@ func TestGenerateFindingKey(t *testing.T) {
 			args: args{
 				findingInfo: createFindingInfo(t, secretFindingInfo),
 			},
-			want:    GenerateSecretKey(secretFindingInfo).String(),
+			want:    GenerateSecretKey(secretFindingInfo).SecretString(),
 			wantErr: false,
 		},
 		{
@@ -129,7 +129,7 @@ func TestGenerateFindingKey(t *testing.T) {
 			args: args{
 				findingInfo: createFindingInfo(t, pkgFindingInfo),
 			},
-			want:    GeneratePackageKey(pkgFindingInfo).String(),
+			want:    GeneratePackageKey(pkgFindingInfo).PackageString(),
 			wantErr: false,
 		},
 	}

--- a/pkg/shared/findingkey/exploit.go
+++ b/pkg/shared/findingkey/exploit.go
@@ -17,19 +17,30 @@ package findingkey
 
 import (
 	"crypto/sha256"
+	"fmt"
 
 	"github.com/openclarity/vmclarity/api/models"
 )
 
-// GenerateExploitFindingUniqueKey Unique key for an exploit today is SourceDB + CVE ID + the discovering URLs.
-func GenerateExploitFindingUniqueKey(exploit models.ExploitFindingInfo) string {
-	hash := sha256.New()
+type ExploitKey struct {
+	SourceDB string
+	CveID    string
+	Urls     *[]string
+}
 
-	hash.Write([]byte(*exploit.SourceDB))
-	hash.Write([]byte(*exploit.CveID))
-	for _, url := range *exploit.Urls {
+func (k ExploitKey) String() string {
+	hash := sha256.New()
+	for _, url := range *k.Urls {
 		hash.Write([]byte(url))
 	}
 
-	return string(hash.Sum(nil))
+	return fmt.Sprintf("%s.%s.%s", k.SourceDB, k.CveID, string(hash.Sum(nil)))
+}
+
+func GenerateExploitKey(exploit models.ExploitFindingInfo) ExploitKey {
+	return ExploitKey{
+		SourceDB: *exploit.SourceDB,
+		CveID:    *exploit.CveID,
+		Urls:     exploit.Urls,
+	}
 }

--- a/pkg/shared/findingkey/exploit.go
+++ b/pkg/shared/findingkey/exploit.go
@@ -28,6 +28,7 @@ type ExploitKey struct {
 	Urls     *[]string
 }
 
+// String returns an unique string representation of the exploit finding.
 func (k ExploitKey) String() string {
 	hash := sha256.New()
 	for _, url := range *k.Urls {
@@ -35,6 +36,12 @@ func (k ExploitKey) String() string {
 	}
 
 	return fmt.Sprintf("%s.%s.%s", k.SourceDB, k.CveID, string(hash.Sum(nil)))
+}
+
+// ExploitString returns an unique string representation of the exploit independent of
+// where the exploit finding was found by the scanner.
+func (k ExploitKey) ExploitString() string {
+	return k.String()
 }
 
 func GenerateExploitKey(exploit models.ExploitFindingInfo) ExploitKey {

--- a/pkg/shared/findingkey/malware.go
+++ b/pkg/shared/findingkey/malware.go
@@ -29,8 +29,15 @@ type MalwareKey struct {
 	RuleName    string
 }
 
+// String returns an unique string representation of the malware finding.
 func (k MalwareKey) String() string {
 	return fmt.Sprintf("%s.%s.%s.%s", k.MalwareName, k.MalwareType, k.Path, k.RuleName)
+}
+
+// MalwareString returns an unique string representation of the malware independent of
+// where the malware finding was found by the scanner.
+func (k MalwareKey) MalwareString() string {
+	return fmt.Sprintf("%s.%s.%s", k.MalwareName, k.MalwareType, k.RuleName)
 }
 
 func GenerateMalwareKey(info models.MalwareFindingInfo) MalwareKey {

--- a/pkg/shared/findingkey/misconfiguration.go
+++ b/pkg/shared/findingkey/misconfiguration.go
@@ -29,8 +29,15 @@ type MisconfigurationKey struct {
 	Message     string
 }
 
+// String returns an unique string representation of the misconfiguration finding.
 func (k MisconfigurationKey) String() string {
 	return fmt.Sprintf("%s.%s.%s", k.ScannerName, k.TestID, k.Message)
+}
+
+// MisconfigurationString returns an unique string representation of the misconfiguration independent of
+// where the misconfiguration finding was found by the scanner.
+func (k MisconfigurationKey) MisconfigurationString() string {
+	return k.String()
 }
 
 func GenerateMisconfigurationKey(info models.MisconfigurationFindingInfo) MisconfigurationKey {

--- a/pkg/shared/findingkey/package.go
+++ b/pkg/shared/findingkey/package.go
@@ -26,8 +26,15 @@ type PackageKey struct {
 	PackageVersion string
 }
 
+// String returns an unique string representation of the package finding.
 func (k PackageKey) String() string {
 	return fmt.Sprintf("%s.%s", k.PackageName, k.PackageVersion)
+}
+
+// PackageString returns an unique string representation of the package independent of
+// where the package finding was found by the scanner.
+func (k PackageKey) PackageString() string {
+	return k.String()
 }
 
 func GeneratePackageKey(info models.PackageFindingInfo) PackageKey {

--- a/pkg/shared/findingkey/rootkit.go
+++ b/pkg/shared/findingkey/rootkit.go
@@ -27,8 +27,15 @@ type RootkitKey struct {
 	Message     string
 }
 
+// String returns an unique string representation of the rootkit finding.
 func (k RootkitKey) String() string {
 	return fmt.Sprintf("%s.%s.%s", k.Name, k.RootkitType, k.Message)
+}
+
+// RootkitString returns an unique string representation of the rootkit independent of
+// where the rootkit finding was found by the scanner.
+func (k RootkitKey) RootkitString() string {
+	return k.String()
 }
 
 func GenerateRootkitKey(info models.RootkitFindingInfo) RootkitKey {

--- a/pkg/shared/findingkey/secret.go
+++ b/pkg/shared/findingkey/secret.go
@@ -27,8 +27,15 @@ type SecretKey struct {
 	EndColumn   int
 }
 
+// String returns an unique string representation of the secret finding.
 func (k SecretKey) String() string {
 	return fmt.Sprintf("%s.%d.%d", k.Fingerprint, k.StartColumn, k.EndColumn)
+}
+
+// SecretString returns an unique string representation of the secret independent of
+// where the secret finding was found by the scanner.
+func (k SecretKey) SecretString() string {
+	return k.String()
 }
 
 func GenerateSecretKey(secret models.SecretFindingInfo) SecretKey {

--- a/pkg/shared/findingkey/vulnerability.go
+++ b/pkg/shared/findingkey/vulnerability.go
@@ -21,20 +21,20 @@ import (
 	"github.com/openclarity/vmclarity/api/models"
 )
 
-type VulKey struct {
-	VulName        string
-	PackageName    string
-	PackageVersion string
+type VulnerabilityKey struct {
+	VulnerabilityName string
+	PackageName       string
+	PackageVersion    string
 }
 
-func (k VulKey) String() string {
-	return fmt.Sprintf("%s.%s.%s", k.VulName, k.PackageName, k.PackageVersion)
+func (k VulnerabilityKey) String() string {
+	return fmt.Sprintf("%s.%s.%s", k.VulnerabilityName, k.PackageName, k.PackageVersion)
 }
 
-func GenerateVulnerabilityKey(vuln models.VulnerabilityFindingInfo) VulKey {
-	return VulKey{
-		VulName:        *vuln.VulnerabilityName,
-		PackageName:    *vuln.Package.Name,
-		PackageVersion: *vuln.Package.Version,
+func GenerateVulnerabilityKey(vuln models.VulnerabilityFindingInfo) VulnerabilityKey {
+	return VulnerabilityKey{
+		VulnerabilityName: *vuln.VulnerabilityName,
+		PackageName:       *vuln.Package.Name,
+		PackageVersion:    *vuln.Package.Version,
 	}
 }

--- a/pkg/shared/findingkey/vulnerability.go
+++ b/pkg/shared/findingkey/vulnerability.go
@@ -27,8 +27,15 @@ type VulnerabilityKey struct {
 	PackageVersion    string
 }
 
+// String returns an unique string representation of the vulnerability finding.
 func (k VulnerabilityKey) String() string {
 	return fmt.Sprintf("%s.%s.%s", k.VulnerabilityName, k.PackageName, k.PackageVersion)
+}
+
+// VulnerabilityString returns an unique string representation of the vulnerability independent of
+// where the vulnerability finding was found by the scanner.
+func (k VulnerabilityKey) VulnerabilityString() string {
+	return k.VulnerabilityName
 }
 
 func GenerateVulnerabilityKey(vuln models.VulnerabilityFindingInfo) VulnerabilityKey {

--- a/ui/src/layout/Dashboard/FindingsImpactWidget/index.js
+++ b/ui/src/layout/Dashboard/FindingsImpactWidget/index.js
@@ -27,9 +27,10 @@ const TABS_COLUMNS_MAPPING = {
 		]
 	},
 	[FINDINGS_MAPPING.EXPLOITS.dataKey]: {
-		headerItems: ["Vulnerability name"],
+		headerItems: ["Vulnerability name", "URLs"],
 		bodyItems: [
-			{dataKey: "exploit.cveID"}
+			{dataKey: "exploit.cveID"},
+			{dataKey: "exploit.urls"}
 		]
 	},
 	[FINDINGS_MAPPING.MISCONFIGURATIONS.dataKey]: {


### PR DESCRIPTION
## Description

https://github.com/openclarity/vmclarity/issues/890

* Refactor to make findings keys for different families more consistent
* Add new key that will be independent of where vulnerability/malware is found (e.g. package/path). Let me know if you have any suggestions to improve the naming here :)

 before <img width="250" alt="exploits" src="https://github.com/openclarity/vmclarity/assets/46568597/956dd03f-1d59-4f6e-908c-00241fe1827d"> -> after <img width="250" alt="exploits" src="https://github.com/openclarity/vmclarity/assets/46568597/640ac28e-4e63-4c6d-888b-e7cef9a31f5c">


before <img width="250" alt="malware" src="https://github.com/openclarity/vmclarity/assets/46568597/9ca92a11-15cf-45bb-b30e-3fcdfc458a3d">  -> after <img width="250" alt="malware-after" src="https://github.com/openclarity/vmclarity/assets/46568597/42d66789-cda1-4ae4-9208-484ecb9a447e">

In these examples the number of assets scanned was different, hence the discrepancies in the asset counts.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
