### PR TITLE
fix: Nil pointer error if `ContainerImageInfo.Id` field is not set

### DIFF
--- a/api/server/database/gorm/asset.go
+++ b/api/server/database/gorm/asset.go
@@ -292,6 +292,12 @@ func (t *AssetsTableHandler) checkUniqueness(asset types.Asset) (*types.Asset, e
 		return nil, fmt.Errorf("failed to get value by discriminator: %w", err)
 	}
 
+	if asset.Id == nil || *asset.Id == "" {
+		return &types.Asset{}, &common.BadRequestError{
+			Reason: "asset ID is required",
+		}
+	}
+
 	var filter string
 	switch info := discriminator.(type) {
 	case types.VMInfo:


### PR DESCRIPTION
## Description

- Added a check if `asset.Id` is nil or empty, a 400 bad request error is returned.

Fixes: #707

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
