### PR TITLE
fix: riskiest assets fails with postgres 

### DIFF
--- a/api/server/database/gorm/odata.go
+++ b/api/server/database/gorm/odata.go
@@ -129,7 +129,9 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 				FieldType:           odatasql.ComplexFieldType,
 				ComplexFieldSchemas: []string{"ScanFindingsSummary"},
 			},
-			"findingsProcessed": odatasql.FieldMeta{FieldType: odatasql.NumberFieldType},
+			"findingsProcessed": odatasql.FieldMeta{
+				FieldType: odatasql.BooleanFieldType,
+			},
 			"resourceCleanupStatus": odatasql.FieldMeta{
 				FieldType:           odatasql.ComplexFieldType,
 				ComplexFieldSchemas: []string{"ResourceCleanupStatus"},

--- a/api/server/database/odatasql/jsonsql/postgres.go
+++ b/api/server/database/odatasql/jsonsql/postgres.go
@@ -36,6 +36,10 @@ func (postgres) CastToDateTime(strTime string) string {
 	return fmt.Sprintf("(%s)::timestamptz", strTime)
 }
 
+func (postgres) CastToInteger(strInt string) string {
+	return fmt.Sprintf("(%s)::integer", strInt)
+}
+
 func (postgres) JSONEach(source string) string {
 	// The postgres function expect the data must be an array, so we need
 	// to detect any other types in the SQL statement and switch it to

--- a/api/server/database/odatasql/jsonsql/sqlite.go
+++ b/api/server/database/odatasql/jsonsql/sqlite.go
@@ -36,6 +36,10 @@ func (sqlite) CastToDateTime(strTime string) string {
 	return fmt.Sprintf("datetime(%s)", strTime)
 }
 
+func (sqlite) CastToInteger(strInt string) string {
+	return strInt
+}
+
 func (sqlite) JSONEach(source string) string {
 	return fmt.Sprintf("JSON_EACH(%s)", source)
 }

--- a/api/server/database/odatasql/jsonsql/variant.go
+++ b/api/server/database/odatasql/jsonsql/variant.go
@@ -15,10 +15,12 @@
 
 package jsonsql
 
+//nolint:interfacebloat
 type Variant interface {
 	JSONObject(parts []string) string
 	JSONArrayAggregate(string) string
 	CastToDateTime(string) string
+	CastToInteger(string) string
 	JSONEach(source string) string
 	JSONArray(items []string) string
 	JSONExtract(source string, path string) string

--- a/api/server/database/odatasql/query.go
+++ b/api/server/database/odatasql/query.go
@@ -524,7 +524,7 @@ func buildWhereFromPrimative(sqlVariant jsonsql.Variant, node *godata.ParseNode)
 	case godata.ExpressionTokenString:
 		return sqlVariant.JSONQuote(node.Token.Value), nil
 	case godata.ExpressionTokenInteger, godata.ExpressionTokenFloat:
-		return node.Token.Value, nil
+		return sqlVariant.CastToInteger(node.Token.Value), nil
 	case godata.ExpressionTokenBoolean:
 		return singleQuote(node.Token.Value), nil
 	case godata.ExpressionTokenDateTime:
@@ -563,7 +563,7 @@ func buildWhereFromNav(sqlVariant jsonsql.Variant, schemaMetas map[string]Schema
 	case StringFieldType, BooleanFieldType:
 		return sqlVariant.JSONExtract(fieldSource, queryPath), nil
 	case NumberFieldType:
-		return sqlVariant.JSONExtractText(fieldSource, queryPath), nil
+		return sqlVariant.CastToInteger(sqlVariant.JSONExtractText(fieldSource, queryPath)), nil
 	case DateTimeFieldType:
 		return sqlVariant.CastToDateTime(sqlVariant.JSONExtractText(fieldSource, queryPath)), nil
 	case CollectionFieldType, RelationshipFieldType, ComplexFieldType:


### PR DESCRIPTION
## Description

https://github.com/openclarity/vmclarity/issues/1127

* Queries to get assets with `TotalExploits`, `TotalMalware`, etc were failing because the total value was not casted to integer. Therefore, implementation of cast to integer for Postgres is required.
* For `TotalVulnerabilities` instead of checking if this object property is greater than zero, we need to check the fields inside this object (`totalCriticalVulnerabilities`, `totalHighVulnerabilities`, etc).
* Fix `findingsProcessed` is boolean not integer in the ODATA schema

This fix was tested manually with the Docker provider using Postgres ✅ 

<img width="462" alt="Screenshot 2024-05-13 at 18 24 03" src="https://github.com/openclarity/vmclarity/assets/46568597/fd68dde5-9d4a-4707-9c7c-97341674bdcc">

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
