### PR TITLE
fix(e2e): set directory asset last seen to future time

### DIFF
--- a/e2e/dir_scan_test.go
+++ b/e2e/dir_scan_test.go
@@ -61,6 +61,8 @@ var _ = ginkgo.Describe("Running a SBOM and plugin scan", func() {
 				apitypes.Asset{
 					AssetInfo: &assetType,
 					FirstSeen: to.Ptr(time.Now()),
+					// Set to future time so asset is not terminated by discoverer.
+					LastSeen: to.Ptr(time.Now().Add(time.Minute * 10)),
 				},
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
## Description

https://github.com/openclarity/vmclarity/issues/1599

Set `lastSeen` field to 10 min from now so the directory asset is not marked as terminated by the discoverer. 

Kudos to @adamtagscherer and @csatib02 for catching this issue 🎉 

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
