### PR TITLE
chore: rm pinning container images by digest

### DIFF
--- a/installation/docker/docker-compose.yml
+++ b/installation/docker/docker-compose.yml
@@ -89,7 +89,7 @@ services:
         condition: on-failure
 
   exploit-db-server:
-    image: ${VMCLARITY_EXPLOITSDB_SERVER_CONTAINER_IMAGE:-ghcr.io/openclarity/exploit-db-server:v0.2.4@sha256:16530b9be24ae507a216bc6405c0eb945f25efb47020d3afd286e33b0fb22482}
+    image: ${VMCLARITY_EXPLOITSDB_SERVER_CONTAINER_IMAGE:-ghcr.io/openclarity/exploit-db-server:v0.2.4}
     ports:
       - "1326:1326"
     deploy:
@@ -103,7 +103,7 @@ services:
       retries: 60
 
   trivy-server:
-    image: ${VMCLARITY_TRIVY_SERVER_CONTAINER_IMAGE:-docker.io/aquasec/trivy:0.49.1@sha256:91494b87ddc64f62860d52997532643956c24eeee0d0dda317d563c28c8581bc}
+    image: ${VMCLARITY_TRIVY_SERVER_CONTAINER_IMAGE:-docker.io/aquasec/trivy:0.49.1}
     command:
       - server
     ports:
@@ -120,7 +120,7 @@ services:
       retries: 60
 
   grype-server:
-    image: ${VMCLARITY_GRYPE_SERVER_CONTAINER_IMAGE:-ghcr.io/openclarity/grype-server:v0.7.2@sha256:33391b234bdc08c8383f213fa973ffc860d3aea589b862dc34dc461b9e2271df}
+    image: ${VMCLARITY_GRYPE_SERVER_CONTAINER_IMAGE:-ghcr.io/openclarity/grype-server:v0.7.2}
     command:
       - run
       - --log-level
@@ -142,7 +142,7 @@ services:
       retries: 60
 
   freshclam-mirror:
-    image: ${VMCLARITY_FRESHCLAM_MIRROR_CONTAINER_IMAGE:-ghcr.io/openclarity/freshclam-mirror:v0.3.0@sha256:d7d6ff86915e378afb9ea75505d5f2df368215beac12b462b01c4c67d5e4617f}
+    image: ${VMCLARITY_FRESHCLAM_MIRROR_CONTAINER_IMAGE:-ghcr.io/openclarity/freshclam-mirror:v0.3.0}
     ports:
       - "1000:80"
     deploy:
@@ -152,7 +152,7 @@ services:
         condition: on-failure
 
   yara-rule-server:
-    image: ${VMCLARITY_YARA_RULE_SERVER_CONTAINER_IMAGE:-ghcr.io/openclarity/yara-rule-server:v0.1.0@sha256:be517c96bb0f7d00166b8598a213d6c6d7997df0ce1a2c3678c46d1dbedd731f}
+    image: ${VMCLARITY_YARA_RULE_SERVER_CONTAINER_IMAGE:-ghcr.io/openclarity/yara-rule-server:v0.1.0}
     command:
       - run
     ports:
@@ -171,7 +171,7 @@ services:
       retries: 60
 
   postgresql:
-    image: ${VMCLARITY_POSTGRESQL_CONTAINER_IMAGE:-docker.io/bitnami/postgresql:12.17.0-debian-11-r28@sha256:f1fb96f5d86d7280d0fb977968e0a1f5a7a8dacb64b012394ef47bd079d1544d}
+    image: ${VMCLARITY_POSTGRESQL_CONTAINER_IMAGE:-docker.io/bitnami/postgresql:12.17.0-debian-11-r28}
     env_file: ./postgres.env
     ports:
       - "5432:5432"
@@ -184,7 +184,7 @@ services:
         condition: on-failure
 
   swagger-ui:
-    image: swaggerapi/swagger-ui:v5.11.3@sha256:4d342e0b0d06d026254b023db54106825e59877dfbca860914242f02fe3f1300
+    image: swaggerapi/swagger-ui:v5.11.3
     environment:
       CONFIG_URL: /apidocs/swagger-config.json
     configs:

--- a/installation/kubernetes/helm/vmclarity/README.md
+++ b/installation/kubernetes/helm/vmclarity/README.md
@@ -83,7 +83,7 @@ secrets.
 | exploitDBServer.image.pullPolicy | string | `"IfNotPresent"` | Exploit DB Server image pull policy |
 | exploitDBServer.image.registry | string | `"ghcr.io"` | Exploit DB Server container registry |
 | exploitDBServer.image.repository | string | `"openclarity/exploit-db-server"` | Exploit DB Server container repository |
-| exploitDBServer.image.tag | string | `"v0.2.3@sha256:faa74ed783cf5520ec4c8889a0dbce024a1992b50c7515dfd00cad5253f8590a"` | Exploit DB Server container tag |
+| exploitDBServer.image.tag | string | `"v0.2.3"` | Exploit DB Server container tag |
 | exploitDBServer.podSecurityContext.enabled | bool | `true` | Pod security context enabled |
 | exploitDBServer.podSecurityContext.fsGroup | int | `1001` | Pod security context fsGroup |
 | exploitDBServer.replicas | int | `1` | Number of replicas for the exploit-db-server service |
@@ -104,7 +104,7 @@ secrets.
 | freshclamMirror.image.pullPolicy | string | `"IfNotPresent"` | Freshclam Mirror image pull policy |
 | freshclamMirror.image.registry | string | `"ghcr.io"` | Freshclam Mirror container registry |
 | freshclamMirror.image.repository | string | `"openclarity/freshclam-mirror"` | Freshclam Mirror container repository |
-| freshclamMirror.image.tag | string | `"v0.3.0@sha256:d7d6ff86915e378afb9ea75505d5f2df368215beac12b462b01c4c67d5e4617f"` | Freshclam Mirror container tag |
+| freshclamMirror.image.tag | string | `"v0.3.0"` | Freshclam Mirror container tag |
 | freshclamMirror.podSecurityContext.enabled | bool | `false` | Pod security context enabled |
 | freshclamMirror.podSecurityContext.fsGroup | int | `1001` | Pod security context fsGroup |
 | freshclamMirror.replicas | int | `1` | Number of replicas for the freshclam mirror service |
@@ -125,7 +125,7 @@ secrets.
 | gateway.image.pullPolicy | string | `"IfNotPresent"` | Gateway service container pull policy |
 | gateway.image.registry | string | `"docker.io"` | Gateway service container registry |
 | gateway.image.repository | string | `"nginxinc/nginx-unprivileged"` | Gateway service container repository |
-| gateway.image.tag | string | `"1.25.3@sha256:5c7c5f3a43fdd395ae5b21fa4ff4daba0c5c561071bd6eb21cbb4cf616d0aee0"` | Gateway service container tag |
+| gateway.image.tag | string | `"1.25.3"` | Gateway service container tag |
 | gateway.podSecurityContext.enabled | bool | `true` | Pod security context enabled |
 | gateway.podSecurityContext.fsGroup | int | `101` | Pod security context fsGroup |
 | gateway.replicas | int | `1` | Number of replicas for the gateway |
@@ -153,7 +153,7 @@ secrets.
 | grypeServer.image.pullPolicy | string | `"IfNotPresent"` | Grype server image pull policy |
 | grypeServer.image.registry | string | `"ghcr.io"` | Grype server container registry |
 | grypeServer.image.repository | string | `"openclarity/grype-server"` | Grype server container repository |
-| grypeServer.image.tag | string | `"v0.7.2@sha256:33391b234bdc08c8383f213fa973ffc860d3aea589b862dc34dc461b9e2271df"` | Grype server container tag |
+| grypeServer.image.tag | string | `"v0.7.2"` | Grype server container tag |
 | grypeServer.logLevel | string | `"info"` | Log level for the grype-server service |
 | grypeServer.podSecurityContext.enabled | bool | `true` | Pod security context enabled |
 | grypeServer.podSecurityContext.fsGroup | int | `1001` | Pod security context fsGroup |
@@ -240,7 +240,7 @@ secrets.
 | postgresql.image.pullPolicy | string | `"IfNotPresent"` | Postgresql container image pull policy |
 | postgresql.image.registry | string | `"docker.io"` | Postgresql container registry |
 | postgresql.image.repository | string | `"bitnami/postgresql"` | Postgresql container repository |
-| postgresql.image.tag | string | `"14.6.0-debian-11-r31@sha256:5f00817d0f92465eeb1a823380ad43c8e49eecd261fc0f25dd44ab316e8c7b1c"` | Postgresql container tag |
+| postgresql.image.tag | string | `"14.6.0-debian-11-r31"` | Postgresql container tag |
 | postgresql.podSecurityContext.enabled | bool | `true` | Pod security context enabled |
 | postgresql.podSecurityContext.fsGroup | int | `1001` | Pod security context fsGroup |
 | postgresql.resources.limits | object | `{}` | The resources limits for the postgresql containers |
@@ -261,7 +261,7 @@ secrets.
 | swaggerUI.image.pullPolicy | string | `"IfNotPresent"` | Swagger UI image pull policy |
 | swaggerUI.image.registry | string | `"docker.io"` | Swagger UI container registry |
 | swaggerUI.image.repository | string | `"swaggerapi/swagger-ui"` | Swagger UI container repository |
-| swaggerUI.image.tag | string | `"v5.3.1@sha256:ed97fba3dc40c61fbf8346f0f0fdf494bea36ac6b55d3fb4446e9255965a46d9"` | Swagger UI container tag |
+| swaggerUI.image.tag | string | `"v5.3.1"` | Swagger UI container tag |
 | swaggerUI.podSecurityContext.enabled | bool | `false` | Pod security context enabled |
 | swaggerUI.podSecurityContext.fsGroup | int | `101` | Pod security context fsGroup |
 | swaggerUI.replicas | int | `1` | Number of replicas for the swagger-ui service |
@@ -346,7 +346,7 @@ secrets.
 | yaraRuleServer.image.pullPolicy | string | `"IfNotPresent"` | Yara Rule Server image pull policy |
 | yaraRuleServer.image.registry | string | `"ghcr.io"` | Yara Rule Server container registry |
 | yaraRuleServer.image.repository | string | `"openclarity/yara-rule-server"` | Yara Rule Server container repository |
-| yaraRuleServer.image.tag | string | `"v0.1.0@sha256:be517c96bb0f7d00166b8598a213d6c6d7997df0ce1a2c3678c46d1dbedd731f"` | Yara Rule Server container tag |
+| yaraRuleServer.image.tag | string | `"v0.1.0"` | Yara Rule Server container tag |
 | yaraRuleServer.podSecurityContext.enabled | bool | `false` | Pod security context enabled |
 | yaraRuleServer.podSecurityContext.fsGroup | int | `1001` | Pod security context fsGroup |
 | yaraRuleServer.replicas | int | `1` | Number of replicas for the Yara Rule Server service |

--- a/installation/kubernetes/helm/vmclarity/values.yaml
+++ b/installation/kubernetes/helm/vmclarity/values.yaml
@@ -354,7 +354,7 @@ gateway:
     # -- Gateway service container repository
     repository: nginxinc/nginx-unprivileged
     # -- Gateway service container tag
-    tag: 1.25.3@sha256:5c7c5f3a43fdd395ae5b21fa4ff4daba0c5c561071bd6eb21cbb4cf616d0aee0
+    tag: 1.25.3
     # -- Gateway image digest. If set will override the tag.
     digest: ""
     # -- Gateway service container pull policy
@@ -426,7 +426,7 @@ postgresql:
     # -- Postgresql container repository
     repository: bitnami/postgresql
     # -- Postgresql container tag
-    tag: 14.6.0-debian-11-r31@sha256:5f00817d0f92465eeb1a823380ad43c8e49eecd261fc0f25dd44ab316e8c7b1c
+    tag: 14.6.0-debian-11-r31
     # -- Postgresql image digest. If set will override the tag.
     digest: ""
     # -- Postgresql container image pull policy
@@ -499,7 +499,7 @@ exploitDBServer:
     # -- Exploit DB Server container repository
     repository: openclarity/exploit-db-server
     # -- Exploit DB Server container tag
-    tag: v0.2.3@sha256:faa74ed783cf5520ec4c8889a0dbce024a1992b50c7515dfd00cad5253f8590a
+    tag: v0.2.3
     # -- Exploit DB Server image digest. If set will override the tag.
     digest: ""
     # -- Exploit DB Server image pull policy
@@ -615,7 +615,7 @@ grypeServer:
     # -- Grype server container repository
     repository: openclarity/grype-server
     # -- Grype server container tag
-    tag: v0.7.2@sha256:33391b234bdc08c8383f213fa973ffc860d3aea589b862dc34dc461b9e2271df
+    tag: v0.7.2
     # -- Grype server image digest. If set will override the tag.
     digest: ""
     # -- Grype server image pull policy
@@ -676,7 +676,7 @@ freshclamMirror:
     # -- Freshclam Mirror container repository
     repository: openclarity/freshclam-mirror
     # -- Freshclam Mirror container tag
-    tag: v0.3.0@sha256:d7d6ff86915e378afb9ea75505d5f2df368215beac12b462b01c4c67d5e4617f
+    tag: v0.3.0
     # -- Freshclam Mirror image digest. If set will override the tag.
     digest: ""
     # -- Freshclam Mirror image pull policy
@@ -734,7 +734,7 @@ swaggerUI:
     # -- Swagger UI container repository
     repository: swaggerapi/swagger-ui
     # -- Swagger UI container tag
-    tag: v5.3.1@sha256:ed97fba3dc40c61fbf8346f0f0fdf494bea36ac6b55d3fb4446e9255965a46d9
+    tag: v5.3.1
     # -- Swagger UI image digest. If set will override the tag.
     digest: ""
     # -- Swagger UI image pull policy
@@ -792,7 +792,7 @@ yaraRuleServer:
     # -- Yara Rule Server container repository
     repository: openclarity/yara-rule-server
     # -- Yara Rule Server container tag
-    tag: v0.1.0@sha256:be517c96bb0f7d00166b8598a213d6c6d7997df0ce1a2c3678c46d1dbedd731f
+    tag: v0.1.0
     # -- Yara Rule Server image digest. If set will override the tag.
     digest: ""
     # -- Yara Rule Server image pull policy


### PR DESCRIPTION
## Description

Remove container image pinning in docker-compose and helm chart.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
