### PR TITLE
ci: add missing orchestrator dev image to cleanup

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -26,7 +26,7 @@ on:
         default: true
 
 env:
-  images: vmclarity-apiserver-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
+  images: vmclarity-apiserver-dev,vmclarity-orchestrator-dev,vmclarity-cli-dev,vmclarity-ui-backend-dev,vmclarity-ui-dev
 
 permissions:
   packages: write


### PR DESCRIPTION
## Description

Add missing `vmclarity-orchestrator-dev` to scheduled image cleanup job.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
