### PR TITLE
build: add cleaning up go vendor directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ bin/vmclarity-cr-discovery-server: $(shell find api containerruntimediscovery/se
 	cd containerruntimediscovery/server && go build $(BUILD_OPTS) -ldflags="$(LDFLAGS)" -o $(ROOT_DIR)/$@ cmd/main.go
 
 .PHONY: clean
-clean: clean-ui clean-go ## Clean all build artifacts
+clean: clean-ui clean-go clean-vendor ## Clean all build artifacts
 
 .PHONY: clean-go
 clean-go: ## Clean all Go build artifacts
@@ -95,6 +95,11 @@ clean-go: ## Clean all Go build artifacts
 clean-ui: ## Clean UI build
 	@rm -rf ui/build
 	$(info UI cleanup done)
+
+.PHONY: clean-vendor
+clean-vendor: ## Clean go vendor directories
+	$(info Clean go vendor directories)
+	@find $(ROOT_DIR) -name 'vendor' -type d -exec rm -rf {} \;
 
 .PHONY: $(LINTGOMODULES)
 TIDYGOMODULES = $(addprefix tidy-, $(GOMODULES))


### PR DESCRIPTION
## Description

Add cleaning up go vendor directories to Makefile.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
