### PR TITLE
fix(testenv): missing replace in go.mod

### DIFF
--- a/testenv/go.mod
+++ b/testenv/go.mod
@@ -243,6 +243,7 @@ require (
 
 replace (
 	github.com/openclarity/vmclarity => ../
+	github.com/openclarity/vmclarity/api/client => ../api/client
 	github.com/openclarity/vmclarity/api/types => ../api/types
 	github.com/openclarity/vmclarity/utils => ../utils
 )


### PR DESCRIPTION
## Description

Ad missing `repalce` for `api/client` to `testenv/go.mod`.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
