### PR TITLE
refactor(scanner): separate GetImage from ToDirectory

### DIFF
--- a/scanner/utils/containerrootfs/example/main.go
+++ b/scanner/utils/containerrootfs/example/main.go
@@ -23,7 +23,13 @@ import (
 )
 
 func main() {
-	err := containerrootfs.ToDirectory(context.TODO(), "nginx-1.10.tar", "output")
+	image, cleanup, err := containerrootfs.GetImageWithCleanup(context.TODO(), "nginx-1.10.tar")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer cleanup()
+
+	err = containerrootfs.ToDirectory(context.TODO(), image, "output")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/scanner/utils/containerrootfs/totempdirectory.go
+++ b/scanner/utils/containerrootfs/totempdirectory.go
@@ -78,7 +78,13 @@ func toTempDirectory(ctx context.Context, src string) (Rootfs, error) {
 	}
 	tdrf.dir = tmpdir
 
-	err = ToDirectory(ctx, src, tmpdir)
+	image, cleanup, err := GetImageWithCleanup(ctx, src)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get image: %w", err)
+	}
+	defer cleanup()
+
+	err = ToDirectory(ctx, image, tmpdir)
 	if err != nil {
 		return nil, fmt.Errorf("unable to output squashed image to directory: %w", err)
 	}


### PR DESCRIPTION
So if the image metadata is also needed, we don't get the image twice.

## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

Put getting the image in a separate function so that if the image metadata is also needed outside of extracting it to a directory, we don't need to get the image twice.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
