### PR TITLE
fix: rename asset to target in cloud init

### DIFF
--- a/cli/test/boot/vagrant/cloud-config.cfg
+++ b/cli/test/boot/vagrant/cloud-config.cfg
@@ -35,7 +35,7 @@ write_files:
       [Unit]
       Description=VMClarity scanner job
       Requires=docker.service
-      After=network.asset docker.service
+      After=network.target docker.service
 
       [Service]
       Type=oneshot
@@ -44,7 +44,7 @@ write_files:
       ExecStart=docker run --rm --name %n -v /opt/vmclarity:/vmclarity busybox ls /vmclarity
 
       [Install]
-      WantedBy=multi-user.asset
+      WantedBy=multi-user.target
 runcmd:
   - [ systemctl, daemon-reload ]
   - [ systemctl, start, docker.service ]

--- a/provider/cloudinit/cloud-init.tmpl.yaml
+++ b/provider/cloudinit/cloud-init.tmpl.yaml
@@ -13,7 +13,7 @@ write_files:
       [Unit]
       Description=VMClarity scanner job
       Requires=docker.service
-      After=network.asset docker.service
+      After=network.target docker.service
       
       [Service]
       Type=oneshot
@@ -35,7 +35,7 @@ write_files:
           --output /var/opt/vmclarity
       
       [Install]
-      WantedBy=multi-user.asset
+      WantedBy=multi-user.target
 
 runcmd:
   - [ systemctl, daemon-reload ]

--- a/provider/cloudinit/testdata/cloud-init.yaml
+++ b/provider/cloudinit/testdata/cloud-init.yaml
@@ -23,7 +23,7 @@ write_files:
       [Unit]
       Description=VMClarity scanner job
       Requires=docker.service
-      After=network.asset docker.service
+      After=network.target docker.service
       
       [Service]
       Type=oneshot
@@ -45,7 +45,7 @@ write_files:
           --output /var/opt/vmclarity
       
       [Install]
-      WantedBy=multi-user.asset
+      WantedBy=multi-user.target
 runcmd:
   - [ systemctl, daemon-reload ]
   - [ systemctl, start, docker.service ]


### PR DESCRIPTION
## Description

This PR renames the `network.asset` to `network.target` and the `multi-user.asset` to `multi-user.target` in the cloud init files.

PR where this regression was introduced: https://github.com/openclarity/vmclarity/pull/282

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
