### PR TITLE
feat(e2e): revisit k8s test env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,8 +165,15 @@ ifneq ($(CI),true)
 endif
 
 .PHONY: e2e
-e2e: $(E2E_TARGETS) ## Run end-to-end test suite
+e2e: $(E2E_TARGETS) ## Run end-to-end test suite on Docker
 	$(E2E_ENV) go -C $(ROOT_DIR)/e2e test -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 2h -timeout 2h -ginkgo.v .
+
+E2E_ENV_K8S = $(E2E_ENV)
+E2E_ENV_K8S += VMCLARITY_E2E_PLATFORM=kubernetes
+
+.PHONY: e2e-k8s
+e2e-k8s: $(E2E_TARGETS) ## Run end-to-end test suite on Kubernetes
+	$(E2E_ENV_K8S) go -C $(ROOT_DIR)/e2e test -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 2h -timeout 2h -ginkgo.v .
 
 VENDORMODULES = $(addprefix vendor-, $(GOMODULES))
 

--- a/e2e/abort_scan_test.go
+++ b/e2e/abort_scan_test.go
@@ -33,7 +33,11 @@ var _ = ginkgo.Describe("Aborting a scan", func() {
 			ginkgo.By("applying a scan configuration")
 			apiScanConfig, err := client.PostScanConfig(
 				ctx,
-				GetFullScanConfig(cfg.TestSuiteParams.Scope, cfg.TestSuiteParams.ScanTimeout),
+				GetCustomScanConfig(
+					cfg.TestSuiteParams.FamiliesConfig,
+					cfg.TestSuiteParams.Scope,
+					cfg.TestSuiteParams.ScanTimeout,
+				),
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/e2e/basic_scan_test.go
+++ b/e2e/basic_scan_test.go
@@ -56,8 +56,8 @@ var _ = ginkgo.Describe("Running a basic scan (only SBOM)", func() {
 
 	ginkgo.Context("which scans a docker image", func() {
 		ginkgo.It("should finish successfully", func(ctx ginkgo.SpecContext) {
-			if cfg.TestEnvConfig.Platform != types.EnvironmentTypeDocker {
-				ginkgo.Skip("skipping test because it's not running on docker")
+			if cfg.TestEnvConfig.Platform != types.EnvironmentTypeDocker && cfg.TestEnvConfig.Platform != types.EnvironmentTypeKubernetes {
+				ginkgo.Skip("skipping test because it's not running on docker or kubernetes platform")
 			}
 
 			containerInfo, err := (*assets.Items)[0].AssetInfo.AsContainerInfo()

--- a/e2e/basic_scan_test.go
+++ b/e2e/basic_scan_test.go
@@ -97,12 +97,10 @@ func RunSuccessfulScan(ctx ginkgo.SpecContext, report *ReportFailedConfig, filte
 		ctx,
 		GetCustomScanConfig(
 			&apitypes.ScanFamiliesConfig{
-				Sbom: &apitypes.SBOMConfig{
-					Enabled: to.Ptr(true),
-				},
+				Sbom: cfg.TestSuiteParams.FamiliesConfig.Sbom,
 			},
 			filter,
-			int(cfg.TestSuiteParams.ScanTimeout.Seconds()),
+			cfg.TestSuiteParams.ScanTimeout,
 		))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/e2e/basic_scan_test.go
+++ b/e2e/basic_scan_test.go
@@ -137,6 +137,11 @@ func RunSuccessfulScan(ctx ginkgo.SpecContext, report *ReportFailedConfig, filte
 		return false
 	}, DefaultTimeout, DefaultPeriod).Should(gomega.BeTrue())
 
+	report.objects = append(
+		report.objects,
+		APIObject{"assetScan", fmt.Sprintf("scan/id eq '%s'", *apiScanConfig.Id)},
+	)
+
 	ginkgo.By("waiting until scan state changes to done")
 	scanParams = apitypes.GetScansParams{
 		Filter: to.Ptr(fmt.Sprintf(

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -23,6 +23,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/viper"
 
+	apitypes "github.com/openclarity/vmclarity/api/types"
+	"github.com/openclarity/vmclarity/core/to"
 	"github.com/openclarity/vmclarity/testenv"
 	"github.com/openclarity/vmclarity/testenv/aws"
 	azureenv "github.com/openclarity/vmclarity/testenv/azure"
@@ -42,6 +44,42 @@ type TestSuiteParams struct {
 	ServicesReadyTimeout time.Duration
 	ScanTimeout          time.Duration
 	Scope                string
+	FamiliesConfig       *apitypes.ScanFamiliesConfig
+}
+
+var FullScanFamiliesConfig = &apitypes.ScanFamiliesConfig{
+	Exploits: &apitypes.ExploitsConfig{
+		Enabled:  to.Ptr(true),
+		Scanners: &[]string{"exploitdb"},
+	},
+	InfoFinder: &apitypes.InfoFinderConfig{
+		Enabled:  to.Ptr(true),
+		Scanners: &[]string{"sshTopology"},
+	},
+	Malware: &apitypes.MalwareConfig{
+		Enabled:  to.Ptr(true),
+		Scanners: &[]string{"clam", "yara"},
+	},
+	Misconfigurations: &apitypes.MisconfigurationsConfig{
+		Enabled:  to.Ptr(true),
+		Scanners: &[]string{"lynis", "cisdocker"},
+	},
+	Rootkits: &apitypes.RootkitsConfig{
+		Enabled:  to.Ptr(true),
+		Scanners: &[]string{"chkrootkit"},
+	},
+	Sbom: &apitypes.SBOMConfig{
+		Enabled:   to.Ptr(true),
+		Analyzers: &[]string{"syft", "trivy", "windows"},
+	},
+	Secrets: &apitypes.SecretsConfig{
+		Enabled:  to.Ptr(true),
+		Scanners: &[]string{"gitleaks"},
+	},
+	Vulnerabilities: &apitypes.VulnerabilitiesConfig{
+		Enabled:  to.Ptr(true),
+		Scanners: &[]string{"grype", "trivy"},
+	},
 }
 
 // nolint:gomnd
@@ -50,28 +88,41 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 
 	switch t {
 	case types.EnvironmentTypeAWS, types.EnvironmentTypeGCP:
+		// NOTE(paralta) Disabling the malware families to speed up the test
+		familiesConfig := FullScanFamiliesConfig
+		familiesConfig.Malware.Enabled = to.Ptr(false)
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 10 * time.Minute,
 			ScanTimeout:          20 * time.Minute,
 			Scope:                fmt.Sprintf(scope, "tags"),
+			FamiliesConfig:       familiesConfig,
 		}
 	case types.EnvironmentTypeAzure:
+		// NOTE(paralta) Disabling the malware families to speed up the test
+		familiesConfig := FullScanFamiliesConfig
+		familiesConfig.Malware.Enabled = to.Ptr(false)
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 20 * time.Minute,
 			ScanTimeout:          40 * time.Minute,
 			Scope:                fmt.Sprintf(scope, "tags"),
+			FamiliesConfig:       familiesConfig,
 		}
 	case types.EnvironmentTypeDocker:
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 5 * time.Minute,
 			ScanTimeout:          2 * time.Minute,
 			Scope:                fmt.Sprintf(scope, "labels"),
+			FamiliesConfig:       FullScanFamiliesConfig,
 		}
 	case types.EnvironmentTypeKubernetes:
+		// NOTE(paralta) Disabling syft https://github.com/anchore/syft/issues/1545
+		familiesConfig := FullScanFamiliesConfig
+		familiesConfig.Sbom.Analyzers = &[]string{"trivy", "windows"}
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 5 * time.Minute,
 			ScanTimeout:          2 * time.Minute,
 			Scope:                fmt.Sprintf(scope, "labels") + " and assetInfo/containerName eq 'alpine'",
+			FamiliesConfig:       familiesConfig,
 		}
 	default:
 		return &TestSuiteParams{}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -110,7 +110,7 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 	case types.EnvironmentTypeDocker:
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 5 * time.Minute,
-			ScanTimeout:          2 * time.Minute,
+			ScanTimeout:          5 * time.Minute,
 			Scope:                fmt.Sprintf(scope, "labels"),
 			FamiliesConfig:       FullScanFamiliesConfig,
 		}
@@ -120,7 +120,7 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 		familiesConfig.Sbom.Analyzers = &[]string{"trivy", "windows"}
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 5 * time.Minute,
-			ScanTimeout:          2 * time.Minute,
+			ScanTimeout:          5 * time.Minute,
 			Scope:                fmt.Sprintf(scope, "labels") + " and assetInfo/containerName eq 'alpine'",
 			FamiliesConfig:       familiesConfig,
 		}

--- a/e2e/config/config.go
+++ b/e2e/config/config.go
@@ -61,11 +61,17 @@ func TestSuiteParamsForEnv(t types.EnvironmentType) *TestSuiteParams {
 			ScanTimeout:          40 * time.Minute,
 			Scope:                fmt.Sprintf(scope, "tags"),
 		}
-	case types.EnvironmentTypeDocker, types.EnvironmentTypeKubernetes:
+	case types.EnvironmentTypeDocker:
 		return &TestSuiteParams{
 			ServicesReadyTimeout: 5 * time.Minute,
 			ScanTimeout:          2 * time.Minute,
 			Scope:                fmt.Sprintf(scope, "labels"),
+		}
+	case types.EnvironmentTypeKubernetes:
+		return &TestSuiteParams{
+			ServicesReadyTimeout: 5 * time.Minute,
+			ScanTimeout:          2 * time.Minute,
+			Scope:                fmt.Sprintf(scope, "labels") + " and assetInfo/containerName eq 'alpine'",
 		}
 	default:
 		return &TestSuiteParams{}

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -162,7 +162,7 @@ func TestConfig(t *testing.T) {
 				},
 				TestSuiteParams: &TestSuiteParams{
 					ServicesReadyTimeout: 5 * time.Minute,
-					ScanTimeout:          2 * time.Minute,
+					ScanTimeout:          5 * time.Minute,
 					Scope:                "assetInfo/labels/any(t: t/key eq 'scanconfig' and t/value eq 'test') and assetInfo/containerName eq 'alpine'",
 					FamiliesConfig:       kubernetesFamiliesConfig,
 				},
@@ -250,7 +250,7 @@ func TestConfig(t *testing.T) {
 				},
 				TestSuiteParams: &TestSuiteParams{
 					ServicesReadyTimeout: 5 * time.Minute,
-					ScanTimeout:          2 * time.Minute,
+					ScanTimeout:          5 * time.Minute,
 					Scope:                "assetInfo/labels/any(t: t/key eq 'scanconfig' and t/value eq 'test')",
 					FamiliesConfig:       FullScanFamiliesConfig,
 				},

--- a/e2e/config/config_test.go
+++ b/e2e/config/config_test.go
@@ -35,6 +35,9 @@ import (
 )
 
 func TestConfig(t *testing.T) {
+	kubernetesFamiliesConfig := FullScanFamiliesConfig
+	kubernetesFamiliesConfig.Sbom.Analyzers = &[]string{"trivy", "windows"}
+
 	tests := []struct {
 		Name    string
 		EnvVars map[string]string
@@ -160,7 +163,8 @@ func TestConfig(t *testing.T) {
 				TestSuiteParams: &TestSuiteParams{
 					ServicesReadyTimeout: 5 * time.Minute,
 					ScanTimeout:          2 * time.Minute,
-					Scope:                "assetInfo/labels/any(t: t/key eq 'scanconfig' and t/value eq 'test')",
+					Scope:                "assetInfo/labels/any(t: t/key eq 'scanconfig' and t/value eq 'test') and assetInfo/containerName eq 'alpine'",
+					FamiliesConfig:       kubernetesFamiliesConfig,
 				},
 			},
 		},
@@ -248,6 +252,7 @@ func TestConfig(t *testing.T) {
 					ServicesReadyTimeout: 5 * time.Minute,
 					ScanTimeout:          2 * time.Minute,
 					Scope:                "assetInfo/labels/any(t: t/key eq 'scanconfig' and t/value eq 'test')",
+					FamiliesConfig:       FullScanFamiliesConfig,
 				},
 			},
 		},

--- a/e2e/dir_scan_test.go
+++ b/e2e/dir_scan_test.go
@@ -102,7 +102,7 @@ var _ = ginkgo.Describe("Running a SBOM and plugin scan", func() {
 						},
 					},
 					scope,
-					600,
+					600*time.Second,
 				),
 			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/e2e/fail_scan_test.go
+++ b/e2e/fail_scan_test.go
@@ -17,6 +17,7 @@ package e2e
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -34,9 +35,9 @@ var _ = ginkgo.Describe("Detecting scan failures", func() {
 			apiScanConfig, err := client.PostScanConfig(
 				ctx,
 				GetCustomScanConfig(
-					&FullScanFamiliesConfig,
+					cfg.TestSuiteParams.FamiliesConfig,
 					"assetInfo/labels/any(t: t/key eq 'notexisting' and t/value eq 'label')",
-					600,
+					600*time.Second,
 				))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -94,9 +95,9 @@ var _ = ginkgo.Describe("Detecting scan failures", func() {
 			apiScanConfig, err := client.PostScanConfig(
 				ctx,
 				GetCustomScanConfig(
-					&FullScanFamiliesConfig,
+					cfg.TestSuiteParams.FamiliesConfig,
 					cfg.TestSuiteParams.Scope,
-					2,
+					2*time.Second,
 				))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/e2e/full_scan_test.go
+++ b/e2e/full_scan_test.go
@@ -85,6 +85,11 @@ var _ = ginkgo.Describe("Running a full scan (exploits, info finder, malware, mi
 				return false
 			}, DefaultTimeout, DefaultPeriod).Should(gomega.BeTrue())
 
+			reportFailedConfig.objects = append(
+				reportFailedConfig.objects,
+				APIObject{"assetScan", fmt.Sprintf("scan/id eq '%s'", *apiScanConfig.Id)},
+			)
+
 			ginkgo.By("waiting until scan state changes to done")
 			scanParams = apitypes.GetScansParams{
 				Filter: to.Ptr(fmt.Sprintf(

--- a/e2e/full_scan_test.go
+++ b/e2e/full_scan_test.go
@@ -49,7 +49,12 @@ var _ = ginkgo.Describe("Running a full scan (exploits, info finder, malware, mi
 			ginkgo.By("applying a scan configuration")
 			apiScanConfig, err := client.PostScanConfig(
 				ctx,
-				GetFullScanConfig(cfg.TestSuiteParams.Scope, cfg.TestSuiteParams.ScanTimeout))
+				GetCustomScanConfig(
+					cfg.TestSuiteParams.FamiliesConfig,
+					cfg.TestSuiteParams.Scope,
+					cfg.TestSuiteParams.ScanTimeout,
+				),
+			)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			ginkgo.By("updating scan configuration to run now")

--- a/e2e/helpers.go
+++ b/e2e/helpers.go
@@ -33,43 +33,7 @@ const (
 	fullScanStartOffset = 5 * time.Second
 )
 
-var FullScanFamiliesConfig = apitypes.ScanFamiliesConfig{
-	Exploits: &apitypes.ExploitsConfig{
-		Enabled: to.Ptr(true),
-	},
-	InfoFinder: &apitypes.InfoFinderConfig{
-		Enabled: to.Ptr(true),
-	},
-	// NOTE(paralta) Disabling the malware families to speed up the test
-	Malware: &apitypes.MalwareConfig{
-		Enabled: to.Ptr(false),
-	},
-	Misconfigurations: &apitypes.MisconfigurationsConfig{
-		Enabled: to.Ptr(true),
-	},
-	Rootkits: &apitypes.RootkitsConfig{
-		Enabled: to.Ptr(true),
-	},
-	Sbom: &apitypes.SBOMConfig{
-		Enabled: to.Ptr(true),
-	},
-	Secrets: &apitypes.SecretsConfig{
-		Enabled: to.Ptr(true),
-	},
-	Vulnerabilities: &apitypes.VulnerabilitiesConfig{
-		Enabled: to.Ptr(true),
-	},
-}
-
-func GetFullScanConfig(scope string, timeout time.Duration) apitypes.ScanConfig {
-	return GetCustomScanConfig(
-		&FullScanFamiliesConfig,
-		scope,
-		int(timeout.Seconds()),
-	)
-}
-
-func GetCustomScanConfig(scanFamiliesConfig *apitypes.ScanFamiliesConfig, scope string, timeoutSeconds int) apitypes.ScanConfig {
+func GetCustomScanConfig(scanFamiliesConfig *apitypes.ScanFamiliesConfig, scope string, timeout time.Duration) apitypes.ScanConfig {
 	return apitypes.ScanConfig{
 		Name: to.Ptr(uuid.New().String()),
 		ScanTemplate: &apitypes.ScanTemplate{
@@ -77,7 +41,7 @@ func GetCustomScanConfig(scanFamiliesConfig *apitypes.ScanFamiliesConfig, scope 
 				ScanFamiliesConfig: scanFamiliesConfig,
 			},
 			Scope:          to.Ptr(scope),
-			TimeoutSeconds: to.Ptr(timeoutSeconds),
+			TimeoutSeconds: to.Ptr(int(timeout.Seconds())),
 		},
 		Scheduled: &apitypes.RuntimeScheduleScanConfig{
 			CronLine: to.Ptr("0 */4 * * *"),

--- a/e2e/report.go
+++ b/e2e/report.go
@@ -107,6 +107,20 @@ func DumpAPIData(ctx ginkgo.SpecContext, client *apiclient.Client, config *Repor
 			buf, err := json.MarshalIndent(*scans.Items, "", "\t")
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			ginkgo.GinkgoWriter.Printf("Scan: %s\n", string(buf))
+
+		case "assetScan":
+			var params apitypes.GetAssetScansParams
+			if object.filter == "" {
+				params = apitypes.GetAssetScansParams{}
+			} else {
+				params = apitypes.GetAssetScansParams{Filter: to.Ptr(object.filter)}
+			}
+			assetScans, err := client.GetAssetScans(ctx, params)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+			buf, err := json.MarshalIndent(*assetScans.Items, "", "\t")
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			ginkgo.GinkgoWriter.Printf("Asset Scan: %s\n", string(buf))
 		}
 	}
 }

--- a/installation/kubernetes/helm/vmclarity/README.md
+++ b/installation/kubernetes/helm/vmclarity/README.md
@@ -73,7 +73,7 @@ secrets.
 | crDiscoveryServer.serviceAccount.name | string | `""` | The name of the ServiceAccount to use. If not set and create is true, it will use the component's calculated name. |
 | exploitDBServer.containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Force the child process to run as non-privileged |
 | exploitDBServer.containerSecurityContext.capabilities.drop | list | `["ALL"]` | List of capabilities to be dropped |
-| exploitDBServer.containerSecurityContext.enabled | bool | `true` | Container security context enabled |
+| exploitDBServer.containerSecurityContext.enabled | bool | `false` | Container security context enabled |
 | exploitDBServer.containerSecurityContext.privileged | bool | `false` | Whether the container should run in privileged mode |
 | exploitDBServer.containerSecurityContext.readOnlyRootFilesystem | bool | `true` | Mounts the container file system as ReadOnly |
 | exploitDBServer.containerSecurityContext.runAsGroup | int | `1001` | Group ID which the containers should run as |

--- a/installation/kubernetes/helm/vmclarity/values.yaml
+++ b/installation/kubernetes/helm/vmclarity/values.yaml
@@ -529,7 +529,7 @@ exploitDBServer:
 
   containerSecurityContext:
     # -- Container security context enabled
-    enabled: true
+    enabled: false
     # -- User ID which the containers should run as
     runAsUser: 1001
     # -- Group ID which the containers should run as


### PR DESCRIPTION
## Description

Revisit kubernetes test environment and ensure that tests are successfully running on this provider.

* Fix images failing to load by using image name not image ID while saving image to load to node
* Define new params for the k8s environment
* Add target in Makefile to run e2e tests on Kubernetes
* Disable syft analyzer in kubernetes e2e tests due to scan failures when scanning container images https://github.com/openclarity/vmclarity/issues/1666 (second error reported)
* Enable misconfiguration family for Docker and Kubernetes (this change required an increase in scan timeout)

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[x] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
