### PR TITLE
build: add go vet to checks

### DIFF
--- a/.github/workflows/reusable-verification.yml
+++ b/.github/workflows/reusable-verification.yml
@@ -111,6 +111,10 @@ jobs:
           make gomod-tidy
           [[ -z "$(git status --porcelain)" ]] || exit 1
 
+      - name: Run go vet
+        run: |
+          make vet
+
       - name: Cache golangci-lint cache
         uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ ui: ## Build UI component
 ##@ Testing
 
 .PHONY: check
-check: lint test ## Run tests and linters
+check: vet lint test ## Run tests and linters
 
 LINTGOMODULES = $(addprefix lint-, $(GOMODULES))
 FIXGOMODULES = $(addprefix fix-, $(GOMODULES))
@@ -213,6 +213,14 @@ $(TESTGOMODULES):
 
 .PHONY: test
 test: $(TESTGOMODULES) ## Run Go unit tests
+
+VETGOMODULES = $(addprefix vet-, $(GOMODULES))
+
+$(VETGOMODULES):
+	go -C $(@:vet-%=%) vet ./...
+
+.PHONY: vet
+vet: $(VETGOMODULES) ## Run go vet for modules
 
 ##@ Docker
 


### PR DESCRIPTION
## Description]

Add `go vet` to `check` target in makefile in order to perform additional check prior running `golangci-lint` or test in order to catch certain issues early on like compilation errors.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
