### PR TITLE
ci: run k8s tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,23 @@ jobs:
       use_release_repository: false
       post_image_tags: true
 
-  e2e:
+  e2e-docker:
     needs: build
-    name: End-to-End
+    name: End-to-End Tests on Docker
     uses: ./.github/workflows/reusable-end-to-end-testing.yml
     with:
       image_tag: ${{ format('pr{0}-{1}', github.event.pull_request.number, github.sha) }}
       use_release_repository: false
+      platform: docker
+
+  e2e-k8s:
+    needs: build
+    name: End-to-End Tests on Kubernetes
+    uses: ./.github/workflows/reusable-end-to-end-testing.yml
+    with:
+      image_tag: ${{ format('pr{0}-{1}', github.event.pull_request.number, github.sha) }}
+      use_release_repository: false
+      platform: kubernetes
 
   success:
     # https://github.com/actions/runner/issues/2566
@@ -42,7 +52,8 @@ jobs:
     if: ${{ !cancelled() && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'failure') }}
     needs:
       - build
-      - e2e
+      - e2e-docker
+      - e2e-k8s
     name: Success
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/reusable-end-to-end-testing.yml
+++ b/.github/workflows/reusable-end-to-end-testing.yml
@@ -111,4 +111,4 @@ jobs:
           VMCLARITY_E2E_CR_DISCOVERY_SERVER_IMAGE: ${{ format('{0}:{1}', needs.images.outputs.cr-discovery-server-image, inputs.image_tag) }}
           VMCLARITY_E2E_SCANNER_PLUGIN_KICS: ${{ format('{0}:{1}', needs.images.outputs.plugin-kics-image, inputs.image_tag) }}
         run: |
-          make e2e
+          make e2e-docker

--- a/.github/workflows/reusable-end-to-end-testing.yml
+++ b/.github/workflows/reusable-end-to-end-testing.yml
@@ -17,6 +17,10 @@ on:
         type: boolean
         description: 'If set to true the image published to the release repository is used otherwise the development.'
         default: false
+      platform:
+        required: true
+        type: string
+        description: 'Platform used to run end-to-end tests. Supported values are `docker` and `kubernetes`.'
 
 jobs:
   images:
@@ -101,6 +105,16 @@ jobs:
             ${{ runner.os }}-go-${{ github.ref_name }}-
             ${{ runner.os }}-go-${{ github.event.repository.default_branch }}-
 
+      - name: Install kind for Kubernetes
+        if: inputs.platform == 'kubernetes'
+        uses: engineerd/setup-kind@v0.5.0
+        with:
+          skipClusterCreation: true
+
+      - name: Install helm for Kubernetes
+        if: inputs.platform == 'kubernetes'
+        uses: azure/setup-helm@v4.2.0
+
       - name: Run end to end tests
         env:
           VMCLARITY_E2E_APISERVER_IMAGE:  ${{ format('{0}:{1}', needs.images.outputs.apiserver-image, inputs.image_tag) }}
@@ -110,5 +124,12 @@ jobs:
           VMCLARITY_E2E_SCANNER_IMAGE: ${{ format('{0}:{1}', needs.images.outputs.cli-image, inputs.image_tag) }}
           VMCLARITY_E2E_CR_DISCOVERY_SERVER_IMAGE: ${{ format('{0}:{1}', needs.images.outputs.cr-discovery-server-image, inputs.image_tag) }}
           VMCLARITY_E2E_SCANNER_PLUGIN_KICS: ${{ format('{0}:{1}', needs.images.outputs.plugin-kics-image, inputs.image_tag) }}
+          VMCLARITY_E2E_PLATFORM: ${{ inputs.platform }}
         run: |
-          make e2e-docker
+          if [[ "${{ inputs.platform }}" == "kubernetes" ]]; then
+            make e2e-k8s
+          elif [[ "${{ inputs.platform }}" == "docker" ]]; then
+            make e2e-docker
+          else
+            echo "Invalid platform"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -165,15 +165,20 @@ ifneq ($(CI),true)
 endif
 
 .PHONY: e2e
-e2e: $(E2E_TARGETS) ## Run end-to-end test suite on Docker
-	$(E2E_ENV) go -C $(ROOT_DIR)/e2e test -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 2h -timeout 2h -ginkgo.v .
+e2e: e2e-docker e2e-k8s ## Run end-to-end test suite
+
+E2E_COMMAND = go -C $(ROOT_DIR)/e2e test -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 2h -timeout 2h -ginkgo.v .
+
+.PHONY: e2e-docker
+e2e-docker: $(E2E_TARGETS) ## Run end-to-end test suite on Docker
+	$(E2E_ENV) $(E2E_COMMAND)
 
 E2E_ENV_K8S = $(E2E_ENV)
 E2E_ENV_K8S += VMCLARITY_E2E_PLATFORM=kubernetes
 
 .PHONY: e2e-k8s
 e2e-k8s: $(E2E_TARGETS) ## Run end-to-end test suite on Kubernetes
-	$(E2E_ENV_K8S) go -C $(ROOT_DIR)/e2e test -v -failfast -test.v -test.paniconexit0 -ginkgo.timeout 2h -timeout 2h -ginkgo.v .
+	$(E2E_ENV_K8S) $(E2E_COMMAND)
 
 VENDORMODULES = $(addprefix vendor-, $(GOMODULES))
 

--- a/testenv/kubernetes/kind/dockerimageloader.go
+++ b/testenv/kubernetes/kind/dockerimageloader.go
@@ -52,27 +52,7 @@ func (l *DockerImageLoader) imageIDsFromRepoTags(ctx context.Context, repoTags [
 		}
 
 		if len(result) <= 0 {
-			// Pull image if not found locally
-			resp, err := l.docker.ImagePull(ctx, repoTag, imagetypes.PullOptions{})
-			if err != nil {
-				return nil, fmt.Errorf("failed to pull image %s: %w", repoTag, err)
-			}
-
-			// Drain response to avoid blocking
-			_, _ = io.Copy(io.Discard, resp)
-			_ = resp.Close()
-
-			result, err = l.docker.ImageList(ctx, imagetypes.ListOptions{
-				Filters: filters.NewArgs(
-					filters.Arg("reference", repoTag)),
-			})
-			if err != nil {
-				return nil, fmt.Errorf("failed to list image %s: %w", repoTag, err)
-			}
-
-			if len(result) <= 0 {
-				return nil, fmt.Errorf("failed to find image: %s", repoTag)
-			}
+			continue
 		}
 
 		imageIDs = append(imageIDs, result[0].ID)
@@ -98,8 +78,30 @@ func (l *DockerImageLoader) Load(ctx context.Context, nodes []nodes.Node) error 
 	mapping := make(imageIDRepoTagMapping, 0)
 	for _, image := range l.images {
 		ids, err := l.imageIDsFromRepoTags(ctx, []string{image})
-		if err != nil || len(ids) == 0 {
+		if err != nil {
 			return fmt.Errorf("failed to get ImageID for RepoTag %s: %w", image, err)
+		}
+
+		if len(ids) <= 0 {
+			logger.Infof("failed to find image %s locally, trying image pull", image)
+			resp, err := l.docker.ImagePull(ctx, image, imagetypes.PullOptions{})
+			if err != nil {
+				return fmt.Errorf("failed to pull image %s: %w", image, err)
+			}
+
+			// Drain response to avoid blocking
+			_, _ = io.Copy(io.Discard, resp)
+			_ = resp.Close()
+
+			result, err := l.docker.ImageList(ctx, imagetypes.ListOptions{
+				Filters: filters.NewArgs(
+					filters.Arg("reference", image)),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to list image %s: %w", image, err)
+			}
+
+			ids = []string{result[0].ID}
 		}
 
 		mapping[ids[0]] = image


### PR DESCRIPTION
## Description

* Add new `make e2e-docker` target and use `make e2e` to run end to end tests on both Docker and Kubernetes
* Run end to end tests running on Kubernetes in the CI pipeline. This should not increase the CI pipeline run time significantly since Kubernetes tests (~15min) and Docker tests (~14min) will run in parallel.
* Required steps for merge in this repository need to be updated

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
