### PR TITLE
chore(deps): update Python version to 3.12

### DIFF
--- a/plugins/sdk-python/example/Dockerfile.test
+++ b/plugins/sdk-python/example/Dockerfile.test
@@ -4,12 +4,12 @@ FROM ubuntu:24.04 AS builder-image
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update &&  \
-    apt-get install --no-install-recommends -y python3.9 python3.9-dev python3.9-venv python3-pip python3-wheel build-essential && \
+    apt-get install --no-install-recommends -y python3.12 python3.12-dev python3.12-venv python3-pip python3-wheel build-essential && \
 	  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create and activate virtual environment
 # Using final folder name to avoid path issues with packages
-RUN python3.9 -m venv /venv
+RUN python3.12 -m venv /venv
 ENV PATH="/venv/bin:$PATH"
 
 # Install SDK from folder
@@ -21,7 +21,7 @@ RUN pip3 install --no-cache-dir /pluginsdk
 FROM ubuntu:24.04 AS runner-image
 
 RUN apt-get update &&  \
-    apt-get install --no-install-recommends -y python3.9 python3-venv && \
+    apt-get install --no-install-recommends -y python3.12 python3-venv && \
 	  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy installed venv packages


### PR DESCRIPTION
## Description

Updating the Python version in the test Dockerfile of the example of the python plugin SDK, because v3.9 is not available anymore in the repositories of Ubuntu 24.04 that was updated here: 

https://github.com/openclarity/vmclarity/commit/cb413065f1236cee15773a6d185748dbe17eda25

This causes building the docker image to fail:

```
22.85 E: Unable to locate package python3.9
22.85 E: Couldn't find any package by glob 'python3.9'
22.85 E: Couldn't find any package by regex 'python3.9'
------
Dockerfile.test:23
--------------------
  22 |     
  23 | >>> RUN apt-get update &&  \
  24 | >>>     apt-get install --no-install-recommends -y python3.9 python3-venv && \
  25 | >>>        apt-get clean && rm -rf /var/lib/apt/lists/*
  26 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update &&      apt-get install --no-install-recommends -y python3.9 python3-venv && \t  apt-get clean && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
make: *** [docker-scanner-plugins] Error 1
```

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[X] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
