### PR TITLE
feat: change renovate schedule to weekly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -253,14 +253,12 @@
     "gomodUpdateImportPaths",
     "helmUpdateSubChartArchives"
   ],
-  "prConcurrentLimit": 10,
-  "prHourlyLimit": 5,
+  "prConcurrentLimit": 20,
   "printConfig": false,
   "rebaseWhen": "conflicted",
   "reviewersFromCodeOwners": true,
   "schedule": [
-    "after 6am every weekday",
-    "before 12pm every weekday"
+    "after 8am on Monday"
   ],
   "semanticCommits": "enabled",
   "timezone": "Etc/UTC",


### PR DESCRIPTION
## Description

Change renovate bot to weekly updates and increase the concurrent limit to 20.

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
