### PR TITLE
feat(utils): set stdin explicitly for command

### DIFF
--- a/utils/command/command.go
+++ b/utils/command/command.go
@@ -57,7 +57,8 @@ func (c *Command) Start(ctx context.Context) (*State, error) {
 		cmd.Dir = c.WorkDir
 	}
 
-	var stdOut, stdErr bytes.Buffer
+	var stdIn, stdOut, stdErr bytes.Buffer
+	cmd.Stdin = &stdIn
 	cmd.Stdout = &stdOut
 	cmd.Stderr = &stdErr
 
@@ -65,6 +66,7 @@ func (c *Command) Start(ctx context.Context) (*State, error) {
 
 	return &State{
 		cmd:    cmd,
+		Stdin:  &stdIn,
 		StdOut: &stdOut,
 		StdErr: &stdErr,
 	}, err
@@ -76,6 +78,7 @@ func (c *Command) String() string {
 
 type State struct {
 	cmd    *exec.Cmd
+	Stdin  *bytes.Buffer
 	StdOut *bytes.Buffer
 	StdErr *bytes.Buffer
 }


### PR DESCRIPTION
## Description

If there is no stdin set for the command, the standard library attempts to use the /dev/null device, which is not always available.

https://cs.opensource.google/go/go/+/refs/tags/go1.22.4:src/os/exec/exec.go;drc=f7f266c88598398dcf32b448bcea2100e1702630;l=506


## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
