### PR TITLE
ci: bump action for artifact upload/download

### DIFF
--- a/.github/workflows/build-and-push-component.yaml
+++ b/.github/workflows/build-and-push-component.yaml
@@ -97,19 +97,23 @@ jobs:
 
       - name: Export digest
         if: inputs.push
+        id: digest
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
+          
+          echo "digest=${digest#sha256:}" >> "$GITHUB_OUTPUT"
 
       - name: Upload digests
         if: inputs.push
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ needs.build-vars.outputs.digests-cache-name }}
+          name: ${{ needs.build-vars.outputs.digests-cache-name }}-${{ steps.digest.outputs.digest }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+          compression-level: 0
 
   merge-and-push:
     if: inputs.push
@@ -119,9 +123,10 @@ jobs:
       - build-and-push
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ needs.build-vars.outputs.digests-cache-name }}
+          pattern: ${{ needs.build-vars.outputs.digests-cache-name }}-*
+          merge-multiple: true
           path: /tmp/digests
 
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,7 @@ jobs:
         run: make dist-gcp-deployment
 
       - name: Upload
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: |
@@ -114,6 +114,7 @@ jobs:
             dist/bicep/vmclarity.json
             dist/bicep/vmclarity-UI.json
           if-no-files-found: error
+          compression-level: 0
 
   main_release:
     needs:
@@ -130,7 +131,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifacts
           path: dist


### PR DESCRIPTION
## Description

Bump `actions/upload-artifact` and `actions/download-artifact` to `v4` using the following [migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md) as the new version has breaking changes.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
