### PR TITLE
feat: add the capability to exclude directories and files from ClamAV

### DIFF
--- a/.families.yaml
+++ b/.families.yaml
@@ -113,6 +113,10 @@ malware:
     clam:
       freshclam_binary_path: freshclam
       clamscan_binary_path: clamscan
+      #clamscan_exclude_files:
+      #  - "^.*\.log$"
+      #clamscan_exclude_dirs:
+      #  - "^/sys"
 
 rootkits:
   enabled: true

--- a/scanner/families/malware/clam/clam.go
+++ b/scanner/families/malware/clam/clam.go
@@ -115,7 +115,24 @@ func (s *Scanner) Run(sourceType utils.SourceType, userInput string) error {
 		defer cleanup()
 
 		// Define the clamscan args to run
-		args := []string{"--infected", "-r", fsPath}
+		// Set default arguments
+		args := []string{
+			"--infected",
+			"--recursive",
+		}
+
+		// --exclude=REGEX, --exclude-dir=REGEX
+		// Don't scan file/directory names matching regular expression. These options can be used multiple times.
+		for _, file := range s.config.ClamScanExcludeFiles {
+			args = append(args, "--exclude="+file)
+		}
+
+		for _, dir := range s.config.ClamScanExcludeDirs {
+			args = append(args, "--exclude-dir="+dir)
+		}
+
+		// Append files/directories to scan as a last argument - clamscan [options] [file/directory/-]
+		args = append(args, fsPath)
 
 		s.logger.Infof("Running clamscan...")
 		// Execute the clamscan command

--- a/scanner/families/malware/clam/config/config.go
+++ b/scanner/families/malware/clam/config/config.go
@@ -16,7 +16,9 @@
 package config
 
 type Config struct {
-	ClamScanBinaryPath            string `yaml:"clamscan_binary_path" mapstructure:"clamscan_binary_path"`
-	FreshclamBinaryPath           string `yaml:"freshclam_binary_path" mapstructure:"freshclam_binary_path"`
-	AlternativeFreshclamMirrorURL string `yaml:"alternative_freshclam_mirror_url" mapstructure:"alternative_freshclam_mirror_url"`
+	ClamScanBinaryPath            string   `yaml:"clamscan_binary_path" mapstructure:"clamscan_binary_path"`
+	ClamScanExcludeFiles          []string `yaml:"clamscan_exclude_files" mapstructure:"clamscan_exclude_files"`
+	ClamScanExcludeDirs           []string `yaml:"clamscan_exclude_dirs" mapstructure:"clamscan_exclude_dirs"`
+	FreshclamBinaryPath           string   `yaml:"freshclam_binary_path" mapstructure:"freshclam_binary_path"`
+	AlternativeFreshclamMirrorURL string   `yaml:"alternative_freshclam_mirror_url" mapstructure:"alternative_freshclam_mirror_url"`
 }


### PR DESCRIPTION
## Description

Adding the capability to exclude directories and files from ClamAV.

https://linux.die.net/man/1/clamscan

```
--exclude=REGEX, --exclude-dir=REGEX
Don't scan file/directory names matching regular expression. These options can be used multiple times.
```

## Type of Change

[ ] Bug Fix  
[X] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
