### PR TITLE
ci: add Make targets for fixing Renovate updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,13 @@ GOMODULES := $(shell find $(ROOT_DIR) -name 'go.mod' -exec dirname {} \;)
 BUILD_TIMESTAMP := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 COMMIT_HASH := $(shell git rev-parse HEAD)
 INSTALLATION_DIR := $(ROOT_DIR)/installation
-HELM_CHART_DIR := $(INSTALLATION_DIR)/kubernetes/helm
+HELM_CHART_DIR := $(INSTALLATION_DIR)/kubernetes/helm/vmclarity
 HELM_OCI_REPOSITORY := ghcr.io/openclarity/charts
 DIST_DIR ?= $(ROOT_DIR)/dist
 BICEP_DIR := $(INSTALLATION_DIR)/azure
+CFN_DIR := $(INSTALLATION_DIR)/aws
+DOCKER_COMPOSE_DIR := $(INSTALLATION_DIR)/docker
+GCP_DM_DIR := $(INSTALLATION_DIR)/gcp/dm
 
 ####
 ## Load additional makefiles
@@ -356,7 +359,6 @@ $(DIST_DIR)/%/LICENSE: $(ROOT_DIR)/LICENSE
 $(DIST_DIR)/%/README.md: $(ROOT_DIR)/README.md
 	cp -v $< $@
 
-CFN_DIR := $(INSTALLATION_DIR)/aws
 CFN_FILES := $(shell find $(CFN_DIR))
 CFN_DIST_DIR := $(DIST_DIR)/cloudformation
 
@@ -404,7 +406,6 @@ $(BICEP_DIST_DIR)/LICENSE: $(ROOT_DIR)/LICENSE | $(BICEP_DIST_DIR)
 $(BICEP_DIST_DIR):
 	@mkdir -p $@
 
-DOCKER_COMPOSE_DIR := $(INSTALLATION_DIR)/docker
 DOCKER_COMPOSE_FILES := $(shell find $(DOCKER_COMPOSE_DIR))
 DOCKER_COMPOSE_DIST_DIR := $(DIST_DIR)/docker-compose
 
@@ -429,7 +430,6 @@ $(DOCKER_COMPOSE_DIST_DIR)/LICENSE: $(ROOT_DIR)/LICENSE | $(DOCKER_COMPOSE_DIST_
 $(DOCKER_COMPOSE_DIST_DIR):
 	@mkdir -p $@
 
-GCP_DM_DIR := $(INSTALLATION_DIR)/gcp/dm
 GCP_DM_FILES := $(shell find $(GCP_DM_DIR))
 GCP_DM_DIST_DIR := $(DIST_DIR)/gcp-deployment
 
@@ -453,7 +453,6 @@ $(GCP_DM_DIST_DIR)/LICENSE: $(ROOT_DIR)/LICENSE | $(GCP_DM_DIST_DIR)
 $(GCP_DM_DIST_DIR):
 	@mkdir -p $@
 
-HELM_CHART_DIR := $(INSTALLATION_DIR)/kubernetes/helm/vmclarity
 HELM_CHART_FILES := $(shell find $(HELM_CHART_DIR))
 HELM_CHART_DIST_DIR := $(DIST_DIR)/helm-vmclarity-chart
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ INSTALLATION_DIR := $(ROOT_DIR)/installation
 HELM_CHART_DIR := $(INSTALLATION_DIR)/kubernetes/helm
 HELM_OCI_REPOSITORY := ghcr.io/openclarity/charts
 DIST_DIR ?= $(ROOT_DIR)/dist
-BICEP_DIR := $(INSTALLATION_DIR)/azure/vmclarity
+BICEP_DIR := $(INSTALLATION_DIR)/azure
 
 ####
 ## Load additional makefiles
@@ -380,7 +380,6 @@ $(CFN_DIST_DIR)/LICENSE: $(ROOT_DIR)/LICENSE | $(CFN_DIST_DIR)
 $(CFN_DIST_DIR):
 	@mkdir -p $@
 
-BICEP_DIR := $(INSTALLATION_DIR)/azure
 BICEP_FILES := $(shell find $(BICEP_DIR))
 BICEP_DIST_DIR := $(DIST_DIR)/bicep
 


### PR DESCRIPTION
## Description

Extend Makefile with targets for fixing Renovate version updates by running post update steps.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
