### PR TITLE
fix: license-cache target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ LICENSECACHEMODULES = $(addprefix license-cache-, $(GOMODULES))
 $(LICENSECACHEMODULES):
 	cd $(@:license-cache-%=%) && "$(LICENSEI_BIN)" cache --config "$(LICENSEI_CONFIG)"
 
-+.PHONY: license-cache
+.PHONY: license-cache
 license-cache: bin/licensei $(LICENSECACHEMODULES) ## Generate license cache
 
 .PHONY: lint


### PR DESCRIPTION
## Description

Remove wrong character from license-cache target.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
