### PR TITLE
fix: race condition in workflow

### DIFF
--- a/workflow/workflow_test.go
+++ b/workflow/workflow_test.go
@@ -168,8 +168,9 @@ func TestWorkflow(t *testing.T) {
 			},
 			State:                NewTestState(),
 			ExpectedErrorMatcher: Not(HaveOccurred()),
-			ExpectedOrderMatcher: BeEquivalentTo(
-				[]string{testTaskID1, testTaskID5, testTaskID2, testTaskID3, testTaskID4},
+			ExpectedOrderMatcher: SatisfyAny(
+				BeEquivalentTo([]string{testTaskID1, testTaskID5, testTaskID2, testTaskID3, testTaskID4}),
+				BeEquivalentTo([]string{testTaskID5, testTaskID1, testTaskID2, testTaskID3, testTaskID4}),
 			),
 		},
 		{
@@ -223,8 +224,9 @@ func TestWorkflow(t *testing.T) {
 			},
 			State:                NewTestState(),
 			ExpectedErrorMatcher: HaveOccurred(),
-			ExpectedOrderMatcher: BeEquivalentTo(
-				[]string{testTaskID1, testTaskID5, testTaskID2, testTaskID3},
+			ExpectedOrderMatcher: SatisfyAny(
+				BeEquivalentTo([]string{testTaskID1, testTaskID5, testTaskID2, testTaskID3}),
+				BeEquivalentTo([]string{testTaskID5, testTaskID1, testTaskID2, testTaskID3}),
 			),
 		},
 		{
@@ -279,8 +281,9 @@ func TestWorkflow(t *testing.T) {
 			State:                NewTestState(),
 			Timeout:              4 * time.Second,
 			ExpectedErrorMatcher: HaveOccurred(),
-			ExpectedOrderMatcher: BeEquivalentTo(
-				[]string{testTaskID1, testTaskID5, testTaskID2, testTaskID3},
+			ExpectedOrderMatcher: SatisfyAny(
+				BeEquivalentTo([]string{testTaskID1, testTaskID5, testTaskID2, testTaskID3}),
+				BeEquivalentTo([]string{testTaskID5, testTaskID1, testTaskID2, testTaskID3}),
 			),
 		},
 		{


### PR DESCRIPTION
## Description

Fix race condition where certain cases goroutine is able to send task update to closed channel. 

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
