### PR TITLE
fix: missing replace in go.mod

### DIFF
--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -265,6 +265,8 @@ replace (
 	github.com/openclarity/vmclarity/api/client => ../api/client
 	github.com/openclarity/vmclarity/api/types => ../api/types
 	github.com/openclarity/vmclarity/cli => ../cli
+	github.com/openclarity/vmclarity/containerruntimediscovery/client => ../containerruntimediscovery/client
+	github.com/openclarity/vmclarity/containerruntimediscovery/types => ../containerruntimediscovery/types
 	github.com/openclarity/vmclarity/testenv => ../testenv
 	github.com/openclarity/vmclarity/uibackend/client => ../uibackend/client
 	github.com/openclarity/vmclarity/uibackend/types => ../uibackend/types

--- a/testenv/go.mod
+++ b/testenv/go.mod
@@ -247,6 +247,8 @@ replace (
 	github.com/openclarity/vmclarity/api/client => ../api/client
 	github.com/openclarity/vmclarity/api/types => ../api/types
 	github.com/openclarity/vmclarity/cli => ../cli
+	github.com/openclarity/vmclarity/containerruntimediscovery/client => ../containerruntimediscovery/client
+	github.com/openclarity/vmclarity/containerruntimediscovery/types => ../containerruntimediscovery/types
 	github.com/openclarity/vmclarity/utils => ../utils
 )
 


### PR DESCRIPTION
## Description

Fix missing `replace` statements in `e2e/go.mod` and `testenv/go.mod` files.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
