### PR TITLE
fix(cli): don't return error if home dir doesn't exist

### DIFF
--- a/pkg/shared/families/infofinder/sshtopology/scanner.go
+++ b/pkg/shared/families/infofinder/sshtopology/scanner.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/fs"
 	"os"
 	"os/exec"
 	"path"
@@ -183,7 +182,7 @@ func getHomeUserDirs(rootDir string) ([]string, error) {
 	}
 
 	homeDirPath := path.Join(rootDir, "home")
-  files, _ := os.ReadDir(homeDirPath)
+	files, _ := os.ReadDir(homeDirPath)
 
 	for _, f := range files {
 		if f.IsDir() {

--- a/pkg/shared/families/infofinder/sshtopology/scanner.go
+++ b/pkg/shared/families/infofinder/sshtopology/scanner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path"
@@ -182,10 +183,7 @@ func getHomeUserDirs(rootDir string) ([]string, error) {
 	}
 
 	homeDirPath := path.Join(rootDir, "home")
-	files, err := os.ReadDir(homeDirPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read dir (%v): %w", homeDirPath, err)
-	}
+  files, _ := os.ReadDir(homeDirPath)
 
 	for _, f := range files {
 		if f.IsDir() {

--- a/pkg/shared/families/infofinder/sshtopology/scanner.go
+++ b/pkg/shared/families/infofinder/sshtopology/scanner.go
@@ -77,11 +77,7 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 		defer cleanup()
 
 		var errs []error
-		homeUserDirs, err := getHomeUserDirs(fsPath)
-		if err != nil {
-			// Collect the error and continue.
-			errs = append(errs, fmt.Errorf("failed to get home user dirs: %w", err))
-		}
+		homeUserDirs := getHomeUserDirs(fsPath)
 		s.logger.Debugf("Found home user dirs %+v", homeUserDirs)
 
 		errorsChan := make(chan error)
@@ -172,7 +168,7 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 	return nil
 }
 
-func getHomeUserDirs(rootDir string) ([]string, error) {
+func getHomeUserDirs(rootDir string) []string {
 	var dirs []string
 
 	// Set root home if exists.
@@ -190,7 +186,7 @@ func getHomeUserDirs(rootDir string) ([]string, error) {
 		}
 	}
 
-	return dirs, nil
+	return dirs
 }
 
 func (s *Scanner) getSSHDaemonKeysFingerprints(rootPath string) ([]types.Info, error) {

--- a/pkg/shared/families/infofinder/sshtopology/scanner_test.go
+++ b/pkg/shared/families/infofinder/sshtopology/scanner_test.go
@@ -33,42 +33,28 @@ func Test_getHomeUserDirs(t *testing.T) {
 		rootDir string
 	}
 	tests := []struct {
-		name    string
-		args    args
-		want    []string
-		wantErr bool
+		name string
+		args args
+		want []string
 	}{
 		{
 			name: "sanity",
 			args: args{
 				rootDir: "../testdata/rootfolder",
 			},
-			want:    []string{"../testdata/rootfolder/home/dir1", "../testdata/rootfolder/home/dir2"},
-			wantErr: false,
+			want: []string{"../testdata/rootfolder/home/dir1", "../testdata/rootfolder/home/dir2"},
 		},
 		{
 			name: "root folder with root home folder",
 			args: args{
 				rootDir: "../testdata/rootfolderwithroothome",
 			},
-			want:    []string{"../testdata/rootfolderwithroothome/root", "../testdata/rootfolderwithroothome/home/dir1", "../testdata/rootfolderwithroothome/home/dir2"},
-			wantErr: false,
-		},
-		{
-			name: "missing dir",
-			args: args{
-				rootDir: "../testdata/missingrootfolder",
-			},
-			wantErr: true,
+			want: []string{"../testdata/rootfolderwithroothome/root", "../testdata/rootfolderwithroothome/home/dir1", "../testdata/rootfolderwithroothome/home/dir2"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getHomeUserDirs(tt.args.rootDir)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("getHomeUserDirs() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := getHomeUserDirs(tt.args.rootDir)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getHomeUserDirs() got = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
## Description

This PR fixes the `sshTopology` scanner's error, that failed when there was no `home` directory in the scanned filesystem.

before:
<img width="1961" alt="Screenshot 2024-01-17 at 12 40 49" src="https://github.com/openclarity/vmclarity/assets/11526157/3211247e-45d5-47eb-bdf6-fba6c0f6a83b">

after:
<img width="577" alt="Screenshot 2024-01-18 at 21 21 00" src="https://github.com/openclarity/vmclarity/assets/11526157/31b8ebff-b8af-472c-8896-2d95745f818e">

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
