### PR TITLE
docs(ci): improve docs on release flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -541,6 +541,7 @@ multimod-verify: bin/multimod
 
 .PHONY: multimod-prerelease
 multimod-prerelease: bin/multimod
+	git stash --all
 	$(MULTIMOD_BIN) prerelease --all-module-sets --skip-go-mod-tidy=true --commit-to-different-branch=false
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,10 @@ git commit -m "release: update module set to version v0.7.0"
 ```
 
 * Run the version verification command to check for any issues.
+
+> [!NOTE]
+> If you use `go.work` and `go.work.sum` files in the project, temporarily remove/rename them so it won't interfere with this step.
+
 ```sh
 make multimod-verify
 ```
@@ -66,3 +70,14 @@ Please note that the release tag is not necessarily associated with the "release
 * Navigate to the [Releases page](https://github.com/openclarity/vmclarity/releases) and verify the draft release description as well as the assets listed.
 
 * Once the draft release has been verified, click on `Edit` release and then on `Publish Release`.
+
+## 5. Post release steps
+
+* In the [docs repository](https://github.com/openclarity/docs.openclarity.io), modify the value of `latest_version` in `config/_default/config.toml`, create a pull request and merge after it was reviewed.
+
+```toml
+[params]
+  latest_version = "0.7.0" # Used in some installation commands
+```
+
+* From the release page, download the AWS Cloudformation files (`aws-cloudformation-v0.7.0.tar.gz`), extract the archive locally and upload its contents to the S3 bucket used for storing them for VMClarity installation.


### PR DESCRIPTION
## Description

- added automatic stashing in`multimod-prerelease` make target instead of warning in the docs
- added additional info and post release steps to the release docs

## Type of Change

- [ ] Bug Fix  
- [ ] New Feature  
- [ ] Breaking Change  
- [ ] Refactor  
- [X] Documentation  
- [ ] Other (please describe)  

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
