### PR TITLE
feat: make grype timeouts configurable

### DIFF
--- a/.families.yaml
+++ b/.families.yaml
@@ -46,6 +46,9 @@ vulnerabilities:
           update_db: true
           db_root_dir: "/tmp/"
           listing_url: "https://toolbox-data.anchore.io/grype/databases/listing.json"
+          max_allowed_built_age: "120h"
+          listing_file_timeout: "60s"
+          update_timeout: "60s"
           scope: "squashed"
         remote_grype_config:
           grype_server_address: ""

--- a/orchestrator/watcher/assetscan/families.go
+++ b/orchestrator/watcher/assetscan/families.go
@@ -91,10 +91,13 @@ func withVulnerabilities(config *apitypes.VulnerabilitiesConfig, opts *ScannerCo
 			grypeConfig = cliconfig.GrypeConfig{
 				Mode: cliconfig.ModeLocal,
 				LocalGrypeConfig: cliconfig.LocalGrypeConfig{
-					UpdateDB:   true,
-					DBRootDir:  "/tmp/",
-					ListingURL: "https://toolbox-data.anchore.io/grype/databases/listing.json",
-					Scope:      source.SquashedScope,
+					UpdateDB:           true,
+					DBRootDir:          "/tmp/",
+					ListingURL:         cliconfig.DefaultGrypeListingURL,
+					MaxAllowedBuiltAge: cliconfig.DefaultGrypeMaxDatabaseAge,
+					ListingFileTimeout: cliconfig.DefaultGrypeListingFileTimeout,
+					UpdateTimeout:      cliconfig.DefaultGrypeUpdateTimeout,
+					Scope:              source.SquashedScope,
 				},
 			}
 		}

--- a/scanner/config/local_grype.go
+++ b/scanner/config/local_grype.go
@@ -16,8 +16,17 @@
 package config
 
 import (
+	"time"
+
 	"github.com/anchore/stereoscope/pkg/image"
 	"github.com/anchore/syft/syft/source"
+)
+
+const (
+	DefaultGrypeListingURL         = "https://toolbox-data.anchore.io/grype/databases/listing.json"
+	DefaultGrypeListingFileTimeout = 60 * time.Second
+	DefaultGrypeUpdateTimeout      = 60 * time.Second
+	DefaultGrypeMaxDatabaseAge     = 120 * time.Hour
 )
 
 type LocalGrypeConfigEx struct {
@@ -26,10 +35,13 @@ type LocalGrypeConfigEx struct {
 }
 
 type LocalGrypeConfig struct {
-	UpdateDB   bool         `yaml:"update_db" mapstructure:"update_db"`
-	DBRootDir  string       `yaml:"db_root_dir" mapstructure:"db_root_dir"` // Location to write the vulnerability database cache.
-	ListingURL string       `yaml:"listing_url" mapstructure:"listing_url"` // URL of the vulnerability database.
-	Scope      source.Scope `yaml:"scope" mapstructure:"scope"`             // indicates "how" or from "which perspectives" the source object should be cataloged from.
+	UpdateDB           bool          `yaml:"update_db" mapstructure:"update_db"`
+	DBRootDir          string        `yaml:"db_root_dir" mapstructure:"db_root_dir"`                     // Location to write the vulnerability database cache.
+	ListingURL         string        `yaml:"listing_url" mapstructure:"listing_url"`                     // URL of the vulnerability database.
+	MaxAllowedBuiltAge time.Duration `yaml:"max_allowed_built_age" mapstructure:"max_allowed_built_age"` // Period if time after which the database is considered stale.
+	ListingFileTimeout time.Duration `yaml:"listing_file_timeout" mapstructure:"listing_file_timeout"`   // Timeout of grype's HTTP client used for downloading the listing file.
+	UpdateTimeout      time.Duration `yaml:"update_timeout" mapstructure:"update_timeout"`               // Timeout of grype's HTTP client used for downloading the database.
+	Scope              source.Scope  `yaml:"scope" mapstructure:"scope"`                                 // indicates "how" or from "which perspectives" the source object should be cataloged from.
 }
 
 func ConvertToLocalGrypeConfig(scanner *Scanner, registry *Registry) LocalGrypeConfigEx {
@@ -46,10 +58,13 @@ func ConvertToLocalGrypeConfig(scanner *Scanner, registry *Registry) LocalGrypeC
 
 	return LocalGrypeConfigEx{
 		LocalGrypeConfig: LocalGrypeConfig{
-			UpdateDB:   scanner.GrypeConfig.UpdateDB,
-			DBRootDir:  scanner.GrypeConfig.DBRootDir,
-			ListingURL: scanner.GrypeConfig.ListingURL,
-			Scope:      source.ParseScope(string(scanner.GrypeConfig.Scope)),
+			UpdateDB:           scanner.GrypeConfig.UpdateDB,
+			DBRootDir:          scanner.GrypeConfig.DBRootDir,
+			ListingURL:         scanner.GrypeConfig.ListingURL,
+			MaxAllowedBuiltAge: scanner.GrypeConfig.MaxAllowedBuiltAge,
+			ListingFileTimeout: scanner.GrypeConfig.ListingFileTimeout,
+			UpdateTimeout:      scanner.GrypeConfig.UpdateTimeout,
+			Scope:              source.ParseScope(string(scanner.GrypeConfig.Scope)),
 		},
 		RegistryOptions: &image.RegistryOptions{
 			InsecureSkipTLSVerify: registry.SkipVerifyTLS,

--- a/scanner/config/local_grype.go
+++ b/scanner/config/local_grype.go
@@ -38,7 +38,7 @@ type LocalGrypeConfig struct {
 	UpdateDB           bool          `yaml:"update_db" mapstructure:"update_db"`
 	DBRootDir          string        `yaml:"db_root_dir" mapstructure:"db_root_dir"`                     // Location to write the vulnerability database cache.
 	ListingURL         string        `yaml:"listing_url" mapstructure:"listing_url"`                     // URL of the vulnerability database.
-	MaxAllowedBuiltAge time.Duration `yaml:"max_allowed_built_age" mapstructure:"max_allowed_built_age"` // Period if time after which the database is considered stale.
+	MaxAllowedBuiltAge time.Duration `yaml:"max_allowed_built_age" mapstructure:"max_allowed_built_age"` // Period of time after which the database is considered stale.
 	ListingFileTimeout time.Duration `yaml:"listing_file_timeout" mapstructure:"listing_file_timeout"`   // Timeout of grype's HTTP client used for downloading the listing file.
 	UpdateTimeout      time.Duration `yaml:"update_timeout" mapstructure:"update_timeout"`               // Timeout of grype's HTTP client used for downloading the database.
 	Scope              source.Scope  `yaml:"scope" mapstructure:"scope"`                                 // indicates "how" or from "which perspectives" the source object should be cataloged from.

--- a/scanner/scanner/grype/local_grype.go
+++ b/scanner/scanner/grype/local_grype.go
@@ -80,6 +80,9 @@ func (s *LocalScanner) run(sourceType utils.SourceType, userInput string) {
 		DBRootDir:           s.config.DBRootDir,
 		ListingURL:          s.config.ListingURL,
 		ValidateByHashOnGet: false,
+		MaxAllowedBuiltAge:  s.config.MaxAllowedBuiltAge,
+		ListingFileTimeout:  s.config.ListingFileTimeout,
+		UpdateTimeout:       s.config.UpdateTimeout,
 	}
 	s.logger.Infof("Loading DB. update=%v", s.config.UpdateDB)
 


### PR DESCRIPTION
## Description

There is a known issue with grype, it occasionally get stuck when a new database version is published:

https://github.com/anchore/grype/issues/1731

To solve this problem, timeouts of the HTTP client have been made configurable: 

https://github.com/anchore/grype/commit/7c849c33b01396cb2346e656f01376d8474f3d7a


This PR allows VMClarity users to configure these timeouts. 

## Type of Change

[ ] Bug Fix  
[X] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
