### PR TITLE
refactor(gcp): add healthcheck to GCP installer

### DIFF
--- a/installation/gcp/dm/components/vmclarity-install.sh
+++ b/installation/gcp/dm/components/vmclarity-install.sh
@@ -148,6 +148,10 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8081/healthz/ready || exit 1
+      interval: 10s
+      retries: 60
 
   orchestrator:
     image: {OrchestratorContainerImage}
@@ -163,6 +167,10 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8082/healthz/ready || exit 1
+      interval: 10s
+      retries: 60
 
   ui:
     image: {UIContainerImage}
@@ -188,6 +196,10 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8083/healthz/ready || exit 1
+      interval: 10s
+      retries: 60
 
   gateway:
     image: nginx
@@ -219,6 +231,10 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "1326"]
+      interval: 10s
+      retries: 60
 
   trivy-server:
     image: {TrivyServerContainerImage}
@@ -238,6 +254,10 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
+    healthcheck:
+      test: ["CMD", "nc", "-z", "127.0.0.1", "9992"]
+      interval: 10s
+      retries: 60
 
   grype-server:
     image: {GrypeServerContainerImage}
@@ -258,6 +278,10 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
+    healthcheck:
+      test: wget --no-verbose --tries=10 --spider http://127.0.0.1:8080/healthz/ready || exit 1
+      interval: 10s
+      retries: 60
 
   freshclam-mirror:
     image: {FreshclamMirrorContainerImage}
@@ -291,6 +315,10 @@ services:
       replicas: 1
       restart_policy:
         condition: on-failure
+    healthcheck:
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8082/healthz/ready || exit 1
+      interval: 10s
+      retries: 60
 
   postgresql:
     image: {PostgresqlContainerImage}


### PR DESCRIPTION
## Description

This PR adds healthchecks to the docker containers that spin up when the system is installed on GCP.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
