### PR TITLE
refactor: Azure providerv2 with workflow

### DIFF
--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -245,6 +245,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.20.1 // indirect
+	github.com/heimdalr/dag v1.4.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
@@ -331,6 +332,7 @@ require (
 	github.com/openclarity/vmclarity/containerruntimediscovery/types v0.7.0 // indirect
 	github.com/openclarity/vmclarity/plugins/runner v0.7.0 // indirect
 	github.com/openclarity/vmclarity/plugins/sdk-go v0.7.0 // indirect
+	github.com/openclarity/vmclarity/workflow v0.0.0-20240529135718-9427f32382c0 // indirect
 	github.com/openclarity/yara-rule-server v0.3.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect

--- a/orchestrator/go.sum
+++ b/orchestrator/go.sum
@@ -1007,6 +1007,8 @@ github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
+github.com/heimdalr/dag v1.4.0 h1:zG3JA4RDVLc55k3AXAgfwa+EgBNZ0TkfOO3C29Ucpmg=
+github.com/heimdalr/dag v1.4.0/go.mod h1:OCh6ghKmU0hPjtwMqWBoNxPmtRioKd1xSu7Zs4sbIqM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
@@ -1286,6 +1288,8 @@ github.com/open-policy-agent/opa v0.64.1 h1:n8IJTYlFWzqiOYx+JiawbErVxiqAyXohovcZ
 github.com/open-policy-agent/opa v0.64.1/go.mod h1:j4VeLorVpKipnkQ2TDjWshEuV3cvP/rHzQhYaraUXZY=
 github.com/openclarity/grype-server/api v0.0.0-20240502131359-2f1a56ef9b22 h1:el6Lv08DBTBjbz+4nxlf8y49SlzrPdTfE+T0k+t7DsY=
 github.com/openclarity/grype-server/api v0.0.0-20240502131359-2f1a56ef9b22/go.mod h1:luXlVKVWmYNDzJKwKReCH268FlzELa2Q/iH6oAcxALE=
+github.com/openclarity/vmclarity/workflow v0.0.0-20240529135718-9427f32382c0 h1:xNe5taWaenvcEUTneuzQ5BQuu12YNCg2kUYaZHYxXcE=
+github.com/openclarity/vmclarity/workflow v0.0.0-20240529135718-9427f32382c0/go.mod h1:7XvhwnI/VNd1Cv4ZnUfqtqkVHFZvvuHbmlx7LuDrJr0=
 github.com/openclarity/yara-rule-server v0.3.0 h1:kXbiWASsx5W+MgfZ5jLTQKep9anSzdbk4ODWiCZ8cnA=
 github.com/openclarity/yara-rule-server v0.3.0/go.mod h1:2amH9uD0uFllsj5QViHf7y4F+yw1vJnaiYX1wfShFrs=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/provider/azure/option.go
+++ b/provider/azure/option.go
@@ -1,0 +1,50 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+type Option func(*Provider)
+
+type ScannerTaskOption Option
+
+func WithEnsureVMInfo(deps ...string) ScannerTaskOption {
+	return func(s *Provider) {
+		s.EnsureAssetVMInfo(deps)
+	}
+}
+
+func WithEnsureSnapshot(deps ...string) ScannerTaskOption {
+	return func(s *Provider) {
+		s.EnsureSnapshotWithCleanup(deps)
+	}
+}
+
+func WithEnsureDisk(deps ...string) ScannerTaskOption {
+	return func(s *Provider) {
+		s.EnsureDiskWithCleanup(deps)
+	}
+}
+
+func WithEnsureScannerVM(deps ...string) ScannerTaskOption {
+	return func(s *Provider) {
+		s.EnsureScannerVMWithCleanup(deps)
+	}
+}
+
+func WithEnsureAttachDiskToScannerVM(deps ...string) ScannerTaskOption {
+	return func(s *Provider) {
+		s.EnsureAttachDiskToScannerVM(deps)
+	}
+}

--- a/provider/azure/scanner/scanner.go
+++ b/provider/azure/scanner/scanner.go
@@ -58,84 +58,189 @@ type Scanner struct {
 	ScannerStorageContainerName string
 }
 
+type AssetScanState struct {
+	assetVM   armcompute.VirtualMachinesClientGetResponse
+	scannerVM armcompute.VirtualMachine
+	snapshot  armcompute.Snapshot
+	disk      armcompute.Disk
+}
+
 // nolint:cyclop
 func (s *Scanner) RunAssetScan(ctx context.Context, config *provider.ScanJobConfig) error {
-	vmInfo, err := config.AssetInfo.AsVMInfo()
-	if err != nil {
-		return provider.FatalErrorf("unable to get vminfo from asset: %w", err)
+	tasks := []*workflowTypes.Task[*AssetScanState]{
+		{
+			Name: "GetVMInfo",
+			Deps: nil,
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				vmInfo, err := config.AssetInfo.AsVMInfo()
+				if err != nil {
+					return provider.FatalErrorf("unable to get vminfo from asset: %w", err)
+				}
+
+				resourceGroup, vmName, err := resourceGroupAndNameFromInstanceID(vmInfo.InstanceID)
+				if err != nil {
+					return err
+				}
+
+				state.assetVM, err = s.VMClient.Get(ctx, resourceGroup, vmName, nil)
+				if err != nil {
+					_, err = utils.HandleAzureRequestError(err, "getting asset virtual machine %s", vmName)
+					return err
+				}
+
+				return nil
+			},
+		},
+		{
+			Name: "EnsureSnapshot",
+			Deps: []string{"GetVMInfo"},
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				var err error
+
+				state.snapshot, err = s.ensureSnapshotForVMRootVolume(ctx, config, state.assetVM.VirtualMachine)
+				if err != nil {
+					return fmt.Errorf("failed to ensure snapshot for vm root volume: %w", err)
+				}
+
+				return nil
+			},
+		},
+		{
+			Name: "EnsureDisk",
+			Deps: []string{"GetVMInfo", "EnsureSnapshot"},
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				var err error
+
+				if *state.assetVM.Location == s.ScannerLocation {
+					state.disk, err = s.ensureManagedDiskFromSnapshot(ctx, config, state.snapshot)
+					if err != nil {
+						return fmt.Errorf("failed to ensure managed disk created from snapshot: %w", err)
+					}
+				} else {
+					state.disk, err = s.ensureManagedDiskFromSnapshotInDifferentRegion(ctx, config, state.snapshot)
+					if err != nil {
+						return fmt.Errorf("failed to ensure managed disk from snapshot in different region: %w", err)
+					}
+				}
+
+				return nil
+			},
+		},
+		{
+			Name: "EnsureScannerVM",
+			Deps: []string{"EnsureDisk"},
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				networkInterface, err := s.ensureNetworkInterface(ctx, config)
+				if err != nil {
+					return fmt.Errorf("failed to ensure scanner network interface: %w", err)
+				}
+
+				state.scannerVM, err = s.ensureScannerVirtualMachine(ctx, config, networkInterface)
+				if err != nil {
+					return fmt.Errorf("failed to ensure scanner virtual machine: %w", err)
+				}
+
+				return nil
+			},
+		},
+		{
+			Name: "AttachDiskToScannerVM",
+			Deps: []string{"EnsureScannerVM", "EnsureDisk"},
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				err := s.ensureDiskAttachedToScannerVM(ctx, state.scannerVM, state.disk)
+				if err != nil {
+					return fmt.Errorf("failed to ensure asset disk is attached to virtual machine: %w", err)
+				}
+
+				return nil
+			},
+		},
 	}
 
-	resourceGroup, vmName, err := resourceGroupAndNameFromInstanceID(vmInfo.InstanceID)
+	workflow, err := workflow.New[*AssetScanState, *workflowTypes.Task[*AssetScanState]](tasks)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create RunAssetScan workflow: %w", err)
 	}
 
-	assetVM, err := s.VMClient.Get(ctx, resourceGroup, vmName, nil)
+	err = workflow.Run(ctx, &AssetScanState{})
 	if err != nil {
-		_, err = utils.HandleAzureRequestError(err, "getting asset virtual machine %s", vmName)
-		return err
-	}
-
-	snapshot, err := s.ensureSnapshotForVMRootVolume(ctx, config, assetVM.VirtualMachine)
-	if err != nil {
-		return fmt.Errorf("failed to ensure snapshot for vm root volume: %w", err)
-	}
-
-	var disk armcompute.Disk
-	if *assetVM.Location == s.ScannerLocation {
-		disk, err = s.ensureManagedDiskFromSnapshot(ctx, config, snapshot)
-		if err != nil {
-			return fmt.Errorf("failed to ensure managed disk created from snapshot: %w", err)
-		}
-	} else {
-		disk, err = s.ensureManagedDiskFromSnapshotInDifferentRegion(ctx, config, snapshot)
-		if err != nil {
-			return fmt.Errorf("failed to ensure managed disk from snapshot in different region: %w", err)
-		}
-	}
-
-	networkInterface, err := s.ensureNetworkInterface(ctx, config)
-	if err != nil {
-		return fmt.Errorf("failed to ensure scanner network interface: %w", err)
-	}
-
-	scannerVM, err := s.ensureScannerVirtualMachine(ctx, config, networkInterface)
-	if err != nil {
-		return fmt.Errorf("failed to ensure scanner virtual machine: %w", err)
-	}
-
-	err = s.ensureDiskAttachedToScannerVM(ctx, scannerVM, disk)
-	if err != nil {
-		return fmt.Errorf("failed to ensure asset disk is attached to virtual machine: %w", err)
+		return fmt.Errorf("failed to run RunAssetScan workflow: %w", err)
 	}
 
 	return nil
 }
 
 func (s *Scanner) RemoveAssetScan(ctx context.Context, config *provider.ScanJobConfig) error {
-	err := s.ensureScannerVirtualMachineDeleted(ctx, config)
-	if err != nil {
-		return fmt.Errorf("failed to ensure scanner virtual machine deleted: %w", err)
+	tasks := []*workflowTypes.Task[*AssetScanState]{
+		{
+			Name: "EnsureScannerVMDeleted",
+			Deps: nil,
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				err := s.ensureScannerVirtualMachineDeleted(ctx, config)
+				if err != nil {
+					return fmt.Errorf("failed to ensure scanner virtual machine deleted: %w", err)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "EnsureNetworkInterfaceDeleted",
+			Deps: nil, // []string{"EnsureScannerVMDeleted"},
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				err := s.ensureNetworkInterfaceDeleted(ctx, config)
+				if err != nil {
+					return fmt.Errorf("failed to ensure network interface deleted: %w", err)
+				}
+
+				return nil
+			},
+		},
+		{
+			Name: "EnsureTargetDiskDeleted",
+			Deps: nil, // []string{"EnsureNetworkInterfaceDeleted"},
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				err := s.ensureTargetDiskDeleted(ctx, config)
+				if err != nil {
+					return fmt.Errorf("failed to ensure asset disk deleted: %w", err)
+				}
+
+				return nil
+			},
+		},
+		{
+			Name: "EnsureBlobDeleted",
+			Deps: nil, // []string{"EnsureTargetDiskDeleted"},
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				err := s.ensureBlobDeleted(ctx, config)
+				if err != nil {
+					return fmt.Errorf("failed to ensure snapshot copy blob deleted: %w", err)
+				}
+
+				return nil
+			},
+		},
+		{
+			Name: "EnsureSnapshotDeleted",
+			Deps: nil, // []string{"EnsureBlobDeleted"},
+			Fn: func(ctx context.Context, state *AssetScanState) error {
+				err := s.ensureSnapshotDeleted(ctx, config)
+				if err != nil {
+					return fmt.Errorf("failed to ensure snapshot deleted: %w", err)
+				}
+
+				return nil
+			},
+		},
 	}
 
-	err = s.ensureNetworkInterfaceDeleted(ctx, config)
+	workflow, err := workflow.New[*AssetScanState, *workflowTypes.Task[*AssetScanState]](tasks)
 	if err != nil {
-		return fmt.Errorf("failed to ensure network interface deleted: %w", err)
+		return fmt.Errorf("failed to create RemoveAssetScan workflow: %w", err)
 	}
 
-	err = s.ensureTargetDiskDeleted(ctx, config)
+	err = workflow.Run(ctx, &AssetScanState{})
 	if err != nil {
-		return fmt.Errorf("failed to ensure asset disk deleted: %w", err)
-	}
-
-	err = s.ensureBlobDeleted(ctx, config)
-	if err != nil {
-		return fmt.Errorf("failed to ensure snapshot copy blob deleted: %w", err)
-	}
-
-	err = s.ensureSnapshotDeleted(ctx, config)
-	if err != nil {
-		return fmt.Errorf("failed to ensure snapshot deleted: %w", err)
+		return fmt.Errorf("failed to run RemoveAssetScan workflow: %w", err)
 	}
 
 	return nil

--- a/provider/azure/scanner/task.go
+++ b/provider/azure/scanner/task.go
@@ -1,0 +1,298 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// nolint:wrapcheck
+package scanner
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
+
+	"github.com/openclarity/vmclarity/provider"
+	"github.com/openclarity/vmclarity/provider/azure/utils"
+	workflowTypes "github.com/openclarity/vmclarity/workflow/types"
+)
+
+const (
+	EnsureAssetVMInfoTaskName     = "EnsureVMInfo"
+	EnsureSnapshotTaskName        = "EnsureSnapshot"
+	EnsureDiskTaskName            = "EnsureDisk"
+	EnsureScannerVMTaskName       = "EnsureScannerVM"
+	AttachDiskToScannerVMTaskName = "AttachDiskToScannerVM"
+
+	EnsureBlobDeletedTaskName             = "EnsureBlobDeleted"
+	EnsureSnapshotDeletedTaskName         = "EnsureSnapshotDeleted"
+	EnsureTargetDiskDeletedTaskName       = "EnsureTargetDiskDeleted"
+	EnsureScannerVMDeletedTaskName        = "EnsureScannerVMDeleted"
+	EnsureNetworkInterfaceDeletedTaskName = "EnsureNetworkInterfaceDeleted"
+)
+
+type AssetScanState struct {
+	config *provider.ScanJobConfig
+	mu     *sync.RWMutex
+
+	assetVM   armcompute.VirtualMachinesClientGetResponse
+	scannerVM armcompute.VirtualMachine
+	snapshot  armcompute.Snapshot
+	disk      armcompute.Disk
+}
+
+func (s *AssetScanState) AddAssetVM(assetVM armcompute.VirtualMachinesClientGetResponse) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.assetVM = assetVM
+}
+
+func (s *AssetScanState) AddScannerVM(scannerVM armcompute.VirtualMachine) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.scannerVM = scannerVM
+}
+
+func (s *AssetScanState) AddSnapshot(snapshot armcompute.Snapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.snapshot = snapshot
+}
+
+func (s *AssetScanState) AddDisk(disk armcompute.Disk) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.disk = disk
+}
+
+// Ensures that the virtual machine information is available in the workflow's state.
+func (s *Scanner) EnsureAssetVMInfo(deps []string) {
+	s.RunAssetScanTasks = append(s.RunAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: EnsureAssetVMInfoTaskName,
+		Deps: deps,
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			vmInfo, err := state.config.AssetInfo.AsVMInfo()
+			if err != nil {
+				return provider.FatalErrorf("unable to get vminfo from asset: %w", err)
+			}
+
+			resourceGroup, vmName, err := resourceGroupAndNameFromInstanceID(vmInfo.InstanceID)
+			if err != nil {
+				return err
+			}
+
+			assetVM, err := s.VMClient.Get(ctx, resourceGroup, vmName, nil)
+			if err != nil {
+				_, err = utils.HandleAzureRequestError(err, "getting asset virtual machine %s", vmName)
+				return err
+			}
+
+			state.AddAssetVM(assetVM)
+
+			return nil
+		},
+	})
+}
+
+// Ensures that a snapshot is created for the asset virtual machine's root volume,
+// and that the snapshot is deleted after the workflow has completed.
+func (s *Scanner) EnsureSnapshotWithCleanup(deps []string) {
+	s.RunAssetScanTasks = append(s.RunAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: EnsureSnapshotTaskName,
+		Deps: deps,
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			if reflect.DeepEqual(state.assetVM.VirtualMachine, armcompute.VirtualMachine{}) {
+				return provider.FatalErrorf("assetVM is not available in the AssetScanState")
+			}
+
+			snapshot, err := s.ensureSnapshotForVMRootVolume(ctx, state.config, state.assetVM.VirtualMachine)
+			if err != nil {
+				return fmt.Errorf("failed to ensure snapshot for vm root volume: %w", err)
+			}
+
+			state.AddSnapshot(snapshot)
+
+			return nil
+		},
+	})
+
+	s.RemoveAssetScanTasks = append(s.RemoveAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: EnsureSnapshotDeletedTaskName,
+		Deps: nil,
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			err := s.ensureSnapshotDeleted(ctx, state.config)
+			if err != nil {
+				return fmt.Errorf("failed to ensure snapshot deleted: %w", err)
+			}
+
+			return nil
+		},
+	})
+}
+
+// Ensures that a managed disk is created from the snapshot,
+// and that the disk and the copied blob is deleted after the workflow has completed.
+func (s *Scanner) EnsureDiskWithCleanup(deps []string) {
+	s.RunAssetScanTasks = append(s.RunAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: EnsureDiskTaskName,
+		Deps: deps,
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			var disk armcompute.Disk
+			var err error
+
+			if reflect.DeepEqual(state.assetVM.VirtualMachine, armcompute.VirtualMachine{}) {
+				return provider.FatalErrorf("assetVM is not available in the AssetScanState")
+			}
+
+			if reflect.DeepEqual(state.snapshot, armcompute.Snapshot{}) {
+				return provider.FatalErrorf("snapshot is not available in the AssetScanState")
+			}
+
+			if *state.assetVM.Location == s.ScannerLocation {
+				disk, err = s.ensureManagedDiskFromSnapshot(ctx, state.config, state.snapshot)
+				if err != nil {
+					return fmt.Errorf("failed to ensure managed disk created from snapshot: %w", err)
+				}
+			} else {
+				disk, err = s.ensureManagedDiskFromSnapshotInDifferentRegion(ctx, state.config, state.snapshot)
+				if err != nil {
+					return fmt.Errorf("failed to ensure managed disk from snapshot in different region: %w", err)
+				}
+			}
+
+			state.AddDisk(disk)
+
+			return nil
+		},
+	})
+
+	s.RemoveAssetScanTasks = append(s.RemoveAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: EnsureTargetDiskDeletedTaskName,
+		Deps: []string{EnsureScannerVMDeletedTaskName},
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			err := s.ensureTargetDiskDeleted(ctx, state.config)
+			if err != nil {
+				return fmt.Errorf("failed to ensure asset disk deleted: %w", err)
+			}
+
+			return nil
+		},
+	})
+
+	// In case of cross-region snapshot, we need to ensure the copied blob is deleted as well.
+	s.RemoveAssetScanTasks = append(s.RemoveAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: EnsureBlobDeletedTaskName,
+		Deps: nil,
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			err := s.ensureBlobDeleted(ctx, state.config)
+			if err != nil {
+				return fmt.Errorf("failed to ensure snapshot copy blob deleted: %w", err)
+			}
+
+			return nil
+		},
+	})
+}
+
+// Ensures that a network interface and the scanner virtual machine is created,
+// and that the network interface and the scanner virtual machine are deleted after the workflow has completed.
+func (s *Scanner) EnsureScannerVMWithCleanup(deps []string) {
+	s.RunAssetScanTasks = append(s.RunAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: EnsureScannerVMTaskName,
+		Deps: deps,
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			networkInterface, err := s.ensureNetworkInterface(ctx, state.config)
+			if err != nil {
+				return fmt.Errorf("failed to ensure scanner network interface: %w", err)
+			}
+
+			scannerVM, err := s.ensureScannerVirtualMachine(ctx, state.config, networkInterface)
+			if err != nil {
+				return fmt.Errorf("failed to ensure scanner virtual machine: %w", err)
+			}
+
+			state.AddScannerVM(scannerVM)
+
+			return nil
+		},
+	})
+
+	s.RemoveAssetScanTasks = append(s.RemoveAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: EnsureScannerVMDeletedTaskName,
+		Deps: nil,
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			err := s.ensureScannerVirtualMachineDeleted(ctx, state.config)
+			if err != nil {
+				return fmt.Errorf("failed to ensure scanner virtual machine deleted: %w", err)
+			}
+			return nil
+		},
+	})
+
+	s.RemoveAssetScanTasks = append(s.RemoveAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: EnsureNetworkInterfaceDeletedTaskName,
+		Deps: []string{EnsureScannerVMDeletedTaskName},
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			err := s.ensureNetworkInterfaceDeleted(ctx, state.config)
+			if err != nil {
+				return fmt.Errorf("failed to ensure network interface deleted: %w", err)
+			}
+
+			return nil
+		},
+	})
+}
+
+// Ensures that the asset disk is attached to the scanner virtual machine.
+func (s *Scanner) EnsureAttachDiskToScannerVM(deps []string) {
+	s.RunAssetScanTasks = append(s.RunAssetScanTasks, &workflowTypes.Task[*AssetScanState]{
+		Name: AttachDiskToScannerVMTaskName,
+		Deps: deps,
+		Fn: func(ctx context.Context, state *AssetScanState) error {
+			if reflect.DeepEqual(state.assetVM.VirtualMachine, armcompute.VirtualMachine{}) {
+				return provider.FatalErrorf("assetVM is not available in the AssetScanState")
+			}
+
+			if reflect.DeepEqual(state.disk, armcompute.Disk{}) {
+				return provider.FatalErrorf("disk is not available in the AssetScanState")
+			}
+
+			err := s.ensureDiskAttachedToScannerVM(ctx, state.scannerVM, state.disk)
+			if err != nil {
+				return fmt.Errorf("failed to ensure asset disk is attached to virtual machine: %w", err)
+			}
+
+			return nil
+		},
+	})
+}
+
+// Example Instance ID:
+//
+// /subscriptions/ecad88af-09d5-4725-8d80-906e51fddf02/resourceGroups/vmclarity-sambetts-dev/providers/Microsoft.Compute/virtualMachines/vmclarity-server
+//
+// Will return "vmclarity-sambetts-dev" and "vmclarity-server".
+func resourceGroupAndNameFromInstanceID(instanceID string) (string, string, error) {
+	idParts := strings.Split(instanceID, "/")
+	if len(idParts) != instanceIDPartsLength {
+		return "", "", provider.FatalErrorf("asset instance id in unexpected format got: %s", idParts)
+	}
+	return idParts[resourceGroupPartIdx], idParts[vmNamePartIdx], nil
+}

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/openclarity/vmclarity/containerruntimediscovery/types v0.7.0
 	github.com/openclarity/vmclarity/core v0.7.0
 	github.com/openclarity/vmclarity/scanner v0.7.0
+	github.com/openclarity/vmclarity/workflow v0.0.0-20240529135718-9427f32382c0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
 	golang.org/x/sync v0.7.0
@@ -249,6 +250,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.20.1 // indirect
+	github.com/heimdalr/dag v1.4.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -975,6 +975,8 @@ github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/hashicorp/serf v0.9.5/go.mod h1:UWDWwZeL5cuWDJdl0C6wrvrUwEqtQ4ZKBKKENpqIUyk=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
+github.com/heimdalr/dag v1.4.0 h1:zG3JA4RDVLc55k3AXAgfwa+EgBNZ0TkfOO3C29Ucpmg=
+github.com/heimdalr/dag v1.4.0/go.mod h1:OCh6ghKmU0hPjtwMqWBoNxPmtRioKd1xSu7Zs4sbIqM=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -1240,6 +1242,8 @@ github.com/open-policy-agent/opa v0.64.1 h1:n8IJTYlFWzqiOYx+JiawbErVxiqAyXohovcZ
 github.com/open-policy-agent/opa v0.64.1/go.mod h1:j4VeLorVpKipnkQ2TDjWshEuV3cvP/rHzQhYaraUXZY=
 github.com/openclarity/grype-server/api v0.0.0-20240502131359-2f1a56ef9b22 h1:el6Lv08DBTBjbz+4nxlf8y49SlzrPdTfE+T0k+t7DsY=
 github.com/openclarity/grype-server/api v0.0.0-20240502131359-2f1a56ef9b22/go.mod h1:luXlVKVWmYNDzJKwKReCH268FlzELa2Q/iH6oAcxALE=
+github.com/openclarity/vmclarity/workflow v0.0.0-20240529135718-9427f32382c0 h1:xNe5taWaenvcEUTneuzQ5BQuu12YNCg2kUYaZHYxXcE=
+github.com/openclarity/vmclarity/workflow v0.0.0-20240529135718-9427f32382c0/go.mod h1:7XvhwnI/VNd1Cv4ZnUfqtqkVHFZvvuHbmlx7LuDrJr0=
 github.com/openclarity/yara-rule-server v0.3.0 h1:kXbiWASsx5W+MgfZ5jLTQKep9anSzdbk4ODWiCZ8cnA=
 github.com/openclarity/yara-rule-server v0.3.0/go.mod h1:2amH9uD0uFllsj5QViHf7y4F+yw1vJnaiYX1wfShFrs=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=


### PR DESCRIPTION
## Description

WIP

On the tasks front it needs some more refactoring, i.e. RemoveAssetScan tasks could be defined on their own so their dependencies could be configured independently etc.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[X] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
