### PR TITLE
fix: error returned by mount

### DIFF
--- a/utils/fsutils/mount/unix.go
+++ b/utils/fsutils/mount/unix.go
@@ -101,7 +101,7 @@ type MountError struct {
 	Msg  string
 }
 
-func (e MountError) Error() string {
+func (e *MountError) Error() string {
 	if e.Msg != "" {
 		return fmt.Sprintf("%s: %s", e.Kind, e.Msg)
 	}
@@ -109,8 +109,8 @@ func (e MountError) Error() string {
 	return e.Kind.String()
 }
 
-func NewMountError(errCode int, errMsg string) MountError {
-	return MountError{
+func NewMountError(errCode int, errMsg string) *MountError {
+	return &MountError{
 		Kind: NewMountErrorKind(errCode),
 		Msg:  errMsg,
 	}


### PR DESCRIPTION
## Description

Fix custom `error` returned by `mount.Mount` and `mount.Umount` functions in `utils/fsutils/mount` pkg which returned the `error` by value instead of pointer. 

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
