### PR TITLE
refactor: check licenses in multiple modules

### DIFF
--- a/.github/workflows/reusable-verification.yml
+++ b/.github/workflows/reusable-verification.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Vendor dependencies to retrieve licenses locally
         # Vendor deps before running https://github.com/goph/licensei
         # to avoid false-positives when modules GitHub repo could not be determined
-        run: go mod vendor
+        run: make gomod-vendor
 
       - name: Check licenses
         env:

--- a/makefile.d/20-tools.mk
+++ b/makefile.d/20-tools.mk
@@ -3,6 +3,7 @@
 ####
 
 LICENSEI_BIN := $(BIN_DIR)/licensei
+LICENSEI_CONFIG := $(ROOT_DIR)/.licensei.toml
 LICENSEI_VERSION = 0.9.0
 
 bin/licensei: bin/licensei-$(LICENSEI_VERSION)


### PR DESCRIPTION
## Description

* Modify `license-check` and `license-cache` in Makefile to run for multiple modules
* Add `gomod-vendor` in Makefile

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
