### PR TITLE
ci: disable pinning docker images by digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -157,13 +157,6 @@
       "matchDatasources": [
         "azure-bicep-resource"
       ]
-    },
-    {
-      "matchDatasources": [
-        "docker"
-      ],
-      "pinDigests": true,
-      "allowedVersions": "!/latest$/"
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
## Description

Disable pinning docker images by digest.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
