### PR TITLE
ci: pin Alpine image version for testing

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -225,6 +225,21 @@
         "Always use latest version for VMClarity container images.",
         "Do not pin by digest."
       ]
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "alpine"
+      ],
+      "matchFileNames": [
+        "testenv/**/docker-compose.override.yml"
+      ],
+      "allowedVersions": "3.18.2",
+      "description": [
+        "Pin version of the Alpine container image used for testing."
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
## Description

Pin version of the Alpine container image version used for testing to avoid breaking E2E tests.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
