### PR TITLE
feat(ui): add label to ContainerInfo detail page

### DIFF
--- a/ui/src/layout/detail-displays/AssetDetails/ContainerInfoDetails.jsx
+++ b/ui/src/layout/detail-displays/AssetDetails/ContainerInfoDetails.jsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDisplay';
+import { TagsList } from 'components/Tag';
 import { ContainerImageInfoDetails } from './ContainerImageInfoDetails';
 import { FieldSet } from 'components/FieldSet';
+import { formatTagsToStringsList } from 'utils/utils';
 
 
 export const ContainerInfoDetails = ({assetData}) => {
-    const {containerName, containerID, image} = assetData.assetInfo || {};
-
+    const {containerName, containerID, image, labels} = assetData.assetInfo || {};
 
     return (
         <>
             <TitleValueDisplayRow>
                 <TitleValueDisplay title="Container Name">{containerName}</TitleValueDisplay>
                 <TitleValueDisplay title="Container ID">{containerID}</TitleValueDisplay>
+            </TitleValueDisplayRow>
+
+            <TitleValueDisplayRow>
+                <TitleValueDisplay title="Labels"><TagsList items={formatTagsToStringsList(labels)} /></TitleValueDisplay>
             </TitleValueDisplayRow>
 
             <FieldSet legend="Image">


### PR DESCRIPTION
## Description

Added the labels of a container to the ContainerInfo details page on the UI.

before:

<img width="1036" alt="Screenshot 2024-01-30 at 12 39 54" src="https://github.com/openclarity/vmclarity/assets/11526157/8a26deb7-089d-4317-ad03-d8b740df5422">

after:

<img width="1037" alt="Screenshot 2024-01-30 at 12 36 50" src="https://github.com/openclarity/vmclarity/assets/11526157/03116439-23cc-4e1b-be61-5bb83b49337a">

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
