### PR TITLE
fix(plugin): fix plugin family runner race condition

### DIFF
--- a/scanner/families/plugins/runner/runner.go
+++ b/scanner/families/plugins/runner/runner.go
@@ -78,7 +78,8 @@ func (s *Scanner) Run(ctx context.Context, sourceType utils.SourceType, userInpu
 			s.sendResults(retResults, fmt.Errorf("failed to create plugin runner: %w", err))
 			return
 		}
-		defer func() {
+
+		cleanup := func(ctx context.Context) {
 			if err := rr.Stop(ctx); err != nil {
 				s.logger.WithError(err).Errorf("failed to stop runner")
 			}
@@ -88,14 +89,16 @@ func (s *Scanner) Run(ctx context.Context, sourceType utils.SourceType, userInpu
 			if err := rr.Remove(ctx); err != nil {
 				s.logger.WithError(err).Errorf("failed to remove runner")
 			}
-		}() //nolint:errcheck
+		} //nolint:errcheck
 
 		if err := rr.Start(ctx); err != nil {
+			cleanup(ctx)
 			s.sendResults(retResults, fmt.Errorf("failed to start plugin runner: %w", err))
 			return
 		}
 
 		if err := rr.WaitReady(ctx); err != nil {
+			cleanup(ctx)
 			s.sendResults(retResults, fmt.Errorf("failed to wait for plugin scanner to be ready: %w", err))
 			return
 		}
@@ -103,6 +106,7 @@ func (s *Scanner) Run(ctx context.Context, sourceType utils.SourceType, userInpu
 		// Get plugin metadata
 		metadata, err := rr.Metadata(ctx)
 		if err != nil {
+			cleanup(ctx)
 			s.sendResults(retResults, fmt.Errorf("failed to get plugin scanner metadata: %w", err))
 			return
 		}
@@ -128,20 +132,25 @@ func (s *Scanner) Run(ctx context.Context, sourceType utils.SourceType, userInpu
 		}()
 
 		if err := rr.Run(ctx); err != nil {
+			cleanup(ctx)
 			s.sendResults(retResults, fmt.Errorf("failed to run plugin scanner: %w", err))
 			return
 		}
 
 		if err := rr.WaitDone(ctx); err != nil {
+			cleanup(ctx)
 			s.sendResults(retResults, fmt.Errorf("failed to wait for plugin scanner to finish: %w", err))
 			return
 		}
 
 		findings, pluginResult, err := s.parseResults(ctx, rr)
 		if err != nil {
+			cleanup(ctx)
 			s.sendResults(retResults, fmt.Errorf("failed to parse plugin scanner results: %w", err))
 			return
 		}
+
+		cleanup(ctx)
 
 		retResults.Findings = findings
 		retResults.Output = pluginResult


### PR DESCRIPTION
## Description

If an error occurs, we send the result back to the family manager on a channel and return from the function:

```
if err := rr.WaitReady(ctx); err != nil {
  s.sendResults(retResults, fmt.Errorf("failed to wait for plugin scanner to be ready: %w", err))
  return
}
```

As part of the return, the deferred `Stop` and `Remove` lifecycle functions begin to run:

```
defer func() {
	if err := rr.Stop(ctx); err != nil {
		s.logger.WithError(err).Errorf("failed to stop runner")
	}

	// TODO: add short wait before removing to respect container shutdown procedure

	if err := rr.Remove(ctx); err != nil {
		s.logger.WithError(err).Errorf("failed to remove runner")
	}
}() //nolint:errcheck
```

Once the family manager gets the result in the result channel, it does not really care if the underlying goroutines are finished or not:

https://github.com/openclarity/vmclarity/blob/07500346ae7c80f1201992cdb3c22d0b6377d708/scanner/families/manager.go#L148


This results in a race condition, once the family manager gets all the results it expects, the program will terminate regardless of whether the plugins' Stop() and Destroy() functions have finished or not.

We need to call the `Exit` and `Destroy` lifecycle functions before sending back the result.
 

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
