### PR TITLE
ci: fix setting docker digest for latest tag

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    "docker:pinDigests",
     "helpers:pinGitHubActionDigestsToSemver"
   ],
   "configMigration": true,
@@ -158,6 +157,13 @@
       "matchDatasources": [
         "azure-bicep-resource"
       ]
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": true,
+      "allowedVersions": "!/latest$/"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
## Description

Do not pin  docker image versions by digest for `latest` tags.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
