### PR TITLE
feat(helm): add multiple service types to gateway

### DIFF
--- a/installation/kubernetes/helm/vmclarity/README.md
+++ b/installation/kubernetes/helm/vmclarity/README.md
@@ -111,6 +111,12 @@ secrets.
 | gateway.replicas | int | `1` | Number of replicas for the gateway |
 | gateway.resources.limits | object | `{}` | The resources limits for the gateway containers |
 | gateway.resources.requests | object | `{}` | The requested resources for the gateway containers |
+| gateway.service.annotations | object | `{}` | Annotations set for service |
+| gateway.service.clusterIP | string | `""` | Dedicated IP address used for service |
+| gateway.service.externalTrafficPolicy | string | `"Cluster"` | External Traffic Policy configuration Set the field to Cluster to route external traffic to all ready endpoints and Local to only route to ready node-local endpoints. |
+| gateway.service.nodePorts | object | `{"http":""}` | NodePort configurations |
+| gateway.service.ports | object | `{"http":80}` | Port configurations |
+| gateway.service.type | string | `"ClusterIP"` | Service type: ClusterIP, NodePort, LoadBalancer |
 | gateway.serviceAccount.automountServiceAccountToken | bool | `false` | Allows auto mount of ServiceAccountToken on the serviceAccount created. Can be set to false if pods using this serviceAccount do not need to use K8s API. |
 | gateway.serviceAccount.create | bool | `true` | Enable creation of ServiceAccount |
 | gateway.serviceAccount.name | string | `""` | The name of the ServiceAccount to use. If not set and create is true, it will use the component's calculated name. |

--- a/installation/kubernetes/helm/vmclarity/templates/gateway/deployment.yaml
+++ b/installation/kubernetes/helm/vmclarity/templates/gateway/deployment.yaml
@@ -44,6 +44,9 @@ spec:
           {{- if .Values.gateway.resources }}
           resources: {{- toYaml .Values.gateway.resources | nindent 12 }}
           {{- end }}
+          ports:
+            - containerPort: 8080
+              name: gateway-http
       volumes:
         - name: gateway-config
           configMap:

--- a/installation/kubernetes/helm/vmclarity/templates/gateway/service-headless.yaml
+++ b/installation/kubernetes/helm/vmclarity/templates/gateway/service-headless.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vmclarity.gateway.name" . }}-hl
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "vmclarity.gateway.labels.standard" . | nindent 4 }}
+  {{- if (not (empty .Values.gateway.service.annotations)) }}
+  annotations: {{ .Values.gateway.service.annotations }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.gateway.service.ports.http }}
+      targetPort: gateway-http
+  selector: {{- include "vmclarity.gateway.labels.matchLabels" . | nindent 4 }}

--- a/installation/kubernetes/helm/vmclarity/templates/gateway/service.yaml
+++ b/installation/kubernetes/helm/vmclarity/templates/gateway/service.yaml
@@ -4,11 +4,23 @@ metadata:
   name: {{ include "vmclarity.gateway.name" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "vmclarity.gateway.labels.standard" . | nindent 4 }}
+  {{- if (not (empty .Values.gateway.service.annotations)) }}
+  annotations: {{ .Values.gateway.service.annotations }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.gateway.service.type }}
+  {{- if and .Values.gateway.service.clusterIP (eq .Values.gateway.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.gateway.service.clusterIP }}
+  {{- end }}
   ports:
     - name: http
       protocol: TCP
-      port: 80
-      targetPort: 8080
+      port: {{ .Values.gateway.service.ports.http }}
+      targetPort: gateway-http
+      {{- if and (or (eq .Values.gateway.service.type "NodePort") (eq .Values.gateway.service.type "LoadBalancer")) (not (empty .Values.gateway.service.nodePorts.http)) }}
+      nodePort: {{ .Values.gateway.service.nodePorts.http }}
+      {{- end }}
+  {{- if and (or (eq .Values.gateway.service.type "NodePort") (eq .Values.gateway.service.type "LoadBalancer")) (not (empty .Values.gateway.service.externalTrafficPolicy)) }}
+  externalTrafficPolicy: {{ .Values.gateway.service.externalTrafficPolicy }}
+  {{- end }}
   selector: {{- include "vmclarity.gateway.labels.matchLabels" . | nindent 4 }}

--- a/installation/kubernetes/helm/vmclarity/values.yaml
+++ b/installation/kubernetes/helm/vmclarity/values.yaml
@@ -402,6 +402,23 @@ gateway:
       drop:
         - ALL
 
+  service:
+    # -- Service type: ClusterIP, NodePort, LoadBalancer
+    type: ClusterIP
+    # -- Port configurations
+    ports:
+      http: 80
+    # -- NodePort configurations
+    nodePorts:
+      http: ""
+    # -- Dedicated IP address used for service
+    clusterIP: ""
+    # -- Annotations set for service
+    annotations: {}
+    # -- External Traffic Policy configuration
+    # Set the field to Cluster to route external traffic to all ready endpoints and Local to only route to ready node-local endpoints.
+    externalTrafficPolicy: Cluster
+
 postgresql:
   image:
     # -- Postgresql container registry


### PR DESCRIPTION
## Description

* support `NodePort` and `LoadBalancer` service types additionally to `ClusterIP`
* add headless service

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
