### PR TITLE
fix: subst spaces with commas in GO_BUILD_TAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,9 @@ build: ui build-all-go ## Build all components
 build-all-go: bin/vmclarity-apiserver bin/vmclarity-cli bin/vmclarity-orchestrator bin/vmclarity-ui-backend bin/vmclarity-cr-discovery-server ## Build all go components
 
 BUILD_OPTS = -race
-BUILD_OPTS += -tags="$(GO_BUILD_TAGS)"
+ifneq ($(strip $(GO_BUILD_TAGS)),)
+	BUILD_OPTS += -tags=$(call subst-space-with-comma,$(GO_BUILD_TAGS))
+endif
 
 LDFLAGS = -s -w
 LDFLAGS += -X 'github.com/openclarity/vmclarity/core/version.Version=$(VERSION)'

--- a/makefile.d/10-helpers.mk
+++ b/makefile.d/10-helpers.mk
@@ -33,3 +33,12 @@ else
 		ARCHTYPE = arm64
 	endif
 endif
+
+####
+## Helper to create a comma-separated list from a space-separated list
+####
+
+null  :=
+space := $(null) #
+comma := ,
+subst-space-with-comma = $(subst $(space),$(comma),$(strip $(1)))


### PR DESCRIPTION
## Description

Create a comma-separated list instead of a space-separated list from `GO_BUILD_TAGS` in the Makefile. The previous solution worked for go-related make targets (build, test, vet stc.) but was not sufficient for the `make docker*` targets.

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
