### PR TITLE
chore: repo to work with local go.work file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bin/
 db.db
 site/
 dist
+go.work*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,22 @@ possible, and, if possible, a test case.
 
 ## Development
 
+### Development Environment
+
+For the `gopls` language server to index the whole project, it is possible to create a local `go.work` file including the current go version used and the modules, followed by running `go mod tidy`, such as:
+
+```text
+go 1.21.4
+
+use (
+    ./api
+    ./e2e
+    ./
+)
+
+// maybe replaces if there are conflicts
+```
+
 ### Building VMClarity Binaries
 
 Makefile targets are provided to compile and build the VMClarity binaries.


### PR DESCRIPTION
## Description

Added `go.work*` files to gitignore, and docs how to use a `go.work` file in the repo.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[X] Documentation  
[X] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [x] All new and existing tests pass
