### PR TITLE
feat(cli): support ntfs mount and unmount

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -133,6 +133,8 @@ func isSupportedFS(fs string) bool {
 		return true
 	case string(filesystem.Xfs):
 		return true
+	case string(filesystem.Ntfs):
+		return true
 	default:
 		return false
 	}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -59,6 +59,13 @@ func Test_isSupportedFS(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "ntfs is supported",
+			args: args{
+				fs: filesystem.Ntfs,
+			},
+			want: true,
+		},
+		{
 			name: "btrfs is not supported",
 			args: args{
 				fs: "btrfs",

--- a/utils/fsutils/blockdevice/darwin.go
+++ b/utils/fsutils/blockdevice/darwin.go
@@ -13,26 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !linux && !darwin
-// +build !linux,!darwin
+//go:build darwin
+// +build darwin
 
 package blockdevice
 
 import (
 	"context"
 	"fmt"
-	"runtime"
+
+	"github.com/openclarity/vmclarity/utils/fsutils/diskutil"
 )
 
-type BlockDevice struct {
-	Name       string
-	Path       string
-	FSType     string
-	MountPoint string
-	Label      string
-	UUID       string
-}
+type BlockDevice = diskutil.BlockDevice
 
-func List(_ context.Context) ([]BlockDevice, error) {
-	return nil, fmt.Errorf("mount is unsupported on %s platform", runtime.GOOS)
+func List(ctx context.Context) ([]BlockDevice, error) {
+	blockDevices, err := diskutil.New().List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list block devices: %w", err)
+	}
+
+	return blockDevices, nil
 }

--- a/utils/fsutils/diskutil/blockdevice.go
+++ b/utils/fsutils/diskutil/blockdevice.go
@@ -1,0 +1,75 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskutil
+
+import (
+	"fmt"
+)
+
+type Bytes float64
+
+type BlockDevice struct {
+	DeviceIdentifier string `json:"deviceIdentifier,omitempty" mapstructure:"DEVICE_IDENTIFIER"`
+	Path             string `json:"path,omitempty" mapstructure:"PATH"` // path to the device node
+	Whole            bool   `json:"whole,omitempty" mapstructure:"WHOLE"`
+	PartOfWhole      string `json:"partOfWhole,omitempty" mapstructure:"PART_OF_WHOLE"`
+	DeviceMediaName  string `json:"deviceMediaName,omitempty" mapstructure:"DEVICE_MEDIA_NAME"`
+
+	VolumeName string `json:"volumeName,omitempty" mapstructure:"VOLUME_NAME"`
+	Mounted    bool   `json:"mounted,omitempty" mapstructure:"MOUNTED"`
+	MountPoint string `json:"mountPoint,omitempty" mapstructure:"MOUNT_POINT"`
+	FileSystem string `json:"fileSystem,omitempty" mapstructure:"FILE_SYSTEM"`
+
+	PartitionType   string `json:"partitionType,omitempty" mapstructure:"PARTITION_TYPE"`
+	FSType          string `json:"fstype,omitempty" mapstructure:"FSTYPE"` // filesystem type
+	TypeBundle      string `json:"typeBundle,omitempty" mapstructure:"TYPE_BUNDLE"`
+	NameUserVisible string `json:"nameUserVisible,omitempty" mapstructure:"NAME_USER_VISIBLE"`
+	Owners          string `json:"owners,omitempty" mapstructure:"OWNERS"`
+
+	Content           string `json:"content,omitempty" mapstructure:"CONTENT"`
+	OSCanBeInstalled  bool   `json:"osCanBeInstalled,omitempty" mapstructure:"OS_CAN_BE_INSTALLED"`
+	BooterDisk        string `json:"booterDisk,omitempty" mapstructure:"BOOTER_DISK"`
+	RecoveryDisk      string `json:"recoveryDisk,omitempty" mapstructure:"RECVOERY_DISK"`
+	MediaType         string `json:"mediaType,omitempty" mapstructure:"MEDIA_TYPE"`
+	Protocol          string `json:"protocol,omitempty" mapstructure:"PROTOCOL"`
+	SMARTStatus       string `json:"smartStatus,omitempty" mapstructure:"SMART_STATUS"`
+	VolumeUUID        string `json:"volumeUUID,omitempty" mapstructure:"VOLUME_UUID"`
+	DiskPartitionUUID string `json:"diskPartitionUUID,omitempty" mapstructure:"DISK_PARTITION_UUID"`
+	PartitionOffset   Bytes  `json:"partitionOffset,omitempty" mapstructure:"PARTITION_OFFSET"`
+
+	DiskSize        Bytes `json:"diskSize,omitempty" mapstructure:"DISK_SIZE"`
+	DeviceBlockSize Bytes `json:"deviceBlockSize,omitempty" mapstructure:"DEVICE_BLOCK_SIZE"`
+
+	VolumeUsedSpace     Bytes `json:"volumeUsedSpace,omitempty" mapstructure:"VOLUME_USED_SPACE"`
+	ContainerTotalSpace Bytes `json:"containerTotalSpace,omitempty" mapstructure:"CONTAINER_TOTAL_SPACE"`
+	ContainerFreeSpace  Bytes `json:"containerFreeSpace,omitempty" mapstructure:"CONTAINER_FREE_SPACE"`
+	AllocationBlockSize Bytes `json:"allocationBlockSize,omitempty" mapstructure:"ALLOCATION_BLOCK_SIZE"`
+
+	MediaOSUseOnly bool `json:"mediaOSUseOnly,omitempty" mapstructure:"MEDIA_OS_USE_ONLY"`
+	MediaReadOnly  bool `json:"mediaReadOnly,omitempty" mapstructure:"MEDIA_READ_ONLY"`
+	VolumeReadOnly bool `json:"volumeReadOnly,omitempty" mapstructure:"VOLUME_READ_ONLY"`
+
+	DeviceLocation string `json:"deviceLocation,omitempty" mapstructure:"DEVICE_LOCATION"`
+	RemovableMedia string `json:"removableMedia,omitempty" mapstructure:"REMOVABLE_MEDIA"`
+
+	SolidState         bool `json:"solidState,omitempty" mapstructure:"SOLID_STATE"`
+	Virtual            bool `json:"virtual,omitempty" mapstructure:"VIRTUAL"`
+	HardwareAESSupport bool `json:"hardwareAESSupport,omitempty" mapstructure:"HARDWARE_AES_SUPPORT"`
+}
+
+func (b BlockDevice) String() string {
+	return fmt.Sprintf("Device: %s Filesystem: %s MountPoint: %s", b.DeviceIdentifier, b.FSType, b.MountPoint)
+}

--- a/utils/fsutils/diskutil/diskutil.go
+++ b/utils/fsutils/diskutil/diskutil.go
@@ -1,0 +1,70 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/openclarity/vmclarity/utils/command"
+)
+
+type Diskutil struct {
+	BinaryPath  string
+	Environment []string
+}
+
+func (d *Diskutil) List(ctx context.Context, devPaths ...string) ([]BlockDevice, error) {
+	args := []string{"info", "-all"}
+	if devPaths != nil {
+		args = append(args, devPaths...)
+	}
+
+	o, err := d.run(ctx, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run diskutil command: %w", err)
+	}
+
+	blockDevices, err := parse(o.StdOut)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse diskutil output: %w", err)
+	}
+
+	return blockDevices, nil
+}
+
+func (d *Diskutil) run(ctx context.Context, args ...string) (*command.State, error) {
+	cmd := &command.Command{
+		Cmd:  d.BinaryPath,
+		Args: args,
+		Env:  d.Environment,
+	}
+
+	result, err := cmd.Run(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to run diskutil command: %w", err)
+	}
+
+	return result, nil
+}
+
+func New() *Diskutil {
+	return &Diskutil{
+		BinaryPath:  "diskutil",
+		Environment: os.Environ(),
+	}
+}

--- a/utils/fsutils/diskutil/parse.go
+++ b/utils/fsutils/diskutil/parse.go
@@ -1,0 +1,318 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskutil
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Parse diskutil output into a list of BlockDevice objects.
+// Example output:
+//    Device Identifier:         disk3s5
+//    Device Node:               /dev/disk3s5
+//    Whole:                     No
+//    Part of Whole:             disk3
+
+//    Volume Name:               Data
+//    Mounted:                   Yes
+//    Mount Point:               /System/Volumes/Data
+
+//    Partition Type:            41504653-0000-11AA-AA11-00306543ECAC
+//    File System Personality:   APFS
+//    Type (Bundle):             apfs
+//    Name (User Visible):       APFS
+//    Owners:                    Enabled
+
+//    OS Can Be Installed:       Yes
+//    Booter Disk:               disk3s2
+//    Recovery Disk:             disk3s3
+//    Media Type:                Generic
+//    Protocol:                  Apple Fabric
+//    SMART Status:              Verified
+//    Volume UUID:               10F7AAC0-5602-48CD-8BB3-80DBB7A03D91
+//    Disk / Partition UUID:     10F7AAC0-5602-48CD-8BB3-80DBB7A03D91
+
+//    Disk Size:                 494.4 GB (494384795648 Bytes) (exactly 965595304 512-Byte-Units)
+//    Device Block Size:         4096 Bytes
+
+//    Volume Used Space:         192.7 GB (192652795904 Bytes) (exactly 376274992 512-Byte-Units)
+//    Container Total Space:     494.4 GB (494384795648 Bytes) (exactly 965595304 512-Byte-Units)
+//    Container Free Space:      282.0 GB (281962233856 Bytes) (exactly 550707488 512-Byte-Units)
+//    Allocation Block Size:     4096 Bytes
+
+//    Media OS Use Only:         No
+//    Media Read-Only:           No
+//    Volume Read-Only:          No
+
+//    Device Location:           Internal
+//    Removable Media:           Fixed
+
+//    Solid State:               Yes
+//    Hardware AES Support:      Yes
+
+//    This disk is an APFS Volume.  APFS Information:
+//    APFS Container:            disk3
+//    APFS Physical Store:       disk0s2
+//    Fusion Drive:              No
+//    APFS Volume Group:         10F7AAC0-5602-48CD-8BB3-80DBB7A03D91
+//    FileVault:                 Yes
+//    Sealed:                    No
+//    Locked:                    No
+
+// **********
+
+//    Device Identifier:         disk3s6
+//    Device Node:               /dev/disk3s6
+//    Whole:                     No
+//    Part of Whole:             disk3
+
+//    Volume Name:               VM
+//    Mounted:                   Yes
+//    Mount Point:               /System/Volumes/VM
+
+//    Partition Type:            41504653-0000-11AA-AA11-00306543ECAC
+//    File System Personality:   APFS
+//    Type (Bundle):             apfs
+//    Name (User Visible):       APFS
+//    Owners:                    Enabled
+
+//    OS Can Be Installed:       No
+//    Booter Disk:               disk3s2
+//    Recovery Disk:             disk3s3
+//    Media Type:                Generic
+//    Protocol:                  Apple Fabric
+//    SMART Status:              Verified
+//    Volume UUID:               7E185E38-F7E8-41D2-B5E9-48A7BF23577F
+//    Disk / Partition UUID:     7E185E38-F7E8-41D2-B5E9-48A7BF23577F
+
+//    Disk Size:                 494.4 GB (494384795648 Bytes) (exactly 965595304 512-Byte-Units)
+//    Device Block Size:         4096 Bytes
+
+//    Volume Used Space:         2.1 GB (2147520512 Bytes) (exactly 4194376 512-Byte-Units)
+//    Container Total Space:     494.4 GB (494384795648 Bytes) (exactly 965595304 512-Byte-Units)
+//    Container Free Space:      282.0 GB (281962233856 Bytes) (exactly 550707488 512-Byte-Units)
+//    Allocation Block Size:     4096 Bytes
+
+//    Media OS Use Only:         No
+//    Media Read-Only:           No
+//    Volume Read-Only:          No
+
+//    Device Location:           Internal
+//    Removable Media:           Fixed
+
+//    Solid State:               Yes
+//    Hardware AES Support:      Yes
+
+//    This disk is an APFS Volume.  APFS Information:
+//    APFS Container:            disk3
+//    APFS Physical Store:       disk0s2
+//    Fusion Drive:              No
+//    Encrypted:                 No
+//    FileVault:                 No
+//    Sealed:                    No
+//    Locked:                    No
+
+// **********
+
+func parse(b *bytes.Buffer) ([]BlockDevice, error) {
+	if b == nil {
+		return nil, nil
+	}
+
+	var blockDevices []BlockDevice
+	var currentBlockDevice BlockDevice
+
+	for {
+		line, err := b.ReadString('\n')
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return nil, fmt.Errorf("failed to read line: %w", err)
+		}
+
+		if len(line) == 0 {
+			continue
+		}
+
+		if line == "**********\n" {
+			blockDevices = append(blockDevices, currentBlockDevice)
+			currentBlockDevice = BlockDevice{}
+			continue
+		}
+
+		if err := parseLine(line, &currentBlockDevice); err != nil {
+			return nil, fmt.Errorf("failed to parse line: %w", err)
+		}
+	}
+
+	return blockDevices, nil
+}
+
+// nolint:goconst,gocyclo,cyclop
+func parseLine(line string, bd *BlockDevice) error {
+	var err error
+	switch {
+	case strings.Contains(line, "Device Identifier:"):
+		bd.DeviceIdentifier = parseString(line)
+	case strings.Contains(line, "Device Node:"):
+		bd.Path = parseString(line)
+	case strings.Contains(line, "Part of Whole:"):
+		bd.PartOfWhole = parseString(line)
+	case strings.Contains(line, "Whole:"):
+		bd.Whole = strings.TrimSpace(strings.Split(line, ":")[1]) == "Yes"
+	case strings.Contains(line, "Device / Media Name:"):
+		bd.DeviceMediaName = parseString(line)
+
+	case strings.Contains(line, "Volume Name:"):
+		bd.VolumeName = parseString(line)
+	case strings.Contains(line, "Mounted:"):
+		bd.Mounted = strings.TrimSpace(strings.Split(line, ":")[1]) == "Yes"
+	case strings.Contains(line, "Mount Point:"):
+		bd.MountPoint = parseString(line)
+	case strings.Contains(line, "File System:"):
+		bd.FileSystem = parseString(line)
+
+	case strings.Contains(line, "Partition Type:"):
+		bd.PartitionType = parseString(line)
+	case strings.Contains(line, "File System Personality:"):
+		bd.FSType = parseString(line)
+	case strings.Contains(line, "Type (Bundle):"):
+		bd.TypeBundle = parseString(line)
+	case strings.Contains(line, "Name (User Visible):"):
+		bd.NameUserVisible = parseString(line)
+	case strings.Contains(line, "Owners:"):
+		bd.Owners = parseString(line)
+
+	case strings.Contains(line, "Content (IOContent):"):
+		bd.Content = parseString(line)
+	case strings.Contains(line, "OS Can Be Installed:"):
+		bd.OSCanBeInstalled = strings.TrimSpace(strings.Split(line, ":")[1]) == "Yes"
+	case strings.Contains(line, "Booter Disk:"):
+		bd.BooterDisk = parseString(line)
+	case strings.Contains(line, "Recovery Disk:"):
+		bd.RecoveryDisk = parseString(line)
+	case strings.Contains(line, "Media Type:"):
+		bd.MediaType = parseString(line)
+	case strings.Contains(line, "Protocol:"):
+		bd.Protocol = parseString(line)
+	case strings.Contains(line, "SMART Status:"):
+		bd.SMARTStatus = parseString(line)
+	case strings.Contains(line, "Volume UUID:"):
+		bd.VolumeUUID = parseString(line)
+	case strings.Contains(line, "Disk / Partition UUID:"):
+		bd.DiskPartitionUUID = parseString(line)
+	case strings.Contains(line, "Partition Offset:"):
+		bd.PartitionOffset, err = parseBytes(strings.TrimSpace(strings.Split(line, ":")[1]))
+		if err != nil {
+			return fmt.Errorf("failed to parse partition offset: %w", err)
+		}
+
+	case strings.Contains(line, "Disk Size:"):
+		bd.DiskSize, err = parseBytes(strings.TrimSpace(strings.Split(line, ":")[1]))
+		if err != nil {
+			return fmt.Errorf("failed to parse disk size: %w", err)
+		}
+	case strings.Contains(line, "Device Block Size:"):
+		bd.DeviceBlockSize, err = parseBytes(strings.TrimSpace(strings.Split(line, ":")[1]))
+		if err != nil {
+			return fmt.Errorf("failed to parse device block size: %w", err)
+		}
+
+	case strings.Contains(line, "Volume Used Space:"):
+		bd.VolumeUsedSpace, err = parseBytes(strings.TrimSpace(strings.Split(line, ":")[1]))
+		if err != nil {
+			return fmt.Errorf("failed to parse volume used space: %w", err)
+		}
+	case strings.Contains(line, "Container Total Space:"):
+		bd.ContainerTotalSpace, err = parseBytes(strings.TrimSpace(strings.Split(line, ":")[1]))
+		if err != nil {
+			return fmt.Errorf("failed to parse container total space: %w", err)
+		}
+	case strings.Contains(line, "Container Free Space:"):
+		bd.ContainerFreeSpace, err = parseBytes(strings.TrimSpace(strings.Split(line, ":")[1]))
+		if err != nil {
+			return fmt.Errorf("failed to parse container free space: %w", err)
+		}
+	case strings.Contains(line, "Allocation Block Size:"):
+		bd.AllocationBlockSize, err = parseBytes(strings.TrimSpace(strings.Split(line, ":")[1]))
+		if err != nil {
+			return fmt.Errorf("failed to parse allocation block size: %w", err)
+		}
+
+	case strings.Contains(line, "Media OS Use Only:"):
+		bd.MediaOSUseOnly = strings.TrimSpace(strings.Split(line, ":")[1]) == "Yes"
+	case strings.Contains(line, "Media Read-Only:"):
+		bd.MediaReadOnly = strings.TrimSpace(strings.Split(line, ":")[1]) == "Yes"
+	case strings.Contains(line, "Volume Read-Only:"):
+		bd.VolumeReadOnly = strings.TrimSpace(strings.Split(line, ":")[1]) == "Yes"
+
+	case strings.Contains(line, "Device Location:"):
+		bd.DeviceLocation = parseString(line)
+	case strings.Contains(line, "Removable Media:"):
+		bd.RemovableMedia = parseString(line)
+
+	case strings.Contains(line, "Solid State:"):
+		bd.SolidState = strings.TrimSpace(strings.Split(line, ":")[1]) == "Yes"
+	case strings.Contains(line, "Virtual:"):
+		bd.Virtual = strings.TrimSpace(strings.Split(line, ":")[1]) == "Yes"
+	case strings.Contains(line, "Hardware AES Support:"):
+		bd.HardwareAESSupport = strings.TrimSpace(strings.Split(line, ":")[1]) == "Yes"
+	default:
+		// Ignore unknown lines
+	}
+
+	return nil
+}
+
+func parseString(s string) string {
+	ss := strings.TrimSpace(strings.Split(s, ":")[1])
+
+	if ss == "None" || strings.Contains(ss, "Not applicable") {
+		return ""
+	}
+	return ss
+}
+
+// nolint:mnd
+func parseBytes(s string) (Bytes, error) {
+	ss := strings.Fields(s)
+
+	value, err := strconv.ParseFloat(ss[0], 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse value: %w", err)
+	}
+
+	switch ss[1] {
+	case "KB":
+		value *= 1024
+	case "MB":
+		value *= 1024 * 1024
+	case "GB":
+		value *= 1024 * 1024 * 1024
+	case "TB":
+		value *= 1024 * 1024 * 1024 * 1024
+	case "Bytes":
+		// Do nothing
+	default:
+		return 0, fmt.Errorf("unknown unit: %s", ss[1])
+	}
+
+	return Bytes(value), nil
+}

--- a/utils/fsutils/diskutil/parse_test.go
+++ b/utils/fsutils/diskutil/parse_test.go
@@ -1,0 +1,139 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diskutil
+
+import (
+	"bytes"
+	_ "embed"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+//go:embed testdata/diskutil.txt
+var diskutilOutput []byte
+
+// nolint:maintidx
+func TestParse(t *testing.T) {
+	tests := []struct {
+		Name     string
+		TextData *bytes.Buffer
+		Err      error
+
+		ExpectedErrorMatcher    types.GomegaMatcher
+		ExpectedBlockDeviceList []BlockDevice
+	}{
+		{
+			Name:                    "Nil data",
+			Err:                     nil,
+			ExpectedErrorMatcher:    Not(HaveOccurred()),
+			ExpectedBlockDeviceList: nil,
+		},
+		{
+			Name:                 "Diskutil output",
+			TextData:             bytes.NewBuffer(diskutilOutput),
+			Err:                  nil,
+			ExpectedErrorMatcher: Not(HaveOccurred()),
+			ExpectedBlockDeviceList: []BlockDevice{
+				{
+					DeviceIdentifier: "disk0",
+					Path:             "/dev/disk0",
+					Whole:            true,
+					PartOfWhole:      "disk0",
+					DeviceMediaName:  "APPLE SSD 0000",
+
+					VolumeName: "",
+					Mounted:    false,
+					FileSystem: "",
+
+					Content:          "GUID_partition_scheme",
+					OSCanBeInstalled: false,
+					MediaType:        "Generic",
+					Protocol:         "Apple Fabric",
+					SMARTStatus:      "Verified",
+
+					DiskSize:        1073741824,
+					DeviceBlockSize: 4096,
+
+					MediaOSUseOnly: false,
+					MediaReadOnly:  false,
+					VolumeReadOnly: false,
+
+					DeviceLocation: "Internal",
+					RemovableMedia: "Fixed",
+
+					SolidState:         true,
+					HardwareAESSupport: true,
+				},
+				{
+					DeviceIdentifier: "disk3s6",
+					Path:             "/dev/disk3s6",
+					Whole:            false,
+					PartOfWhole:      "disk3",
+
+					VolumeName: "VM",
+					Mounted:    true,
+					MountPoint: "/System/Volumes/VM",
+
+					PartitionType:   "0000-0000-0000-0000-0000",
+					FSType:          "APFS",
+					TypeBundle:      "apfs",
+					NameUserVisible: "APFS",
+					Owners:          "Enabled",
+
+					OSCanBeInstalled:  false,
+					BooterDisk:        "disk3s2",
+					RecoveryDisk:      "disk3s3",
+					MediaType:         "Generic",
+					Protocol:          "Apple Fabric",
+					SMARTStatus:       "Verified",
+					VolumeUUID:        "0000-0000-0000-0000-0000",
+					DiskPartitionUUID: "0000-0000-0000-0000-0000",
+
+					DiskSize:        1073741824,
+					DeviceBlockSize: 4096,
+
+					VolumeUsedSpace:     2254857830.4,
+					ContainerTotalSpace: 1073741824,
+					ContainerFreeSpace:  1073741824,
+					AllocationBlockSize: 4096,
+
+					MediaOSUseOnly: false,
+					MediaReadOnly:  false,
+					VolumeReadOnly: false,
+
+					DeviceLocation: "Internal",
+					RemovableMedia: "Fixed",
+
+					SolidState:         true,
+					HardwareAESSupport: true,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			list, err := parse(test.TextData)
+
+			g.Expect(err).Should(test.ExpectedErrorMatcher)
+			g.Expect(list).Should(BeEquivalentTo(test.ExpectedBlockDeviceList))
+		})
+	}
+}

--- a/utils/fsutils/diskutil/testdata/diskutil.txt
+++ b/utils/fsutils/diskutil/testdata/diskutil.txt
@@ -1,0 +1,84 @@
+   Device Identifier:         disk0
+   Device Node:               /dev/disk0
+   Whole:                     Yes
+   Part of Whole:             disk0
+   Device / Media Name:       APPLE SSD 0000
+
+   Volume Name:               Not applicable (no file system)
+   Mounted:                   Not applicable (no file system)
+   File System:               None
+
+   Content (IOContent):       GUID_partition_scheme
+   OS Can Be Installed:       No
+   Media Type:                Generic
+   Protocol:                  Apple Fabric
+   SMART Status:              Verified
+
+   Disk Size:                 1.0 GB (1073741824 Bytes)
+   Device Block Size:         4096 Bytes
+
+   Media OS Use Only:         No
+   Media Read-Only:           No
+   Volume Read-Only:          Not applicable (no file system)
+
+   Device Location:           Internal
+   Removable Media:           Fixed
+
+   Solid State:               Yes
+   Hardware AES Support:      Yes
+
+**********
+
+   Device Identifier:         disk3s6
+   Device Node:               /dev/disk3s6
+   Whole:                     No
+   Part of Whole:             disk3
+
+   Volume Name:               VM
+   Mounted:                   Yes
+   Mount Point:               /System/Volumes/VM
+
+   Partition Type:            0000-0000-0000-0000-0000
+   File System Personality:   APFS
+   Type (Bundle):             apfs
+   Name (User Visible):       APFS
+   Owners:                    Enabled
+
+   OS Can Be Installed:       No
+   Booter Disk:               disk3s2
+   Recovery Disk:             disk3s3
+   Media Type:                Generic
+   Protocol:                  Apple Fabric
+   SMART Status:              Verified
+   Volume UUID:               0000-0000-0000-0000-0000
+   Disk / Partition UUID:     0000-0000-0000-0000-0000
+
+   Disk Size:                 1.0 GB (1073741824 Bytes)
+   Device Block Size:         4096 Bytes
+
+   Volume Used Space:         2.1 GB (2147520512 Bytes)
+   Container Total Space:     1.0 GB (1073741824 Bytes)
+   Container Free Space:      1.0 GB (1073741824 Bytes)
+   Allocation Block Size:     4096 Bytes
+
+   Media OS Use Only:         No
+   Media Read-Only:           No
+   Volume Read-Only:          No
+
+   Device Location:           Internal
+   Removable Media:           Fixed
+
+   Solid State:               Yes
+   Hardware AES Support:      Yes
+
+   This disk is an APFS Volume.  APFS Information:
+   APFS Container:            disk3
+   APFS Physical Store:       disk0s2
+   Fusion Drive:              No
+   Encrypted:                 No
+   FileVault:                 No
+   Sealed:                    No
+   Locked:                    No
+
+**********
+


### PR DESCRIPTION
## Description

First part of https://github.com/openclarity/vmclarity/issues/356, add support to mount and unmount NTFS devices. No further changes are required in the mount/unmount logic and the mount option remain the same.

**Steps to test NTFS Support**
	1.	Launch ubuntu instance on AWS
	2.	Create EBS volume and attach it to the instance (device name /dev/xvdbn)
	3.	Check that the new attached volume is listed as a block device (`lsblk`)
	4.	Convert to ntfs (`sudo mkfs.ntfs -f /dev/xvdbn`)
	5.	Run the following script to mount and unmount the NTFS block device

```go
// utils/fsutils/cmd/main.go
package main

import (
	"context"
	"fmt"
	"os"
	"strings"

	"github.com/google/uuid"
	"github.com/openclarity/vmclarity/utils/fsutils/blockdevice"
	"github.com/openclarity/vmclarity/utils/fsutils/filesystem"
	"github.com/openclarity/vmclarity/utils/fsutils/mount"
)

const (
	MountPointTemplate = "/mnt/snapshots/%s"
	MountPointDirPerm  = 0o770
)

// DefaultMountOptions is a set of filesystem independent mount options.
var DefaultMountOptions = []string{
	"noatime",    // Do not update inode access times on this filesystem (e.g. for faster access on the news spool to speed up news servers).
	"noauto",     // Can only be mounted explicitly (i.e., the -a option will not cause the filesystem to be mounted).
	"noexec",     // Do not permit direct execution of any binaries on the mounted filesystem.
	"norelatime", // Do not use the relatime feature: Update inode access times relative to modify or change time. Access time is only updated if the previous access time was earlier than the current modify or change time.
	"nosuid",     // Do not honor set-user-ID and set-group-ID bits or file capabilities when executing programs from this filesystem.
	"ro",         // Mount the filesystem read-only.
}

func main() {
	blockDevices, err := blockdevice.List(context.Background())
	if err != nil {
		fmt.Printf("Error: %v\n", err)
		return
	}

	fmt.Printf("%d Block devices: %+v\n", len(blockDevices), blockDevices)

	for _, device := range blockDevices {
		if device.MountPoint == "" && isSupportedFS(device.FSType) {
			mountPoint := fmt.Sprintf(MountPointTemplate, uuid.New())
			fmt.Printf("mountPoint %s\n", mountPoint)

			if err := os.MkdirAll(mountPoint, MountPointDirPerm); err != nil {
				fmt.Printf("failed to create mountpoint. Device=%s MountPoint=%s: %w\n",
					device.Path, mountPoint, err)
				continue
			}

			if err := mount.Mount(context.Background(), device.Path, mountPoint, device.FSType, DefaultMountOptions); err != nil {
				fmt.Errorf("failed to mount device. Device=%s MountPoint=%s: %w\n",
					device.Path, mountPoint, err)
				continue
			}

			fmt.Printf("Device is mounted. Device=%s MountPoint=%s\n", device.Path, mountPoint)
		} else if device.MountPoint != "" && isSupportedFS(device.FSType) && device.FSType == string(filesystem.Ntfs){
			if err := mount.Umount(context.Background(), device.MountPoint); err != nil {
				fmt.Printf("failed to unmount device. Device=%s MountPoint=%s: %s\n",
					device.Path, device.MountPoint, err)
				continue
			}
			fmt.Printf("Device is unmounted. Device=%s MountPoint=%s\n", device.Path, mountPoint)
		}
	}
}

func isSupportedFS(fs string) bool {
	switch strings.ToLower(fs) {
	case string(filesystem.Ext2), string(filesystem.Ext3), string(filesystem.Ext4):
		return true
	case string(filesystem.Xfs):
		return true
	case string(filesystem.Ntfs):
		return true
	default:
		return false
	}
}
```

Additionally, add list block devices support for darwin.

## Type of Change

[ ] Bug Fix  
[x] New Feature  
[ ] Breaking Change  
[ ] Refactor  
[ ] Documentation  
[ ] Other (please describe)  

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
