### PR TITLE
ci: fix success check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
       use_release_repository: false
 
   success:
+    # https://github.com/actions/runner/issues/2566
+    # https://github.com/actions/toolkit/issues/581
+    if: ${{ !cancelled() && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'failure') }}
     needs:
       - build
       - e2e


### PR DESCRIPTION
## Description

The `success` is skipped instead of failed when depending jobs defined in `needs` parameter are skipped/failed. Skipped `success` job treated the same way as if it was successful therefore CI proceeds with merging Pull Request in case it has  auto-merge enabled.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
