### PR TITLE
ci: mv runner disk cleanup before cache restore

### DIFF
--- a/.github/workflows/reusable-end-to-end-testing.yml
+++ b/.github/workflows/reusable-end-to-end-testing.yml
@@ -70,6 +70,24 @@ jobs:
           cache: false
           go-version-file: '.go-version'
 
+      - name: Free up disk space
+        run: |
+          df -h
+
+          # Remove .NET related tooling
+          sudo du -sh /usr/share/dotnet
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Android related tooling
+          sudo du -sh /usr/local/lib/android
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove CodeQL
+          sudo du -sh /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          df -h
+
       - name: Setup Go caching
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
@@ -80,24 +98,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ github.ref_name }}-
             ${{ runner.os }}-go-${{ github.event.repository.default_branch }}-
-
-      - name: Free up disk space
-        run: |
-          df -h
-          
-          # Remove .NET related tooling
-          sudo du -sh /usr/share/dotnet
-          sudo rm -rf /usr/share/dotnet
-          
-          # Remove Android related tooling
-          sudo du -sh /usr/local/lib/android
-          sudo rm -rf /usr/local/lib/android
-          
-          # Remove CodeQL
-          sudo du -sh /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          
-          df -h
 
       - name: Run end to end tests
         env:

--- a/.github/workflows/reusable-verification.yml
+++ b/.github/workflows/reusable-verification.yml
@@ -96,6 +96,24 @@ jobs:
           cache: false
           go-version-file: '.go-version'
 
+      - name: Free up disk space
+        run: |
+          df -h
+
+          # Remove .NET related tooling
+          sudo du -sh /usr/share/dotnet
+          sudo rm -rf /usr/share/dotnet
+
+          # Remove Android related tooling
+          sudo du -sh /usr/local/lib/android
+          sudo rm -rf /usr/local/lib/android
+
+          # Remove CodeQL
+          sudo du -sh /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          df -h
+
       - name: Setup Go caching
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
@@ -106,24 +124,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-${{ github.ref_name }}-
             ${{ runner.os }}-go-${{ github.event.repository.default_branch }}-
-
-      - name: Free up disk space
-        run: |
-          df -h
-          
-          # Remove .NET related tooling
-          sudo du -sh /usr/share/dotnet
-          sudo rm -rf /usr/share/dotnet
-          
-          # Remove Android related tooling
-          sudo du -sh /usr/local/lib/android
-          sudo rm -rf /usr/local/lib/android
-          
-          # Remove CodeQL
-          sudo du -sh /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          
-          df -h
 
       - name: Verify APIs
         run: |


### PR DESCRIPTION
## Description

Move runner disk cleanup before restoring go cache.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
