### PR TITLE
refactor(gcp): use labels instead of firewall tags

### DIFF
--- a/pkg/orchestrator/provider/gcp/provider.go
+++ b/pkg/orchestrator/provider/gcp/provider.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	compute "cloud.google.com/go/compute/apiv1"
@@ -345,7 +344,7 @@ func (p *Provider) getVMInfoFromVirtualMachine(ctx context.Context, vm *computep
 		Location:         getLastURLPart(vm.Zone),
 		Platform:         platform,
 		SecurityGroups:   &[]models.SecurityGroup{},
-		Tags:             convertTags(vm.Tags),
+		Tags:             convertLabelsToTags(vm.Labels),
 	})
 	if err != nil {
 		return models.AssetType{}, provider.FatalErrorf("failed to create AssetType from VMInfo: %w", err)
@@ -354,35 +353,18 @@ func (p *Provider) getVMInfoFromVirtualMachine(ctx context.Context, vm *computep
 	return assetType, nil
 }
 
-// convertTags converts gcp instance tags in the form []string{key1=val1} into
-// models.Tag{Key: key1, Value: val1}. If the tag does not contain the equals
-// sign, the Key will be the tag and the Value will be empty.
-func convertTags(tags *computepb.Tags) *[]models.Tag {
-	ret := make([]models.Tag, 0, len(tags.Items))
-	for _, item := range tags.Items {
-		key, val := getKeyValue(item)
-		ret = append(ret, models.Tag{
-			Key:   key,
-			Value: val,
-		})
-	}
-	return &ret
-}
+func convertLabelsToTags(labels map[string]string) *[]models.Tag {
+	tags := make([]models.Tag, 0, len(labels))
 
-// TODO(sambetts) Remove this unused function.
-func convertTagsToMap(tags *computepb.Tags) map[string]string {
-	ret := make(map[string]string, len(tags.Items))
-	for _, item := range tags.Items {
-		key, val := getKeyValue(item)
-		ret[key] = val
+	for k, v := range labels {
+		tags = append(
+			tags,
+			models.Tag{
+				Key:   k,
+				Value: v,
+			},
+		)
 	}
-	return ret
-}
 
-func getKeyValue(str string) (string, string) {
-	key, value, found := strings.Cut(str, "=")
-	if found {
-		return key, value
-	}
-	return str, ""
+	return &tags
 }

--- a/pkg/orchestrator/provider/gcp/provider_test.go
+++ b/pkg/orchestrator/provider/gcp/provider_test.go
@@ -19,96 +19,35 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/openclarity/vmclarity/api/models"
+
 	"cloud.google.com/go/compute/apiv1/computepb"
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/openclarity/vmclarity/api/models"
 	"github.com/openclarity/vmclarity/pkg/shared/utils"
 )
 
-func Test_convertTags(t *testing.T) {
-	type args struct {
-		tags *computepb.Tags
-	}
+func Test_convertLabelsToTags(t *testing.T) {
 	tests := []struct {
 		name string
-		args args
+		args map[string]string
 		want *[]models.Tag
 	}{
 		{
 			name: "sanity",
-			args: args{
-				tags: &computepb.Tags{
-					Items: []string{"tag1", "tag2=val2", "tag3="},
-				},
+			args: map[string]string{
+				"valid-tag": "valid-value",
 			},
-			want: &[]models.Tag{
-				{
-					Key:   "tag1",
-					Value: "",
-				},
-				{
-					Key:   "tag2",
-					Value: "val2",
-				},
-				{
-					Key:   "tag3",
-					Value: "",
-				},
-			},
+			want: &[]models.Tag{{
+				Key: "valid-tag", Value: "valid-value",
+			}},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := convertTags(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("convertTags() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
 
-func Test_convertTagsToMap(t *testing.T) {
-	type args struct {
-		tags *computepb.Tags
-	}
-	tests := []struct {
-		name string
-		args args
-		want map[string]string
-	}{
-		{
-			name: "Items=nil",
-			args: args{
-				tags: &computepb.Tags{},
-			},
-			want: map[string]string{},
-		},
-		{
-			name: "no tags",
-			args: args{
-				tags: &computepb.Tags{
-					Items: []string{},
-				},
-			},
-			want: map[string]string{},
-		},
-		{
-			name: "sanity",
-			args: args{
-				tags: &computepb.Tags{
-					Items: []string{"key1=val1", "key2"},
-				},
-			},
-			want: map[string]string{
-				"key1": "val1",
-				"key2": "",
-			},
-		},
-	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := convertTagsToMap(tt.args.tags); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("convertTagsToMap() = %v, want %v", got, tt.want)
+			if got := convertLabelsToTags(tt.args); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertLabelsToTags() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Use labels of the GCP instances instead of their network tags.
Network tags enable you to make firewall rules and routes applicable to specific VM instances, not to help you scan your VM instances with VMClarity.
Labels are a much better fit for this purpose.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
