### PR TITLE
fix: containerd export strictly matching platform

### DIFF
--- a/containerruntimediscovery/server/containerd/discoverer.go
+++ b/containerruntimediscovery/server/containerd/discoverer.go
@@ -325,7 +325,7 @@ func (d *discoverer) ExportImage(ctx context.Context, imageID string) (io.ReadCl
 			ctx,
 			pw,
 			archive.WithImage(d.client.ImageService(), img.Name()),
-			archive.WithPlatform(platforms.Default()),
+			archive.WithPlatform(platforms.DefaultStrict()),
 		)
 		if err != nil {
 			log.GetLoggerFromContextOrDefault(ctx).Errorf("failed to export image: %v", err)
@@ -469,7 +469,7 @@ func (d *discoverer) ExportContainer(ctx context.Context, containerID string) (i
 			ctx,
 			pw,
 			archive.WithImage(d.client.ImageService(), imageName),
-			archive.WithPlatform(platforms.Default()),
+			archive.WithPlatform(platforms.DefaultStrict()),
 		)
 		if err != nil {
 			log.GetLoggerFromContextOrDefault(ctx).Errorf("failed to export container snapshot: %v", err)


### PR DESCRIPTION
## Description

When running a basic Kubernetes scan (SBOM + Vulnerabillities) on container images, asset scans fail with `failed to analyzer input "/mnt/snapshot/image.tar": failed to run job: failed to create source analyzer=syft: an error occurred attempting to resolve '/mnt/snapshot/image.tar': additionally, the following providers failed with file does not exist: oci-archive`.

Looking at the cr discovery server logs, the error is `content digest sha256:<hash>: not found`. 

This PR fixes this issue when an image is exported without providing a specific platform.

Please note that this does not fix the second error mentioned in the issue.

Tested manually on Kubernetes ✅ 

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
