### PR TITLE
feat: CIS docker scanner to work with rootfs, dir

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.3 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
-	github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe // indirect
+	github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.0 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acobaugh/osrelease v0.1.0 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -262,8 +262,8 @@ github.com/Microsoft/hcsshim v0.12.3/go.mod h1:Iyl1WVpZzr+UkzjekHZbV8o5Z9ZkxNGx6
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
-github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe h1:9iFS0fDnBwPWF/pIB77Ym0YhpOyW+6Fs4CUwrQJCgHE=
-github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe/go.mod h1:4Ah+8tyE5uzs8BBmUOo1bIyMWXQnIpx9mvsEzrsmo3Q=
+github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7 h1:d8TjnmUvMG8up/q+oVxanmAMqj+stbZEChx8FHXA9R8=
+github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7/go.mod h1:FUpB0D5B7AaKtY3Xt1kvO5QlJV2OifG3NNmvisDMla8=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0 h1:nHGfwXmFvJrSR9xu8qL7BkO4DqTHXE9N5vPhgY2I+j0=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.3 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
-	github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe // indirect
+	github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.0 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acobaugh/osrelease v0.1.0 // indirect

--- a/orchestrator/go.sum
+++ b/orchestrator/go.sum
@@ -283,8 +283,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
-github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe h1:9iFS0fDnBwPWF/pIB77Ym0YhpOyW+6Fs4CUwrQJCgHE=
-github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe/go.mod h1:4Ah+8tyE5uzs8BBmUOo1bIyMWXQnIpx9mvsEzrsmo3Q=
+github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7 h1:d8TjnmUvMG8up/q+oVxanmAMqj+stbZEChx8FHXA9R8=
+github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7/go.mod h1:FUpB0D5B7AaKtY3Xt1kvO5QlJV2OifG3NNmvisDMla8=
 github.com/Portshift/go-utils v0.0.0-20220421083203-89265d8a6487 h1:CD9mOTUMX6f33pRJoYUDyI+IDnCWWhwBBoXqxGMrAaQ=
 github.com/Portshift/go-utils v0.0.0-20220421083203-89265d8a6487/go.mod h1:w2CFHePN1v+p2v/NSpe7aK+cFu0E2+9MrQ3CgB6vydk=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0 h1:nHGfwXmFvJrSR9xu8qL7BkO4DqTHXE9N5vPhgY2I+j0=

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/Microsoft/hcsshim v0.12.3 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
-	github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe // indirect
+	github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7 // indirect
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.0 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acobaugh/osrelease v0.1.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -280,8 +280,8 @@ github.com/Microsoft/hcsshim v0.12.3/go.mod h1:Iyl1WVpZzr+UkzjekHZbV8o5Z9ZkxNGx6
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
-github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe h1:9iFS0fDnBwPWF/pIB77Ym0YhpOyW+6Fs4CUwrQJCgHE=
-github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe/go.mod h1:4Ah+8tyE5uzs8BBmUOo1bIyMWXQnIpx9mvsEzrsmo3Q=
+github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7 h1:d8TjnmUvMG8up/q+oVxanmAMqj+stbZEChx8FHXA9R8=
+github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7/go.mod h1:FUpB0D5B7AaKtY3Xt1kvO5QlJV2OifG3NNmvisDMla8=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0 h1:nHGfwXmFvJrSR9xu8qL7BkO4DqTHXE9N5vPhgY2I+j0=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=

--- a/scanner/families/misconfiguration/cisdocker/config.go
+++ b/scanner/families/misconfiguration/cisdocker/config.go
@@ -56,6 +56,8 @@ func createDockleConfig(logger *logrus.Entry, sourceType utils.SourceType, name 
 	switch sourceType {
 	case utils.DOCKERARCHIVE:
 		dockleConfig.FilePath = name
+	case utils.ROOTFS, utils.DIR:
+		dockleConfig.DirPath = name
 	default:
 		dockleConfig.ImageName = name
 	}

--- a/scanner/families/misconfiguration/cisdocker/report_test.go
+++ b/scanner/families/misconfiguration/cisdocker/report_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/openclarity/vmclarity/scanner/families/misconfiguration/types"
+	"github.com/openclarity/vmclarity/scanner/utils"
 )
 
 func TestParseDockleReport(t *testing.T) {
@@ -166,7 +167,7 @@ func TestParseDockleReport(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseDockleReport(tt.imageName, *tt.assessmentMap)
+			got := parseDockleReport(utils.IMAGE, tt.imageName, *tt.assessmentMap)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("NewReportParser() mismatch (-want +got):\n%s", diff)
 			}

--- a/scanner/families/misconfiguration/cisdocker/scanner.go
+++ b/scanner/families/misconfiguration/cisdocker/scanner.go
@@ -69,7 +69,7 @@ func (a *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 
 		a.logger.Infof("Successfully scanned %s %s", sourceType, userInput)
 
-		retResults.Misconfigurations = parseDockleReport(userInput, assessmentMap)
+		retResults.Misconfigurations = parseDockleReport(sourceType, userInput, assessmentMap)
 
 		a.sendResults(retResults, nil)
 	}()
@@ -79,9 +79,9 @@ func (a *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 
 func (a *Scanner) isValidInputType(sourceType utils.SourceType) bool {
 	switch sourceType {
-	case utils.IMAGE, utils.DOCKERARCHIVE:
+	case utils.IMAGE, utils.DOCKERARCHIVE, utils.ROOTFS, utils.DIR:
 		return true
-	case utils.ROOTFS, utils.DIR, utils.FILE, utils.SBOM, utils.OCIARCHIVE, utils.OCIDIR:
+	case utils.FILE, utils.SBOM, utils.OCIARCHIVE, utils.OCIDIR:
 		a.logger.Infof("source type %v is not supported for CIS Docker Benchmark scanner, skipping.", sourceType)
 	default:
 		a.logger.Infof("unknown source type %v, skipping.", sourceType)

--- a/scanner/go.mod
+++ b/scanner/go.mod
@@ -4,7 +4,7 @@ go 1.21.4
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.8.0
-	github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe
+	github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7
 	github.com/anchore/clio v0.0.0-20240408173007-3c4abf89e72f
 	github.com/anchore/grype v0.77.2
 	github.com/anchore/stereoscope v0.0.3-0.20240501181043-2e9894674185

--- a/scanner/go.sum
+++ b/scanner/go.sum
@@ -262,8 +262,8 @@ github.com/Microsoft/hcsshim v0.12.3/go.mod h1:Iyl1WVpZzr+UkzjekHZbV8o5Z9ZkxNGx6
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8=
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
-github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe h1:9iFS0fDnBwPWF/pIB77Ym0YhpOyW+6Fs4CUwrQJCgHE=
-github.com/Portshift/dockle v0.3.2-0.20230921065504-6cd22e0b9ebe/go.mod h1:4Ah+8tyE5uzs8BBmUOo1bIyMWXQnIpx9mvsEzrsmo3Q=
+github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7 h1:d8TjnmUvMG8up/q+oVxanmAMqj+stbZEChx8FHXA9R8=
+github.com/Portshift/dockle v0.3.2-0.20240508131533-4f3b165086b7/go.mod h1:FUpB0D5B7AaKtY3Xt1kvO5QlJV2OifG3NNmvisDMla8=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0 h1:nHGfwXmFvJrSR9xu8qL7BkO4DqTHXE9N5vPhgY2I+j0=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=


### PR DESCRIPTION
## Description

The dockle package [has been updated](https://github.com/Portshift/dockle/pull/14) so the CIS docker scanner can be used with `rootfs` and `dir` type of assets as well!

Fixes #1376.

## Type of Change

[ ] Bug Fix  
[X] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
