### PR TITLE
ci: remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,14 +58,11 @@ linters:
   disable:
     - musttag
     - revive
-    - maligned
     - funlen
     - dupl
     - nestif
     - wsl
     - lll
-    - interfacer
-    - exhaustivestruct
     - nlreturn
     - gocritic
     - gochecknoglobals
@@ -74,13 +71,6 @@ linters:
     - paralleltest
     - godox # Allow TODOs
     - tagliatelle # Allow json(camel)
-    - scopelint # deprecated
-    - golint # deprecated
-    - ifshort # deprecated
-    - deadcode # deprecated
-    - varcheck # deprecated
-    - structcheck # deprecated
-    - nosnakecase # deprecated
     - gomnd # deprecated
     - execinquery # deprecated
     - gochecknoinits # Allow init function


### PR DESCRIPTION
## Description

Remove deprecated linters from disabled list to avoid warning messages

## Type of Change

[ ] Bug Fix  
[ ] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[x] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
