### PR TITLE
feat(cli): add OS signal handling

### DIFF
--- a/cli/cmd/root/root.go
+++ b/cli/cmd/root/root.go
@@ -16,7 +16,10 @@
 package root
 
 import (
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -40,7 +43,14 @@ var rootCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	cobra.CheckErr(rootCmd.Execute())
+	// Create os.Signal aware context.Context which will trigger context cancellation
+	// upon receiving any of the listed signals.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGHUP, syscall.SIGTERM)
+	defer func() {
+		cancel()
+	}()
+
+	cobra.CheckErr(rootCmd.ExecuteContext(ctx))
 }
 
 // nolint: gochecknoinits


### PR DESCRIPTION
## Description

Add OS signal handling to `cli` so process shutdown triggered by  SIGINT, SIGHUP, etc are handled gracefully.
## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
