### PR TITLE
fix(gcp): Nil pointer exception, use instance label instead of firewall tag, write unit test

### DIFF
--- a/pkg/orchestrator/provider/gcp/provider.go
+++ b/pkg/orchestrator/provider/gcp/provider.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
@@ -368,12 +367,4 @@ func convertLabelsToTags(labels map[string]string) *[]models.Tag {
 	}
 
 	return &tags
-}
-
-func getKeyValue(str string) (string, string) {
-	key, value, found := strings.Cut(str, "=")
-	if found {
-		return key, value
-	}
-	return str, ""
 }

--- a/pkg/orchestrator/provider/gcp/provider_test.go
+++ b/pkg/orchestrator/provider/gcp/provider_test.go
@@ -16,99 +16,37 @@
 package gcp
 
 import (
+	"github.com/openclarity/vmclarity/api/models"
 	"reflect"
 	"testing"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/pkg/shared/utils"
 )
 
-func Test_convertTags(t *testing.T) {
-	type args struct {
-		tags *computepb.Tags
-	}
+func Test_convertLabelsToTags(t *testing.T) {
 	tests := []struct {
 		name string
-		args args
+		args map[string]string
 		want *[]models.Tag
 	}{
 		{
 			name: "sanity",
-			args: args{
-				tags: &computepb.Tags{
-					Items: []string{"tag1", "tag2=val2", "tag3="},
-				},
+			args: map[string]string{
+				"valid-tag": "valid-value",
 			},
-			want: &[]models.Tag{
-				{
-					Key:   "tag1",
-					Value: "",
-				},
-				{
-					Key:   "tag2",
-					Value: "val2",
-				},
-				{
-					Key:   "tag3",
-					Value: "",
-				},
-			},
+			want: &[]models.Tag{{
+				Key: "valid-tag", Value: "valid-value",
+			}},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := convertTags(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("convertTags() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
-func Test_convertTagsToMap(t *testing.T) {
-	type args struct {
-		tags *computepb.Tags
-	}
-	tests := []struct {
-		name string
-		args args
-		want map[string]string
-	}{
-		{
-			name: "Items=nil",
-			args: args{
-				tags: &computepb.Tags{},
-			},
-			want: map[string]string{},
-		},
-		{
-			name: "no tags",
-			args: args{
-				tags: &computepb.Tags{
-					Items: []string{},
-				},
-			},
-			want: map[string]string{},
-		},
-		{
-			name: "sanity",
-			args: args{
-				tags: &computepb.Tags{
-					Items: []string{"key1=val1", "key2"},
-				},
-			},
-			want: map[string]string{
-				"key1": "val1",
-				"key2": "",
-			},
-		},
-	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := convertTagsToMap(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("convertTagsToMap() = %v, want %v", got, tt.want)
+			if got := convertLabelsToTags(tt.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertLabelsToTags() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Fix a nil pointer exception in the GCP provider.
Use the labels of a GCP instance as tags instead of firewall tags.
Add unit test for the refactored code.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
