### PR TITLE
fix: cli after bumping syft to v1

### DIFF
--- a/cli/analyzer/syft/syft.go
+++ b/cli/analyzer/syft/syft.go
@@ -60,13 +60,10 @@ func (a *Analyzer) Run(sourceType utils.SourceType, userInput string) error {
 	a.logger.Infof("Called %s analyzer on source %s", a.name, src)
 	// TODO platform can be defined
 	// https://github.com/anchore/syft/blob/b20310eaf847c259beb4fe5128c842bd8aa4d4fc/cmd/syft/cli/options/packages.go#L48
-	detection, err := syftsrc.Detect(src, syftsrc.DefaultDetectConfig())
-	if err != nil {
-		return fmt.Errorf("failed to create input from source analyzer=%s: %w", a.name, err)
-	}
-	source, err := detection.NewSource(syftsrc.DetectionSourceConfig{
-		RegistryOptions: a.config.RegistryOptions,
-	})
+
+	cfg := syft.DefaultGetSourceConfig().WithRegistryOptions(a.config.RegistryOptions)
+
+	source, err := syft.GetSource(context.TODO(), src, cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create source analyzer=%s: %w", a.name, err)
 	}
@@ -117,7 +114,7 @@ func (a *Analyzer) setError(res *analyzer.Results, err error) {
 
 func getImageHash(s *syftsbom.SBOM, src string) (string, error) {
 	switch metadata := s.Source.Metadata.(type) {
-	case syftsrc.StereoscopeImageSourceMetadata:
+	case syftsrc.ImageMetadata:
 		hash, err := image_helper.GetHashFromRepoDigestsOrImageID(metadata.RepoDigests, metadata.ID, src)
 		if err != nil {
 			return "", fmt.Errorf("failed to get image hash from repo digests or image id: %w", err)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/CycloneDX/cyclonedx-go v0.8.0
 	github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe
 	github.com/anchore/clio v0.0.0-20240209204744-cb94e40a4f65
-	github.com/anchore/grype v0.74.7
+	github.com/anchore/grype v0.74.8-0.20240301184948-8e7f5cf85a8d
 	github.com/anchore/stereoscope v0.0.2-0.20240221144950-cf0e754f5b56
 	github.com/anchore/syft v1.0.0
 	github.com/aquasecurity/go-dep-parser v0.0.0-20240213093706-423cd04548a5

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -305,8 +305,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype v0.74.7 h1:mGqLPqFazUVxv18ryhPJ9Vlt9Wm66fItmnaERwehfp8=
-github.com/anchore/grype v0.74.7/go.mod h1:ZrmJ4x96uNhibWoc3UAzPa3zMKClVSPH7JBGZC2rVzY=
+github.com/anchore/grype v0.74.8-0.20240301184948-8e7f5cf85a8d h1:Xa791cy2qo1T3icyZ2gCjwGiLAvNppbnF7904YL2i3M=
+github.com/anchore/grype v0.74.8-0.20240301184948-8e7f5cf85a8d/go.mod h1:qvmw/w13pra5dLxxANXse2F0ZyzfKwOEuGG1nieZDF0=
 github.com/anchore/packageurl-go v0.1.1-0.20240202171727-877e1747d426 h1:agoiZchSf1Nnnos1azwIg5hk5Ao9TzZNBD9++AChGEg=
 github.com/anchore/packageurl-go v0.1.1-0.20240202171727-877e1747d426/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/stereoscope v0.0.2-0.20240221144950-cf0e754f5b56 h1:iHvTXZA+qEozPGRRuW1Mv7r7w2fHeJdzWDx+YsSIbyg=

--- a/cli/scanner/grype/common.go
+++ b/cli/scanner/grype/common.go
@@ -109,8 +109,8 @@ func getSource(doc grype_models.Document, userInput, hash string) scanner.Source
 
 	var srcName string
 	switch doc.Source.Target.(type) {
-	case syft_source.StereoscopeImageSourceMetadata:
-		imageMetadata := doc.Source.Target.(syft_source.StereoscopeImageSourceMetadata) // nolint:forcetypeassert
+	case syft_source.ImageMetadata:
+		imageMetadata := doc.Source.Target.(syft_source.ImageMetadata) // nolint:forcetypeassert
 		srcName = imageMetadata.UserInput
 		// If the userInput is a SBOM, the srcName and hash will be got from the SBOM.
 		if srcName == "" {

--- a/cli/scanner/grype/common_test.go
+++ b/cli/scanner/grype/common_test.go
@@ -39,7 +39,7 @@ func TestCreateResults(t *testing.T) {
 	// set StereoscopeImageSourceMetadata type as Target
 	marshalTarget, err := json.Marshal(doc.Source.Target)
 	assert.NilError(t, err)
-	var imageSourceMetadata syft_source.StereoscopeImageSourceMetadata
+	var imageSourceMetadata syft_source.ImageMetadata
 	assert.NilError(t, json.Unmarshal(marshalTarget, &imageSourceMetadata))
 	doc.Source.Target = imageSourceMetadata
 
@@ -90,7 +90,7 @@ func Test_getSource(t *testing.T) {
 	// set StereoscopeImageSourceMetadata type as Target
 	marshalTarget, err := json.Marshal(doc.Source.Target)
 	assert.NilError(t, err)
-	var imageSourceMetadata syft_source.StereoscopeImageSourceMetadata
+	var imageSourceMetadata syft_source.ImageMetadata
 	assert.NilError(t, json.Unmarshal(marshalTarget, &imageSourceMetadata))
 	doc.Source.Target = imageSourceMetadata
 
@@ -105,7 +105,7 @@ func Test_getSource(t *testing.T) {
 	}
 
 	// empty imageMetadata for SBOM input
-	sbomDoc.Source.Target = syft_source.StereoscopeImageSourceMetadata{}
+	sbomDoc.Source.Target = syft_source.ImageMetadata{}
 	// string for other input
 	otherDoc.Source.Target = "test"
 

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb // indirect
 	github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 // indirect
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 // indirect
-	github.com/anchore/grype v0.74.7 // indirect
+	github.com/anchore/grype v0.74.8-0.20240301184948-8e7f5cf85a8d // indirect
 	github.com/anchore/packageurl-go v0.1.1-0.20240202171727-877e1747d426 // indirect
 	github.com/anchore/stereoscope v0.0.2-0.20240221144950-cf0e754f5b56 // indirect
 	github.com/andybalholm/brotli v1.0.5 // indirect

--- a/orchestrator/go.sum
+++ b/orchestrator/go.sum
@@ -326,8 +326,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype v0.74.7 h1:mGqLPqFazUVxv18ryhPJ9Vlt9Wm66fItmnaERwehfp8=
-github.com/anchore/grype v0.74.7/go.mod h1:ZrmJ4x96uNhibWoc3UAzPa3zMKClVSPH7JBGZC2rVzY=
+github.com/anchore/grype v0.74.8-0.20240301184948-8e7f5cf85a8d h1:Xa791cy2qo1T3icyZ2gCjwGiLAvNppbnF7904YL2i3M=
+github.com/anchore/grype v0.74.8-0.20240301184948-8e7f5cf85a8d/go.mod h1:qvmw/w13pra5dLxxANXse2F0ZyzfKwOEuGG1nieZDF0=
 github.com/anchore/packageurl-go v0.1.1-0.20240202171727-877e1747d426 h1:agoiZchSf1Nnnos1azwIg5hk5Ao9TzZNBD9++AChGEg=
 github.com/anchore/packageurl-go v0.1.1-0.20240202171727-877e1747d426/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/stereoscope v0.0.2-0.20240221144950-cf0e754f5b56 h1:iHvTXZA+qEozPGRRuW1Mv7r7w2fHeJdzWDx+YsSIbyg=

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/anchore/go-macholibre v0.0.0-20220308212642-53e6d0aaf6fb // indirect
 	github.com/anchore/go-struct-converter v0.0.0-20221118182256-c68fdcfa2092 // indirect
 	github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 // indirect
-	github.com/anchore/grype v0.74.7 // indirect
+	github.com/anchore/grype v0.74.8-0.20240301184948-8e7f5cf85a8d // indirect
 	github.com/anchore/packageurl-go v0.1.1-0.20240202171727-877e1747d426 // indirect
 	github.com/anchore/stereoscope v0.0.2-0.20240221144950-cf0e754f5b56 // indirect
 	github.com/anchore/syft v1.0.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -319,8 +319,8 @@ github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04 h1:VzprUTpc0v
 github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04/go.mod h1:6dK64g27Qi1qGQZ67gFmBFvEHScy0/C8qhQhNe5B5pQ=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4 h1:rmZG77uXgE+o2gozGEBoUMpX27lsku+xrMwlmBZJtbg=
 github.com/anchore/go-version v1.2.2-0.20210903204242-51efa5b487c4/go.mod h1:Bkc+JYWjMCF8OyZ340IMSIi2Ebf3uwByOk6ho4wne1E=
-github.com/anchore/grype v0.74.7 h1:mGqLPqFazUVxv18ryhPJ9Vlt9Wm66fItmnaERwehfp8=
-github.com/anchore/grype v0.74.7/go.mod h1:ZrmJ4x96uNhibWoc3UAzPa3zMKClVSPH7JBGZC2rVzY=
+github.com/anchore/grype v0.74.8-0.20240301184948-8e7f5cf85a8d h1:Xa791cy2qo1T3icyZ2gCjwGiLAvNppbnF7904YL2i3M=
+github.com/anchore/grype v0.74.8-0.20240301184948-8e7f5cf85a8d/go.mod h1:qvmw/w13pra5dLxxANXse2F0ZyzfKwOEuGG1nieZDF0=
 github.com/anchore/packageurl-go v0.1.1-0.20240202171727-877e1747d426 h1:agoiZchSf1Nnnos1azwIg5hk5Ao9TzZNBD9++AChGEg=
 github.com/anchore/packageurl-go v0.1.1-0.20240202171727-877e1747d426/go.mod h1:Blo6OgJNiYF41ufcgHKkbCKF2MDOMlrqhXv/ij6ocR4=
 github.com/anchore/stereoscope v0.0.2-0.20240221144950-cf0e754f5b56 h1:iHvTXZA+qEozPGRRuW1Mv7r7w2fHeJdzWDx+YsSIbyg=


### PR DESCRIPTION
## Description
The `https://github.com/anchore/syft` v1 introduced breaking changes which required code updates in `cli` module and bumping `https://github.com/anchore/grype` to latest `main` which is compatible with the latest version of `syft`. 

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
