### PR TITLE
fix(ui): abort scan from the ui

### DIFF
--- a/ui/src/layout/Scans/Scans/ScanActionsDisplay/index.jsx
+++ b/ui/src/layout/Scans/Scans/ScanActionsDisplay/index.jsx
@@ -8,10 +8,10 @@ import { APIS } from 'utils/systemConsts';
 import './scan-actions-display.scss';
 
 const ScanActionsDisplay = ({data, onUpdate}) => {
-    const {id, state} = data;
+    const {id, status: { state }} = data;
 
     const [{loading, error}, fetchScan] = useFetch(APIS.SCANS, {loadOnMount: false});
-	const prevLoading = usePrevious(loading);
+    const prevLoading = usePrevious(loading);
 
     useEffect(() => {
         if (prevLoading && !loading && !error && !!onUpdate) {
@@ -22,7 +22,7 @@ const ScanActionsDisplay = ({data, onUpdate}) => {
     if ([SCAN_STATES.Done.state, SCAN_STATES.Failed.state, SCAN_STATES.Aborted.state].includes(state) || loading) {
         return null;
     }
-    
+
     return (
         <div className="scan-actions-display">
             <IconWithTooltip
@@ -32,10 +32,17 @@ const ScanActionsDisplay = ({data, onUpdate}) => {
                 onClick={event => {
                     event.stopPropagation();
                     event.preventDefault();
-                    
+
                     fetchScan({
                         method: FETCH_METHODS.PATCH,
-                        submitData: {state: SCAN_STATES.Aborted.state},
+                        submitData: {
+                          status: {
+                            state: SCAN_STATES.Aborted.state,
+                            reason: "Cancellation",
+                            message: "Scan has been aborted",
+                            lastTransitionTime: new Date().toISOString(),
+                          },
+                        },
                         formatUrl: url => `${url}/${id}`
                     });
                 }}


### PR DESCRIPTION
## Description

Currently JavaScript PATCH-es a badly formatted body for aborting a `Scan`, this PR fixes this.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
