### PR TITLE
refactor: pin Docker Compose schema version

### DIFF
--- a/installation/docker/docker-compose.yml
+++ b/installation/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
   apiserver:


### PR DESCRIPTION
## Description

Pin Docker Compose schema version to `3.5` which includes all the features used the `docker-compose.yml` file.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
