### PR TITLE
refactor(docker): change gateway port to 8080

### DIFF
--- a/installation/docker/docker-compose.yml
+++ b/installation/docker/docker-compose.yml
@@ -78,7 +78,7 @@ services:
   gateway:
     image: nginx
     ports:
-      - "80:80"
+      - "8080:80"
     configs:
       - source: gateway_config
         target: /etc/nginx/nginx.conf


### PR DESCRIPTION
## Description

https://openclarity.io/docs/vmclarity/getting-started/install-vmclarity/#access-ui

The UI is accessible in all platforms at http://localhost:8080/ except for Docker where we use http://localhost:80/.
* Change the port exposed on host to make Docker consistent with other platforms

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
