### PR TITLE
build: fix build tags for go vet and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ lint-helm: ## Lint Helm charts
 	docker run --rm --workdir /workdir --volume "$(ROOT_DIR):/workdir" quay.io/helmpack/chart-testing:v3.8.0 ct lint --all
 
 GOTEST_OPTS := -failfast -timeout 30m -short
-GOTEST_OPTS += -tags="$(GO_BUILD_TAGS)"
+GOTEST_OPTS += $(BUILD_OPTS)
 ifeq ($(CI),true)
 	GOTEST_OPTS += -v
 endif
@@ -223,7 +223,7 @@ $(TESTGOMODULES):
 .PHONY: test
 test: $(TESTGOMODULES) ## Run Go unit tests
 
-GOVET_OPTS := -tags="$(GO_BUILD_TAGS)"
+GOVET_OPTS := $(BUILD_OPTS)
 VETGOMODULES = $(addprefix vet-, $(GOMODULES))
 
 $(VETGOMODULES):


### PR DESCRIPTION
## Description
Fix passing Go build tags properly for Make targets running `go vet` and `go test`.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
