### PR TITLE
fix: bugs around aborting scan

### DIFF
--- a/api/types/assetscanstatus.go
+++ b/api/types/assetscanstatus.go
@@ -23,10 +23,12 @@ import (
 var assetScanStatusStateTransitions = map[AssetScanStatusState][]AssetScanStatusState{
 	AssetScanStatusStatePending: {
 		AssetScanStatusStateScheduled,
+		AssetScanStatusStateAborted,
 	},
 	AssetScanStatusStateScheduled: {
 		AssetScanStatusStateReadyToScan,
 		AssetScanStatusStateFailed,
+		AssetScanStatusStateAborted,
 	},
 	AssetScanStatusStateReadyToScan: {
 		AssetScanStatusStateInProgress,

--- a/orchestrator/watcher/scan/watcher.go
+++ b/orchestrator/watcher/scan/watcher.go
@@ -488,7 +488,7 @@ func (w *Watcher) reconcileAborted(ctx context.Context, scan *apitypes.Scan) err
 					),
 				}
 
-				err = w.client.PatchAssetScan(ctx, as, assetScanID)
+				err := w.client.PatchAssetScan(ctx, as, assetScanID)
 				if err != nil {
 					logger.WithField("AssetScanID", assetScanID).Error("Failed to patch AssetScan")
 					reconciliationFailed = true

--- a/scanner/findingkey/rootkit.go
+++ b/scanner/findingkey/rootkit.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	apitypes "github.com/openclarity/vmclarity/api/types"
+	"github.com/openclarity/vmclarity/core/to"
 )
 
 type RootkitKey struct {
@@ -42,6 +43,6 @@ func GenerateRootkitKey(info apitypes.RootkitFindingInfo) RootkitKey {
 	return RootkitKey{
 		Name:        *info.RootkitName,
 		RootkitType: string(*info.RootkitType),
-		Message:     *info.Message,
+		Message:     to.ValueOrZero(info.Message),
 	}
 }


### PR DESCRIPTION
## Description

Fixed some bugs while testing, mainly around when a scan is being aborted:

- allow to transition from any status to aborted - I think this makes sense as sometimes aborting the scan is needed something is broken and some assetScans couldn't get to the `ReadyToScan` phase
- fix a race condition in the orchestrator - related log:
  ```shell
  WARNING: DATA RACE
  Write at 0x00c001bb8c40 by goroutine 9201:
    github.com/openclarity/vmclarity/orchestrator/watcher/scan.(*Watcher).reconcileAborted.func1()
        /build/orchestrator/watcher/scan/watcher.go:491 +0x238
  
  Previous write at 0x00c001bb8c40 by goroutine 9200:
    github.com/openclarity/vmclarity/orchestrator/watcher/scan.(*Watcher).reconcileAborted.func1()
        /build/orchestrator/watcher/scan/watcher.go:491 +0x238
  
  Goroutine 9201 (running) created at:
    github.com/openclarity/vmclarity/orchestrator/watcher/scan.(*Watcher).reconcileAborted()
        /build/orchestrator/watcher/scan/watcher.go:481 +0xbc0
    github.com/openclarity/vmclarity/orchestrator/watcher/scan.(*Watcher).Reconcile()
        /build/orchestrator/watcher/scan/watcher.go:167 +0x710
    github.com/openclarity/vmclarity/orchestrator/watcher/scan.(*Watcher).Reconcile-fm()
        <autogenerated>:1 +0x58
    github.com/openclarity/vmclarity/orchestrator/common.(*Reconciler[go.shape.struct { ScanID string }]).Start.func1()
        /build/orchestrator/common/reconciler.go:70 +0x19c
  
  Goroutine 9200 (finished) created at:
    github.com/openclarity/vmclarity/orchestrator/watcher/scan.(*Watcher).reconcileAborted()
        /build/orchestrator/watcher/scan/watcher.go:481 +0xbc0
    github.com/openclarity/vmclarity/orchestrator/watcher/scan.(*Watcher).Reconcile()
        /build/orchestrator/watcher/scan/watcher.go:167 +0x710
    github.com/openclarity/vmclarity/orchestrator/watcher/scan.(*Watcher).Reconcile-fm()
        <autogenerated>:1 +0x58
    github.com/openclarity/vmclarity/orchestrator/common.(*Reconciler[go.shape.struct { ScanID string }]).Start.func1()
        /build/orchestrator/common/reconciler.go:70 +0x19c
  ==================
  ```
- fix a panic that also occurred in the orchestrator causing the pod to be continuously restarted on Kubernetes - related log:
  ```shell
  time="2024-04-17T07:44:58Z" level=info msg="Starting healthz server. listenAddr=:8082"
  time="2024-04-17T07:44:58Z" level=info msg="Starting Orchestrator server"
  time="2024-04-17T07:45:12Z" level=info msg="Reconciling item" AssetScanID=61aec253-61ef-44c2-87c6-39dfddd9ccfa controller=AssetScanProcessor
  time="2024-04-17T07:45:12Z" level=info msg="Found 0 existing vulnerabilities findings for this scan" controller=AssetScanProcessor
  time="2024-04-17T07:45:12Z" level=info msg="Found 0 existing package findings for this scan" controller=AssetScanProcessor
  time="2024-04-17T07:45:13Z" level=info msg="Found 0 existing exploit findings for this scan" controller=AssetScanProcessor
  time="2024-04-17T07:45:13Z" level=info msg="Found 0 existing secret findings for this scan" controller=AssetScanProcessor
  time="2024-04-17T07:45:13Z" level=info msg="Found 0 existing malware findings for this scan" controller=AssetScanProcessor
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9466c0]
  
  goroutine 100 [running]:
  github.com/openclarity/vmclarity/scanner/findingkey.GenerateRootkitKey(...)
      /build/scanner/findingkey/rootkit.go:45
  github.com/openclarity/vmclarity/orchestrator/processor/assetscan.(*AssetScanProcessor).getExistingRootkitFindingsForScan(0x400199bc68, {0x823acb0, 0x40001c61c0}, {0x4002645038, 0x400180bec0, 0x4003b88a60, 0x0, 0x4003b88a70, 0x4002645080, 0x40026450e0, ...})
      /build/orchestrator/processor/assetscan/rootkits.go:48 +0x280
  github.com/openclarity/vmclarity/orchestrator/processor/assetscan.(*AssetScanProcessor).reconcileResultRootkitsToFindings(0x400199bc68, {0x823acb0, 0x40001c61c0}, {0x4002645038, 0x400180bec0, 0x4003b88a60, 0x0, 0x4003b88a70, 0x4002645080, 0x40026450e0, ...})
      /build/orchestrator/processor/assetscan/rootkits.go:73 +0x134
  github.com/openclarity/vmclarity/orchestrator/processor/assetscan.(*AssetScanProcessor).Reconcile(0x400199bc68, {0x823acb0, 0x40001c61c0}, {{0x400171c4b0?, 0x0?}})
      /build/orchestrator/processor/assetscan/processor.go:102 +0x69c
  github.com/openclarity/vmclarity/orchestrator/common.(*Reconciler[...]).Start.func1()
      /build/orchestrator/common/reconciler.go:70 +0x11c
  created by github.com/openclarity/vmclarity/orchestrator/common.(*Reconciler[...]).Start in goroutine 1
      /build/orchestrator/common/reconciler.go:56 +0x90
  Stream closed EOF for vmclarity/vmclarity-orchestrator-7bdfdb4f74-cwhtp (orchestrator)
  ```

## Type of Change

[X] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
