### PR TITLE
fix: use custom network for plugin communication

### DIFF
--- a/plugins/runner/internal/containermanager/docker/client.go
+++ b/plugins/runner/internal/containermanager/docker/client.go
@@ -1,0 +1,120 @@
+// Copyright © 2024 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync/atomic"
+
+	dockertypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	dockerclient "github.com/docker/docker/client"
+)
+
+var cachedClient atomic.Pointer[dockerclient.Client]
+
+type dockerClient struct {
+	*dockerclient.Client
+}
+
+// newDockerClient creates a wrapped docker client with helper methods.
+func newDockerClient() (*dockerClient, error) {
+	if cachedClient.Load() == nil {
+		client, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+		if err != nil {
+			return nil, fmt.Errorf("failed to create docker dockerClient: %w", err)
+		}
+		cachedClient.Store(client)
+	}
+
+	return &dockerClient{
+		Client: cachedClient.Load(),
+	}, nil
+}
+
+// GetHostContainer returns the container in which this code is being executed
+// when running in container mode.
+func (c *dockerClient) GetHostContainer(ctx context.Context) (*dockertypes.ContainerJSON, error) {
+	// Check if the host is running inside a docker container.
+	// The hostname is the container ID unless it was manually changed.
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine hostname: %w", err)
+	}
+
+	// Get host container details
+	switch container, err := c.Client.ContainerInspect(ctx, hostname); {
+	case err == nil:
+		// host in container
+		return &container, nil
+
+	case dockerclient.IsErrNotFound(err):
+		// host not in container
+		return nil, nil // nolint:nilnil
+
+	default:
+		// docker error
+		return nil, fmt.Errorf("failed to inspect host: %w", err)
+	}
+}
+
+// GetOrCreateBridgeNetwork creates a bridge network if it does not exist or
+// returns ID if it exists.
+func (c *dockerClient) GetOrCreateBridgeNetwork(ctx context.Context, networkName string) (string, error) {
+	// Do nothing if network already exists
+	networkID, _ := c.getNetworkIDFromName(ctx, networkName)
+	if networkID != "" {
+		return networkID, nil
+	}
+
+	// Create network
+	networkResp, err := c.Client.NetworkCreate(
+		ctx,
+		networkName,
+		dockertypes.NetworkCreate{
+			CheckDuplicate: true,
+			Driver:         "bridge",
+		},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create plugin network: %w", err)
+	}
+
+	return networkResp.ID, nil
+}
+
+func (c *dockerClient) getNetworkIDFromName(ctx context.Context, networkName string) (string, error) {
+	networks, err := c.Client.NetworkList(ctx, dockertypes.NetworkListOptions{
+		Filters: filters.NewArgs(filters.Arg("name", networkName)),
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to list networks: %w", err)
+	}
+	if len(networks) == 0 {
+		return "", fmt.Errorf("scan network not found: %w", err)
+	}
+	if len(networks) > 1 {
+		for _, n := range networks {
+			if n.Name == networkName {
+				return n.ID, nil
+			}
+		}
+		return "", fmt.Errorf("found more than one scan network: %w", err)
+	}
+	return networks[0].ID, nil
+}

--- a/plugins/runner/internal/containermanager/types.go
+++ b/plugins/runner/internal/containermanager/types.go
@@ -32,7 +32,7 @@ const (
 type PluginContainerManager interface {
 	Start(ctx context.Context) error
 	Ready() (bool, error)
-	GetPluginServerEndpoint() (string, error)
+	GetPluginServerEndpoint(ctx context.Context) (string, error)
 	Logs(ctx context.Context) (io.ReadCloser, error)
 	Result(ctx context.Context) (io.ReadCloser, error)
 	Remove(ctx context.Context) error

--- a/plugins/runner/runner.go
+++ b/plugins/runner/runner.go
@@ -93,7 +93,7 @@ func (r *pluginRunner) WaitReady(ctx context.Context) error {
 			}
 
 			// Set plugin server endpoint
-			serverEndpoint, err := r.containerManager.GetPluginServerEndpoint()
+			serverEndpoint, err := r.containerManager.GetPluginServerEndpoint(ctx)
 			if err != nil {
 				return fmt.Errorf("failed to get plugin server endpoint: %w", err)
 			}

--- a/scanner/families/plugins/runner/runner.go
+++ b/scanner/families/plugins/runner/runner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	apitypes "github.com/openclarity/vmclarity/api/types"
+	"github.com/openclarity/vmclarity/core/to"
 	"github.com/openclarity/vmclarity/plugins/runner"
 	"github.com/openclarity/vmclarity/plugins/runner/types"
 	plugintypes "github.com/openclarity/vmclarity/plugins/sdk-go/types"
@@ -108,7 +109,11 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 
 		// Stream logs
 		go func() {
-			logger := s.logger.WithField("metadata", metadata).WithField("plugin", s.config.Name)
+			logger := s.logger.WithField("metadata", map[string]interface{}{
+				"name":       to.ValueOrZero(metadata.Name),
+				"version":    to.ValueOrZero(metadata.Version),
+				"apiVersion": to.ValueOrZero(metadata.ApiVersion),
+			}).WithField("plugin", s.config.Name)
 
 			logs, err := rr.Logs(ctx)
 			if err != nil {


### PR DESCRIPTION
## Description

This PR creates a default plugin network to isolate all plugins from the rest of Docker services. Plugins will only be part of this network.

If running the CLI in container mode, the host container will be attached to the plugin network to allow DNS resolution of plugin container IDs used for communication.

Minor fix to plugin family logging to ensure that plugin metadata is displayed properly instead of pointer values.

IMPORTANT NOTE: Host container when running in container mode needs to have default hostname set by Docker to ensure that it can be detected. If the host container has a custom hostname (e.g. set via --hostname custom-scanner), then VMClarity will not be able to fetch the host container from its hostname and the plugin support will not work.

## Type of Change

[x] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
