### PR TITLE
feat(ui): add related Assets tab to Finding detail pages

### DIFF
--- a/ui/src/components/Table/index.jsx
+++ b/ui/src/components/Table/index.jsx
@@ -19,7 +19,7 @@ const ACTIONS_COLUMN_ID = "ACTIONS";
 const STATIC_COLUMN_IDS = [ACTIONS_COLUMN_ID];
 
 const Table = props => {
-    const {columns, defaultSortBy, onSortChnage, onLineClick, paginationItemsName, url, formatFetchedData, filters, defaultPageIndex=0,
+    const {columns, defaultSortBy, onSortChnage, onLineClick, paginationItemsName, url, formatFetchedData, filters, defaultPageIndex=0, defaultPageSize=50,
         onPageChange, noResultsTitle="items", refreshTimestamp, withPagination=true, data: externalData, onRowSelect,
         actionsComponent: ActionsComponent, customEmptyResultsDisplay: CustomEmptyResultsDisplay, showCustomEmptyDisplay=true,
         actionsColumnWidth=80} = props;
@@ -71,7 +71,7 @@ const Table = props => {
             defaultColumn,
             initialState: {
                 pageIndex: defaultPageIndex,
-                pageSize: 50,
+                pageSize: defaultPageSize,
                 selectedRowIds: {}
             },
             manualPagination: true,
@@ -94,7 +94,7 @@ const Table = props => {
 
             hooks.visibleColumns.push(columns => {
                 const updatedColumns = columns;
-                
+
                 if (withRowActions) {
                     updatedColumns.push({
                         Header: () => null, // No header
@@ -127,7 +127,7 @@ const Table = props => {
     const cleanFilters = pickBy(filters, value => !isNull(value) && value !== "");
     const prevCleanFilters = usePrevious(cleanFilters);
     const filtersChanged = !isEqual(cleanFilters, prevCleanFilters) && !isUndefined(prevCleanFilters);
-    
+
     const prevPageIndex = usePrevious(pageIndex);
 
     const {sortIds: sortKeys, desc: sortDesc} = sortBy || {};
@@ -159,10 +159,10 @@ const Table = props => {
         if (loading) {
             return;
         }
-        
+
         fetchData({queryParams: {...getQueryParams()}});
     }, [fetchData, getQueryParams, loading])
-    
+
     useEffect(() => {
         if (!filtersChanged && pageIndex === prevPageIndex && !sortingChanged && prevRefreshTimestamp === refreshTimestamp) {
             return;
@@ -209,7 +209,7 @@ const Table = props => {
             <CustomEmptyResultsDisplay />
         )
     }
-    
+
     return (
         <div className="table-wrapper">
             {!withPagination ? <div className="no-pagination-results-total">{`Showing ${count} entries`}</div> :
@@ -236,7 +236,7 @@ const Table = props => {
                                         headerGroup.headers.map(column => {
                                             const {sortIds} = column;
                                             const isSorted = isEqual(sortIds, sortKeys);
-                                            
+
                                             return (
                                                 <div className="table-th" {...column.getHeaderProps()}>
                                                     <span className="table-th-content">{column.render('Header')}</span>
@@ -245,7 +245,7 @@ const Table = props => {
                                                             className={classnames("table-sort-icon", {sorted: isSorted}, {rotate: isSorted && sortDesc})}
                                                             name={ICON_NAMES.SORT}
                                                             size={9}
-                                                            onClick={() => setSortBy(({sortIds, desc}) => 
+                                                            onClick={() => setSortBy(({sortIds, desc}) =>
                                                                 ({sortIds: column.sortIds, desc: isEqual(column.sortIds, sortIds) ? !desc : false})
                                                             )}
                                                         />
@@ -271,7 +271,7 @@ const Table = props => {
                     {
                         page.map((row) => {
                             prepareRow(row);
-                    
+
                             return (
                                 <React.Fragment key={row.id}>
                                     <div
@@ -291,9 +291,9 @@ const Table = props => {
                                                     {"align-to-top": alignToTop},
                                                     {[className]: className}
                                                 );
-                        
+
                                                 const isTextValue = !!cell.column.accessor;
-                                                
+
                                                 return (
                                                     <div className={cellClassName} {...cell.getCellProps()}>
                                                         <ValueWithFallback>
@@ -310,7 +310,7 @@ const Table = props => {
                     }
                 </div>
             </div>
-            
+
         </div>
     )
 }
@@ -318,8 +318,8 @@ const Table = props => {
 export default React.memo(Table, (prevProps, nextProps) => {
     const {filters: prevFilters, refreshTimestamp: prevRefreshTimestamp, data: prevData} = prevProps;
     const {filters, refreshTimestamp, data} = nextProps;
-    
+
     const shouldRefresh = !isEqual(prevFilters, filters) || prevRefreshTimestamp !== refreshTimestamp || !isEqual(prevData, data);
-    
+
     return !shouldRefresh;
 });

--- a/ui/src/layout/AssetScans/AssetScansTable.jsx
+++ b/ui/src/layout/AssetScans/AssetScansTable.jsx
@@ -67,8 +67,8 @@ const AssetScansTable = () => {
                 return <StatusIndicator state={state} errors={message === undefined ? [] : [message]} tooltipId={original.id} />;
             }
         },
-        getVulnerabilitiesColumnConfigItem(TABLE_TITLE),
-        ...getFindingsColumnsConfigList(TABLE_TITLE)
+        getVulnerabilitiesColumnConfigItem({tableTile: TABLE_TITLE}),
+        ...getFindingsColumnsConfigList({tableTile: TABLE_TITLE})
     ], []);
 
     return (

--- a/ui/src/layout/Assets/AssetsForFindingTable.jsx
+++ b/ui/src/layout/Assets/AssetsForFindingTable.jsx
@@ -1,0 +1,156 @@
+import React, { useMemo, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { isUndefined } from 'lodash';
+import ExpandableList from 'components/ExpandableList';
+import ToggleButton from 'components/ToggleButton';
+import ContentContainer from 'components/ContentContainer';
+import Table from 'components/Table';
+import Loader from 'components/Loader';
+import { getFindingsColumnsConfigList, getVulnerabilitiesColumnConfigItem, formatTagsToStringsList, formatDate, getAssetName} from 'utils/utils';
+import { APIS } from 'utils/systemConsts';
+import { useFilterDispatch, useFilterState, setFilters, FILTER_TYPES } from 'context/FiltersProvider';
+
+const TABLE_TITLE = "assets";
+
+const NAME_SORT_IDS = ["asset.assetInfo.instanceID", "asset.assetInfo.podName", "asset.assetInfo.dirName", "asset.assetInfo.imageID", "asset.assetInfo.containerName"];
+const LABEL_SORT_IDS = ["asset.assetInfo.tags", "asset.assetInfo.labels"];
+const LOCATION_SORT_IDS = ["asset.assetInfo.location"];
+
+const ASSETS_FILTER_TYPE = FILTER_TYPES.ASSETS;
+const FINDINGS_FILTER_TYPE = FILTER_TYPES.FINDINGS_GENERAL;
+
+const AssetsForFindingTable = (props) => {
+    const {findingId} = props;
+
+    const navigate = useNavigate();
+    const filtersDispatch = useFilterDispatch();
+    const filtersState = useFilterState();
+
+    const {customFilters: assetCustomFilters} = filtersState[ASSETS_FILTER_TYPE];
+    const {hideTerminated} = assetCustomFilters;
+
+    const setHideTerminated = useCallback(hideTerminated => setFilters(filtersDispatch, {
+        type: ASSETS_FILTER_TYPE,
+        filters: {hideTerminated},
+        isCustom: true
+    }), [filtersDispatch]);
+
+    useEffect(() => {
+        if (isUndefined(hideTerminated)) {
+            setHideTerminated(true);
+        }
+    }, [hideTerminated, setHideTerminated]);
+
+    const {customFilters: findingCustomFilters} = filtersState[FINDINGS_FILTER_TYPE];
+    const {showFindingCounts} = findingCustomFilters;
+
+    const setShowFindingCounts = useCallback(showFindingCounts => setFilters(filtersDispatch, {
+        type: FINDINGS_FILTER_TYPE,
+        filters: {showFindingCounts},
+        isCustom: true
+    }), [filtersDispatch]);
+
+    useEffect(() => {
+        if (isUndefined(showFindingCounts)) {
+            setShowFindingCounts(false);
+        }
+    }, [showFindingCounts, setShowFindingCounts]);
+
+    const columns = useMemo(() => [
+        {
+            Header: "Name",
+            id: "instanceID",
+            sortIds: NAME_SORT_IDS,
+            accessor: (original) => getAssetName(original.asset.assetInfo),
+        },
+        {
+            Header: "Labels",
+            id: "tags",
+            sortIds: LABEL_SORT_IDS,
+            Cell: ({row}) => {
+                const {tags, labels} = row.original.asset.assetInfo;
+
+                return (
+                    <ExpandableList items={formatTagsToStringsList(tags ?? labels)} withTagWrap />
+                )
+            },
+            alignToTop: true
+        },
+        {
+            Header: "Type",
+            id: "objectType",
+            sortIds: ["asset.assetInfo.objectType"],
+            accessor: "asset.assetInfo.objectType"
+        },
+        {
+            Header: "Location",
+            id: "location",
+            sortIds: LOCATION_SORT_IDS,
+            accessor: (original) => original.asset.assetInfo.location || original.asset.assetInfo.repoDigests?.[0],
+        },
+        {
+            Header: "Last Seen",
+            id: "lastSeen",
+            sortIds: ["asset.lastSeen"],
+            accessor: original => formatDate(original.asset.lastSeen)
+        },
+        ...(hideTerminated ? [] : [{
+            Header: "Terminated On",
+            id: "terminatedOn",
+            sortIds: ["asset.terminatedOn"],
+            accessor: original => formatDate(original?.asset.terminatedOn)
+        }]),
+        ...(!showFindingCounts ? [] : [
+            getVulnerabilitiesColumnConfigItem({tableTitle: TABLE_TITLE, withAssetPrefix: true}),
+            ...getFindingsColumnsConfigList({tableTitle: TABLE_TITLE, withAssetPrefix: true})
+        ]),
+    ], [hideTerminated, showFindingCounts]);
+
+    if (isUndefined(hideTerminated) || isUndefined(showFindingCounts)) {
+        return <Loader />;
+    }
+
+    const expand = "asset"
+    let filtersList = [`(finding.id eq '${findingId}')`]
+    if (hideTerminated) {
+        filtersList.push("(asset.terminatedOn eq null)");
+    }
+    let select = "asset.id,asset.assetInfo,asset.lastSeen"
+    if (!hideTerminated) {
+        select += ",asset.terminatedOn"
+    }
+    if (showFindingCounts) {
+        select += ",asset.summary"
+    }
+
+    return (
+        <div style={{marginTop: "20px"}}>
+            <div style={{float: "right", marginRight: "36px"}}>
+                <ToggleButton title="Show finding counts" checked={showFindingCounts} onChange={setShowFindingCounts}/>
+            </div>
+            <div style={{float: "right", marginRight: "36px"}}>
+                <ToggleButton title="Hide terminated" checked={hideTerminated} onChange={setHideTerminated}/>
+            </div>
+            <div style={{position: "relative"}}>
+                <ContentContainer withMargin>
+                    <Table
+                        paginationItemsName={TABLE_TITLE.toLowerCase()}
+                        filters={{
+                            ...(!!expand ? {"$expand": expand} : {}),
+                            ...(!!select ? {"$select": select} : {}),
+                            ...(filtersList.length > 0 ? {"$filter": filtersList.join(" and ")} : {})
+                        }}
+                        noResultsTitle={TABLE_TITLE}
+                        onLineClick={({asset}) => navigate(`/${APIS.ASSETS}/${asset.id}`)}
+                        columns={columns}
+                        url={APIS.ASSET_FINDINGS}
+                        defaultSortBy={{sortIds: ["asset.lastSeen", "asset.terminatedOn"], desc: true}}
+                        defaultPageSize={10}
+                    />
+                </ContentContainer>
+            </div>
+        </div>
+    )
+}
+
+export default AssetsForFindingTable;

--- a/ui/src/layout/Assets/AssetsTable.jsx
+++ b/ui/src/layout/Assets/AssetsTable.jsx
@@ -81,8 +81,8 @@ const AssetsTable = () => {
             sortIds: ["terminatedOn"],
             accessor: original => formatDate(original?.terminatedOn)
         }]),
-        getVulnerabilitiesColumnConfigItem(TABLE_TITLE),
-        ...getFindingsColumnsConfigList(TABLE_TITLE)
+        getVulnerabilitiesColumnConfigItem({tableTile: TABLE_TITLE}),
+        ...getFindingsColumnsConfigList({tableTile: TABLE_TITLE})
     ], [hideTerminated]);
     
     if (isUndefined(hideTerminated)) {

--- a/ui/src/layout/Findings/AssetCountDisplay.jsx
+++ b/ui/src/layout/Findings/AssetCountDisplay.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useFetch } from 'hooks';
+import { isUndefined } from 'lodash';
+import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDisplay';
+import Loader from 'components/Loader';
+import { APIS } from 'utils/systemConsts';
+import { formatNumber } from 'utils/utils';
+
+const AssetCountDisplay = (findingId) => {
+    const filter = `finding/id eq '${findingId}'`;
+    const [{loading, data, error}] = useFetch(APIS.ASSET_FINDINGS, {
+        queryParams: {"$expand": "asset", "$filter": filter, "$count": true, "$select": "count,asset/terminatedOn"}
+    });
+
+    if (error) {
+        return null;
+    }
+
+    if (loading) {
+        return <Loader absolute={false} small />
+    }
+
+    let notTerminated = 0;
+    if (data && data.items) {
+        data.items.forEach(item => {
+            if (isUndefined(item.asset.terminatedOn)) {
+                notTerminated++;
+            }
+        });
+    }
+
+    return (
+        <TitleValueDisplayRow>
+            <TitleValueDisplay title="Asset count">{formatNumber(notTerminated)} ({formatNumber(data?.count || 0)})</TitleValueDisplay>
+        </TitleValueDisplayRow>
+    )
+}
+
+export default AssetCountDisplay;

--- a/ui/src/layout/Findings/Exploits/ExploitDetails.jsx
+++ b/ui/src/layout/Findings/Exploits/ExploitDetails.jsx
@@ -30,6 +30,8 @@ const DetailsContent = ({data}) => {
         return <Loader large />
     }
 
+    data.assetCount = assetFindingData.count;
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Exploits/ExploitDetails.jsx
+++ b/ui/src/layout/Findings/Exploits/ExploitDetails.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabExploitDetails from './TabExploitDetails';
-import Loader from 'components/Loader';
-import { APIS } from 'utils/systemConsts';
 
 const EXPLOIT_DETAILS_PATHS = {
     EXPLOIT_DETAILS: "",
@@ -16,22 +13,6 @@ const DetailsContent = ({data}) => {
     
     const {id} = data;
     
-    const filter = `finding/id eq '${id}'`;
-
-    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
-        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
-    });
-
-    if (error) {
-        return null;
-    }
-
-    if (loading) {
-        return <Loader large />
-    }
-
-    data.assetCount = assetFindingData.count;
-
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Exploits/ExploitDetails.jsx
+++ b/ui/src/layout/Findings/Exploits/ExploitDetails.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabExploitDetails from './TabExploitDetails';
+import Loader from 'components/Loader';
+import { APIS } from 'utils/systemConsts';
 
 const EXPLOIT_DETAILS_PATHS = {
     EXPLOIT_DETAILS: "",
@@ -13,6 +16,20 @@ const DetailsContent = ({data}) => {
     
     const {id} = data;
     
+    const filter = `finding/id eq '${id}'`;
+
+    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
+        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
+    });
+
+    if (error) {
+        return null;
+    }
+
+    if (loading) {
+        return <Loader large />
+    }
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Exploits/ExploitDetails.jsx
+++ b/ui/src/layout/Findings/Exploits/ExploitDetails.jsx
@@ -3,16 +3,18 @@ import { useLocation } from 'react-router-dom';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabExploitDetails from './TabExploitDetails';
+import AssetsForFindingTable from 'layout/Assets/AssetsForFindingTable';
 
 const EXPLOIT_DETAILS_PATHS = {
     EXPLOIT_DETAILS: "",
+    ASSET_LIST: "assets",
 }
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}
@@ -21,7 +23,14 @@ const DetailsContent = ({data}) => {
                     id: "general",
                     title: "Exploit details",
                     isIndex: true,
+                    path: EXPLOIT_DETAILS_PATHS.EXPLOIT_DETAILS,
                     component: () => <TabExploitDetails data={data} />
+                },
+                {
+                    id: "assets",
+                    title: "Assets",
+                    path: EXPLOIT_DETAILS_PATHS.ASSET_LIST,
+                    component: () => <AssetsForFindingTable findingId={id} />
                 }
             ]}
             withInnerPadding={false}

--- a/ui/src/layout/Findings/Exploits/TabExploitDetails.jsx
+++ b/ui/src/layout/Findings/Exploits/TabExploitDetails.jsx
@@ -3,9 +3,10 @@ import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDi
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import LinksDisplay from 'layout/Findings/LinkesDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
+import { formatNumber } from 'utils/utils';
 
 const TabExploitDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen} = data;
+    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
     const {cveID, description, sourceDB, urls} = findingInfo;
 
     return (
@@ -21,7 +22,10 @@ const TabExploitDetails = ({data}) => {
                     </TitleValueDisplayRow>
                     <LinksDisplay title="URLs" links={urls} />
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                </>  
+                    <TitleValueDisplayRow>
+                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
+                    </TitleValueDisplayRow>
+                </>
             )}
         />
     )

--- a/ui/src/layout/Findings/Exploits/TabExploitDetails.jsx
+++ b/ui/src/layout/Findings/Exploits/TabExploitDetails.jsx
@@ -3,10 +3,10 @@ import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDi
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import LinksDisplay from 'layout/Findings/LinkesDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
-import { formatNumber } from 'utils/utils';
+import AssetCountDisplay from '../AssetCountDisplay';
 
 const TabExploitDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
+    const {id, findingInfo, firstSeen, lastSeen}  = data;
     const {cveID, description, sourceDB, urls} = findingInfo;
 
     return (
@@ -22,9 +22,7 @@ const TabExploitDetails = ({data}) => {
                     </TitleValueDisplayRow>
                     <LinksDisplay title="URLs" links={urls} />
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                    <TitleValueDisplayRow>
-                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
-                    </TitleValueDisplayRow>
+                    {AssetCountDisplay(id)}
                 </>
             )}
         />

--- a/ui/src/layout/Findings/Malware/MalwareDetails.jsx
+++ b/ui/src/layout/Findings/Malware/MalwareDetails.jsx
@@ -30,6 +30,8 @@ const DetailsContent = ({data}) => {
         return <Loader large />
     }
 
+    data.assetCount = assetFindingData.count;
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Malware/MalwareDetails.jsx
+++ b/ui/src/layout/Findings/Malware/MalwareDetails.jsx
@@ -3,9 +3,11 @@ import { useLocation } from 'react-router-dom';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabMalwareDetails from './TabMalwareDetails';
+import AssetsForFindingTable from 'layout/Assets/AssetsForFindingTable';
 
 const MALWARE_DETAILS_PATHS = {
     MALWARE_DETAILS: "",
+    ASSET_LIST: "assets",
 }
 
 const DetailsContent = ({data}) => {
@@ -21,7 +23,14 @@ const DetailsContent = ({data}) => {
                     id: "general",
                     title: "Malware details",
                     isIndex: true,
+                    path: MALWARE_DETAILS_PATHS.MALWARE_DETAILS,
                     component: () => <TabMalwareDetails data={data} />
+                },
+                {
+                    id: "assets",
+                    title: "Assets",
+                    path: MALWARE_DETAILS_PATHS.ASSET_LIST,
+                    component: () => <AssetsForFindingTable findingId={id} />
                 }
             ]}
             withInnerPadding={false}

--- a/ui/src/layout/Findings/Malware/MalwareDetails.jsx
+++ b/ui/src/layout/Findings/Malware/MalwareDetails.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabMalwareDetails from './TabMalwareDetails';
+import Loader from 'components/Loader';
+import { APIS } from 'utils/systemConsts';
 
 const MALWARE_DETAILS_PATHS = {
     MALWARE_DETAILS: "",
@@ -10,9 +13,23 @@ const MALWARE_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
+    const filter = `finding/id eq '${id}'`;
+
+    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
+        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
+    });
+
+    if (error) {
+        return null;
+    }
+
+    if (loading) {
+        return <Loader large />
+    }
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Malware/MalwareDetails.jsx
+++ b/ui/src/layout/Findings/Malware/MalwareDetails.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabMalwareDetails from './TabMalwareDetails';
-import Loader from 'components/Loader';
-import { APIS } from 'utils/systemConsts';
 
 const MALWARE_DETAILS_PATHS = {
     MALWARE_DETAILS: "",
@@ -13,25 +10,9 @@ const MALWARE_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-
+    
     const {id} = data;
-
-    const filter = `finding/id eq '${id}'`;
-
-    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
-        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
-    });
-
-    if (error) {
-        return null;
-    }
-
-    if (loading) {
-        return <Loader large />
-    }
-
-    data.assetCount = assetFindingData.count;
-
+    
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Malware/TabMalwareDetails.jsx
+++ b/ui/src/layout/Findings/Malware/TabMalwareDetails.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDisplay';
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
+import { formatNumber } from 'utils/utils';
 
 const TabMalwareDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen} = data;
+    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
     const {malwareName, path, ruleName} = findingInfo;
 
     return (
@@ -21,7 +22,10 @@ const TabMalwareDetails = ({data}) => {
                         <TitleValueDisplay title="Rule name">{ruleName}</TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                </>  
+                    <TitleValueDisplayRow>
+                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
+                    </TitleValueDisplayRow>
+                </>
             )}
         />
     )

--- a/ui/src/layout/Findings/Malware/TabMalwareDetails.jsx
+++ b/ui/src/layout/Findings/Malware/TabMalwareDetails.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDisplay';
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
-import { formatNumber } from 'utils/utils';
+import AssetCountDisplay from '../AssetCountDisplay';
 
 const TabMalwareDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
+    const {id, findingInfo, firstSeen, lastSeen} = data;
     const {malwareName, path, ruleName} = findingInfo;
 
     return (
@@ -22,9 +22,7 @@ const TabMalwareDetails = ({data}) => {
                         <TitleValueDisplay title="Rule name">{ruleName}</TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                    <TitleValueDisplayRow>
-                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
-                    </TitleValueDisplayRow>
+                    {AssetCountDisplay(id)}
                 </>
             )}
         />

--- a/ui/src/layout/Findings/Misconfigurations/MisconfigurationDetails.jsx
+++ b/ui/src/layout/Findings/Misconfigurations/MisconfigurationDetails.jsx
@@ -30,6 +30,8 @@ const DetailsContent = ({data}) => {
         return <Loader large />
     }
 
+    data.assetCount = assetFindingData.count;
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Misconfigurations/MisconfigurationDetails.jsx
+++ b/ui/src/layout/Findings/Misconfigurations/MisconfigurationDetails.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabMisconfigurationDetails from './TabMisconfigurationDetails';
-import Loader from 'components/Loader';
-import { APIS } from 'utils/systemConsts';
 
 const MISCONFIGURATION_DETAILS_PATHS = {
     MISCONFIGURATION_DETAILS: "",
@@ -13,25 +10,9 @@ const MISCONFIGURATION_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-
+    
     const {id} = data;
-
-    const filter = `finding/id eq '${id}'`;
-
-    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
-        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
-    });
-
-    if (error) {
-        return null;
-    }
-
-    if (loading) {
-        return <Loader large />
-    }
-
-    data.assetCount = assetFindingData.count;
-
+    
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Misconfigurations/MisconfigurationDetails.jsx
+++ b/ui/src/layout/Findings/Misconfigurations/MisconfigurationDetails.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabMisconfigurationDetails from './TabMisconfigurationDetails';
+import Loader from 'components/Loader';
+import { APIS } from 'utils/systemConsts';
 
 const MISCONFIGURATION_DETAILS_PATHS = {
     MISCONFIGURATION_DETAILS: "",
@@ -10,9 +13,23 @@ const MISCONFIGURATION_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
+    const filter = `finding/id eq '${id}'`;
+
+    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
+        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
+    });
+
+    if (error) {
+        return null;
+    }
+
+    if (loading) {
+        return <Loader large />
+    }
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Misconfigurations/MisconfigurationDetails.jsx
+++ b/ui/src/layout/Findings/Misconfigurations/MisconfigurationDetails.jsx
@@ -3,9 +3,11 @@ import { useLocation } from 'react-router-dom';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabMisconfigurationDetails from './TabMisconfigurationDetails';
+import AssetsForFindingTable from 'layout/Assets/AssetsForFindingTable';
 
 const MISCONFIGURATION_DETAILS_PATHS = {
     MISCONFIGURATION_DETAILS: "",
+    ASSET_LIST: "assets",
 }
 
 const DetailsContent = ({data}) => {
@@ -21,7 +23,14 @@ const DetailsContent = ({data}) => {
                     id: "general",
                     title: "Misconfiguration details",
                     isIndex: true,
+                    path: MISCONFIGURATION_DETAILS_PATHS.MISCONFIGURATION_DETAILS,
                     component: () => <TabMisconfigurationDetails data={data} />
+                },
+                {
+                    id: "assets",
+                    title: "Assets",
+                    path: MISCONFIGURATION_DETAILS_PATHS.ASSET_LIST,
+                    component: () => <AssetsForFindingTable findingId={id} />
                 }
             ]}
             withInnerPadding={false}

--- a/ui/src/layout/Findings/Misconfigurations/TabMisconfigurationDetails.jsx
+++ b/ui/src/layout/Findings/Misconfigurations/TabMisconfigurationDetails.jsx
@@ -3,10 +3,10 @@ import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDi
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
 import { MISCONFIGURATION_SEVERITY_MAP } from './utils';
-import { formatNumber } from 'utils/utils';
+import AssetCountDisplay from '../AssetCountDisplay';
 
 const TabMisconfigurationDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
+    const {id: findingId, findingInfo, firstSeen, lastSeen} = data;
     const {id, severity, description, scannerName, location, remediation, category, message} = findingInfo;
 
     return (
@@ -32,9 +32,7 @@ const TabMisconfigurationDetails = ({data}) => {
                         <TitleValueDisplay title="Description" withOpen defaultOpen>{description}</TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                    <TitleValueDisplayRow>
-                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
-                    </TitleValueDisplayRow>
+                    {AssetCountDisplay(findingId)}
                 </>
             )}
         />

--- a/ui/src/layout/Findings/Misconfigurations/TabMisconfigurationDetails.jsx
+++ b/ui/src/layout/Findings/Misconfigurations/TabMisconfigurationDetails.jsx
@@ -3,9 +3,10 @@ import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDi
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
 import { MISCONFIGURATION_SEVERITY_MAP } from './utils';
+import { formatNumber } from 'utils/utils';
 
 const TabMisconfigurationDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen} = data;
+    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
     const {id, severity, description, scannerName, location, remediation, category, message} = findingInfo;
 
     return (
@@ -31,6 +32,9 @@ const TabMisconfigurationDetails = ({data}) => {
                         <TitleValueDisplay title="Description" withOpen defaultOpen>{description}</TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
+                    <TitleValueDisplayRow>
+                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
+                    </TitleValueDisplayRow>
                 </>
             )}
         />

--- a/ui/src/layout/Findings/Packages/PackageDetails.jsx
+++ b/ui/src/layout/Findings/Packages/PackageDetails.jsx
@@ -30,6 +30,8 @@ const DetailsContent = ({data}) => {
         return <Loader large />
     }
 
+    data.assetCount = assetFindingData.count;
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Packages/PackageDetails.jsx
+++ b/ui/src/layout/Findings/Packages/PackageDetails.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabPackageDetails from './TabPackageDetails';
-import Loader from 'components/Loader';
-import { APIS } from 'utils/systemConsts';
 
 const PACKAGE_DETAILS_PATHS = {
     PACKAGE_DETAILS: "",
@@ -13,25 +10,9 @@ const PACKAGE_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-
+    
     const {id} = data;
-
-    const filter = `finding/id eq '${id}'`;
-
-    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
-        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
-    });
-
-    if (error) {
-        return null;
-    }
-
-    if (loading) {
-        return <Loader large />
-    }
-
-    data.assetCount = assetFindingData.count;
-
+    
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Packages/PackageDetails.jsx
+++ b/ui/src/layout/Findings/Packages/PackageDetails.jsx
@@ -3,16 +3,18 @@ import { useLocation } from 'react-router-dom';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabPackageDetails from './TabPackageDetails';
+import AssetsForFindingTable from 'layout/Assets/AssetsForFindingTable';
 
 const PACKAGE_DETAILS_PATHS = {
     PACKAGE_DETAILS: "",
+    ASSET_LIST: "assets",
 }
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}
@@ -21,7 +23,14 @@ const DetailsContent = ({data}) => {
                     id: "general",
                     title: "Package details",
                     isIndex: true,
+                    path: PACKAGE_DETAILS_PATHS.PACKAGE_DETAILS,
                     component: () => <TabPackageDetails data={data} />
+                },
+                {
+                    id: "assets",
+                    title: "Assets",
+                    path: PACKAGE_DETAILS_PATHS.ASSET_LIST,
+                    component: () => <AssetsForFindingTable findingId={id} />
                 }
             ]}
             withInnerPadding={false}

--- a/ui/src/layout/Findings/Packages/PackageDetails.jsx
+++ b/ui/src/layout/Findings/Packages/PackageDetails.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabPackageDetails from './TabPackageDetails';
+import Loader from 'components/Loader';
+import { APIS } from 'utils/systemConsts';
 
 const PACKAGE_DETAILS_PATHS = {
     PACKAGE_DETAILS: "",
@@ -10,9 +13,23 @@ const PACKAGE_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
+    const filter = `finding/id eq '${id}'`;
+
+    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
+        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
+    });
+
+    if (error) {
+        return null;
+    }
+
+    if (loading) {
+        return <Loader large />
+    }
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Packages/TabPackageDetails.jsx
+++ b/ui/src/layout/Findings/Packages/TabPackageDetails.jsx
@@ -2,12 +2,7 @@ import React from 'react';
 import TitleValueDisplay, { TitleValueDisplayRow, ValuesListDisplay } from 'components/TitleValueDisplay';
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
-import Title from "../../../components/Title/index.jsx";
-import LinksList from "../../../components/LinksList/index.jsx";
-import {useLocation} from "react-router-dom";
-import {FILTER_TYPES, setFilters, useFilterDispatch} from "../../../context/FiltersProvider.js";
-import {ROUTES} from "../../../utils/systemConsts.js";
-import VulnerabilitiesDisplay from "../../../components/VulnerabilitiesDisplay/index.jsx";
+import { formatNumber } from 'utils/utils';
 
 const TabPackageDetails = ({data}) => {
     const {pathname} = useLocation();
@@ -43,7 +38,10 @@ const TabPackageDetails = ({data}) => {
                         <TitleValueDisplay title="Licenses"><ValuesListDisplay values={licenses} /></TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                </>  
+                    <TitleValueDisplayRow>
+                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
+                    </TitleValueDisplayRow>
+                </>
             )}
             rightPlaneDisplay={() => (
                 <>

--- a/ui/src/layout/Findings/Packages/TabPackageDetails.jsx
+++ b/ui/src/layout/Findings/Packages/TabPackageDetails.jsx
@@ -2,7 +2,13 @@ import React from 'react';
 import TitleValueDisplay, { TitleValueDisplayRow, ValuesListDisplay } from 'components/TitleValueDisplay';
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
-import { formatNumber } from 'utils/utils';
+import Title from "../../../components/Title/index.jsx";
+import LinksList from "../../../components/LinksList/index.jsx";
+import {useLocation} from "react-router-dom";
+import {FILTER_TYPES, setFilters, useFilterDispatch} from "../../../context/FiltersProvider.js";
+import {ROUTES} from "../../../utils/systemConsts.js";
+import VulnerabilitiesDisplay from "../../../components/VulnerabilitiesDisplay/index.jsx";
+import AssetCountDisplay from '../AssetCountDisplay';
 
 const TabPackageDetails = ({data}) => {
     const {pathname} = useLocation();
@@ -38,9 +44,7 @@ const TabPackageDetails = ({data}) => {
                         <TitleValueDisplay title="Licenses"><ValuesListDisplay values={licenses} /></TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                    <TitleValueDisplayRow>
-                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
-                    </TitleValueDisplayRow>
+                    {AssetCountDisplay(id)}
                 </>
             )}
             rightPlaneDisplay={() => (

--- a/ui/src/layout/Findings/Rootkits/RootkitDetails.jsx
+++ b/ui/src/layout/Findings/Rootkits/RootkitDetails.jsx
@@ -30,6 +30,8 @@ const DetailsContent = ({data}) => {
         return <Loader large />
     }
 
+    data.assetCount = assetFindingData.count;
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Rootkits/RootkitDetails.jsx
+++ b/ui/src/layout/Findings/Rootkits/RootkitDetails.jsx
@@ -3,16 +3,18 @@ import { useLocation } from 'react-router-dom';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabRootkitDetails from './TabRootkitDetails';
+import AssetsForFindingTable from 'layout/Assets/AssetsForFindingTable';
 
 const ROOTKIT_DETAILS_PATHS = {
-    PACKAGE_DETAILS: "",
+    ROOTKIT_DETAILS: "",
+    ASSET_LIST: "assets",
 }
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}
@@ -21,7 +23,14 @@ const DetailsContent = ({data}) => {
                     id: "general",
                     title: "Rootkit details",
                     isIndex: true,
+                    path: ROOTKIT_DETAILS_PATHS.ROOTKIT_DETAILS,
                     component: () => <TabRootkitDetails data={data} />
+                },
+                {
+                    id: "assets",
+                    title: "Assets",
+                    path: ROOTKIT_DETAILS_PATHS.ASSET_LIST,
+                    component: () => <AssetsForFindingTable findingId={id} />
                 }
             ]}
             withInnerPadding={false}

--- a/ui/src/layout/Findings/Rootkits/RootkitDetails.jsx
+++ b/ui/src/layout/Findings/Rootkits/RootkitDetails.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabRootkitDetails from './TabRootkitDetails';
-import Loader from 'components/Loader';
-import { APIS } from 'utils/systemConsts';
 
 const ROOTKIT_DETAILS_PATHS = {
     PACKAGE_DETAILS: "",
@@ -16,22 +13,6 @@ const DetailsContent = ({data}) => {
     
     const {id} = data;
     
-    const filter = `finding/id eq '${id}'`;
-
-    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
-        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
-    });
-
-    if (error) {
-        return null;
-    }
-
-    if (loading) {
-        return <Loader large />
-    }
-
-    data.assetCount = assetFindingData.count;
-
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Rootkits/RootkitDetails.jsx
+++ b/ui/src/layout/Findings/Rootkits/RootkitDetails.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabRootkitDetails from './TabRootkitDetails';
+import Loader from 'components/Loader';
+import { APIS } from 'utils/systemConsts';
 
 const ROOTKIT_DETAILS_PATHS = {
     PACKAGE_DETAILS: "",
@@ -13,6 +16,20 @@ const DetailsContent = ({data}) => {
     
     const {id} = data;
     
+    const filter = `finding/id eq '${id}'`;
+
+    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
+        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
+    });
+
+    if (error) {
+        return null;
+    }
+
+    if (loading) {
+        return <Loader large />
+    }
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Rootkits/TabRootkitDetails.jsx
+++ b/ui/src/layout/Findings/Rootkits/TabRootkitDetails.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDisplay';
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
+import { formatNumber } from 'utils/utils';
 
 const TabPackageDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen} = data;
+    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
     const {rootkitName, message} = findingInfo;
 
     return (
@@ -18,7 +19,10 @@ const TabPackageDetails = ({data}) => {
                         <TitleValueDisplay title="Message">{message}</TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                </>  
+                    <TitleValueDisplayRow>
+                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
+                    </TitleValueDisplayRow>
+                </>
             )}
         />
     )

--- a/ui/src/layout/Findings/Rootkits/TabRootkitDetails.jsx
+++ b/ui/src/layout/Findings/Rootkits/TabRootkitDetails.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDisplay';
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
-import { formatNumber } from 'utils/utils';
+import AssetCountDisplay from '../AssetCountDisplay';
 
 const TabPackageDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
+    const {id, findingInfo, firstSeen, lastSeen} = data;
     const {rootkitName, message} = findingInfo;
 
     return (
@@ -19,9 +19,7 @@ const TabPackageDetails = ({data}) => {
                         <TitleValueDisplay title="Message">{message}</TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                    <TitleValueDisplayRow>
-                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
-                    </TitleValueDisplayRow>
+                    {AssetCountDisplay(id)}
                 </>
             )}
         />

--- a/ui/src/layout/Findings/Secrets/SecretDetails.jsx
+++ b/ui/src/layout/Findings/Secrets/SecretDetails.jsx
@@ -30,6 +30,8 @@ const DetailsContent = ({data}) => {
         return <Loader large />
     }
 
+    data.assetCount = assetFindingData.count;
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Secrets/SecretDetails.jsx
+++ b/ui/src/layout/Findings/Secrets/SecretDetails.jsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabSecretDetails from './TabSecretDetails';
-import Loader from 'components/Loader';
-import { APIS } from 'utils/systemConsts';
 
 const SECRET_DETAILS_PATHS = {
     SECRET_DETAILS: "",
@@ -13,25 +10,9 @@ const SECRET_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-
+    
     const {id} = data;
-
-    const filter = `finding/id eq '${id}'`;
-
-    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
-        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
-    });
-
-    if (error) {
-        return null;
-    }
-
-    if (loading) {
-        return <Loader large />
-    }
-
-    data.assetCount = assetFindingData.count;
-
+    
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Secrets/SecretDetails.jsx
+++ b/ui/src/layout/Findings/Secrets/SecretDetails.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabSecretDetails from './TabSecretDetails';
+import Loader from 'components/Loader';
+import { APIS } from 'utils/systemConsts';
 
 const SECRET_DETAILS_PATHS = {
     SECRET_DETAILS: "",
@@ -10,9 +13,23 @@ const SECRET_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
+    const filter = `finding/id eq '${id}'`;
+
+    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
+        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
+    });
+
+    if (error) {
+        return null;
+    }
+
+    if (loading) {
+        return <Loader large />
+    }
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Secrets/SecretDetails.jsx
+++ b/ui/src/layout/Findings/Secrets/SecretDetails.jsx
@@ -3,16 +3,18 @@ import { useLocation } from 'react-router-dom';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabSecretDetails from './TabSecretDetails';
+import AssetsForFindingTable from 'layout/Assets/AssetsForFindingTable';
 
 const SECRET_DETAILS_PATHS = {
     SECRET_DETAILS: "",
+    ASSET_LIST: "assets",
 }
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}
@@ -21,7 +23,14 @@ const DetailsContent = ({data}) => {
                     id: "general",
                     title: "Secret details",
                     isIndex: true,
+                    path: SECRET_DETAILS_PATHS.SECRET_DETAILS,
                     component: () => <TabSecretDetails data={data} />
+                },
+                {
+                    id: "assets",
+                    title: "Assets",
+                    path: SECRET_DETAILS_PATHS.ASSET_LIST,
+                    component: () => <AssetsForFindingTable findingId={id} />
                 }
             ]}
             withInnerPadding={false}

--- a/ui/src/layout/Findings/Secrets/TabSecretDetails.jsx
+++ b/ui/src/layout/Findings/Secrets/TabSecretDetails.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDisplay';
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
-import { formatNumber } from 'utils/utils';
+import AssetCountDisplay from '../AssetCountDisplay';
 
 const TabSecretDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
+    const {id, findingInfo, firstSeen, lastSeen} = data;
     const {fingerprint, description, startLine, endLine, filePath} = findingInfo;
 
     return (
@@ -24,9 +24,7 @@ const TabSecretDetails = ({data}) => {
                         <TitleValueDisplay title="File path">{filePath}</TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                    <TitleValueDisplayRow>
-                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
-                    </TitleValueDisplayRow>
+                    {AssetCountDisplay(id)}
                 </>
             )}
         />

--- a/ui/src/layout/Findings/Secrets/TabSecretDetails.jsx
+++ b/ui/src/layout/Findings/Secrets/TabSecretDetails.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import TitleValueDisplay, { TitleValueDisplayRow } from 'components/TitleValueDisplay';
 import DoublePaneDisplay from 'components/DoublePaneDisplay';
 import { FindingsDetailsCommonFields } from '../utils';
+import { formatNumber } from 'utils/utils';
 
 const TabSecretDetails = ({data}) => {
-    const {findingInfo, firstSeen, lastSeen} = data;
+    const {findingInfo, firstSeen, lastSeen, assetCount} = data;
     const {fingerprint, description, startLine, endLine, filePath} = findingInfo;
 
     return (
@@ -23,7 +24,10 @@ const TabSecretDetails = ({data}) => {
                         <TitleValueDisplay title="File path">{filePath}</TitleValueDisplay>
                     </TitleValueDisplayRow>
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                </>  
+                    <TitleValueDisplayRow>
+                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
+                    </TitleValueDisplayRow>
+                </>
             )}
         />
     )

--- a/ui/src/layout/Findings/Vulnerabilities/TabVulnerabilityDetails.jsx
+++ b/ui/src/layout/Findings/Vulnerabilities/TabVulnerabilityDetails.jsx
@@ -5,10 +5,11 @@ import Title from 'components/Title';
 import ProgressBar, { STATUS_MAPPPING } from 'components/ProgressBar';
 import SeverityDisplay from 'components/SeverityDisplay';
 import SeverityWithCvssDisplay from 'components/SeverityWithCvssDisplay';
-import { formatNumber, getHigestVersionCvssData } from 'utils/utils';
+import { getHigestVersionCvssData } from 'utils/utils';
 import LinksDisplay from 'layout/Findings/LinkesDisplay';
 import ScoreTag from './ScoreTag';
 import { FindingsDetailsCommonFields } from '../utils';
+import AssetCountDisplay from '../AssetCountDisplay';
 
 import COLORS from 'utils/scss_variables.module.scss';
 
@@ -31,7 +32,7 @@ const ScoreBar = ({score}) => {
 }
 
 const TabVulnerabilityDetails = ({data}) => {
-    const {id, findingInfo, firstSeen, lastSeen, assetCount} = data;
+    const {id, findingInfo, firstSeen, lastSeen} = data;
     const {vulnerabilityName, package: packageInfo, severity, fix, cvss, description, links} = findingInfo;
     const {name: packageName, version} = packageInfo;
 
@@ -64,9 +65,7 @@ const TabVulnerabilityDetails = ({data}) => {
                     </TitleValueDisplayRow>
                     <LinksDisplay title="Links" links={links} />
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                    <TitleValueDisplayRow>
-                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
-                    </TitleValueDisplayRow>
+                    {AssetCountDisplay(id)}
                 </>
             )}
             rightPlaneDisplay={() => (

--- a/ui/src/layout/Findings/Vulnerabilities/TabVulnerabilityDetails.jsx
+++ b/ui/src/layout/Findings/Vulnerabilities/TabVulnerabilityDetails.jsx
@@ -5,7 +5,7 @@ import Title from 'components/Title';
 import ProgressBar, { STATUS_MAPPPING } from 'components/ProgressBar';
 import SeverityDisplay from 'components/SeverityDisplay';
 import SeverityWithCvssDisplay from 'components/SeverityWithCvssDisplay';
-import { formatDate, getHigestVersionCvssData } from 'utils/utils';
+import { formatNumber, getHigestVersionCvssData } from 'utils/utils';
 import LinksDisplay from 'layout/Findings/LinkesDisplay';
 import ScoreTag from './ScoreTag';
 import { FindingsDetailsCommonFields } from '../utils';
@@ -31,7 +31,7 @@ const ScoreBar = ({score}) => {
 }
 
 const TabVulnerabilityDetails = ({data}) => {
-    const {id, findingInfo, firstSeen, lastSeen} = data;
+    const {id, findingInfo, firstSeen, lastSeen, assetCount} = data;
     const {vulnerabilityName, package: packageInfo, severity, fix, cvss, description, links} = findingInfo;
     const {name: packageName, version} = packageInfo;
 
@@ -64,7 +64,10 @@ const TabVulnerabilityDetails = ({data}) => {
                     </TitleValueDisplayRow>
                     <LinksDisplay title="Links" links={links} />
                     <FindingsDetailsCommonFields firstSeen={firstSeen} lastSeen={lastSeen} />
-                </>  
+                    <TitleValueDisplayRow>
+                        <TitleValueDisplay title="Asset count">{formatNumber(assetCount)}</TitleValueDisplay>
+                    </TitleValueDisplayRow>
+                </>
             )}
             rightPlaneDisplay={() => (
                 <>

--- a/ui/src/layout/Findings/Vulnerabilities/VulnerabilityDetails.jsx
+++ b/ui/src/layout/Findings/Vulnerabilities/VulnerabilityDetails.jsx
@@ -30,6 +30,8 @@ const DetailsContent = ({data}) => {
         return <Loader large />
     }
 
+    data.assetCount = assetFindingData.count;
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Vulnerabilities/VulnerabilityDetails.jsx
+++ b/ui/src/layout/Findings/Vulnerabilities/VulnerabilityDetails.jsx
@@ -3,17 +3,18 @@ import { useLocation } from 'react-router-dom';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabVulnerabilityDetails from './TabVulnerabilityDetails';
-import { AssetList } from 'layout/list-displays';
+import AssetsForFindingTable from 'layout/Assets/AssetsForFindingTable';
 
 const VULNERABILITY_DETAILS_PATHS = {
     VULNERABILITY_DETAILS: "",
+    ASSET_LIST: "assets",
 }
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}
@@ -22,7 +23,14 @@ const DetailsContent = ({data}) => {
                     id: "general",
                     title: "Vulnerability details",
                     isIndex: true,
+                    path: VULNERABILITY_DETAILS_PATHS.VULNERABILITY_DETAILS,
                     component: () => <TabVulnerabilityDetails data={data} />
+                },
+                {
+                    id: "assets",
+                    title: "Assets",
+                    path: VULNERABILITY_DETAILS_PATHS.ASSET_LIST,
+                    component: () => <AssetsForFindingTable findingId={id} />
                 }
             ]}
             withInnerPadding={false}

--- a/ui/src/layout/Findings/Vulnerabilities/VulnerabilityDetails.jsx
+++ b/ui/src/layout/Findings/Vulnerabilities/VulnerabilityDetails.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabVulnerabilityDetails from './TabVulnerabilityDetails';
+import Loader from 'components/Loader';
+import { APIS } from 'utils/systemConsts';
 
 const VULNERABILITY_DETAILS_PATHS = {
     VULNERABILITY_DETAILS: "",
@@ -10,9 +13,23 @@ const VULNERABILITY_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-    
+
     const {id} = data;
-    
+
+    const filter = `finding/id eq '${id}'`;
+
+    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
+        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
+    });
+
+    if (error) {
+        return null;
+    }
+
+    if (loading) {
+        return <Loader large />
+    }
+
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/Vulnerabilities/VulnerabilityDetails.jsx
+++ b/ui/src/layout/Findings/Vulnerabilities/VulnerabilityDetails.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useFetch } from 'hooks';
 import TabbedPage from 'components/TabbedPage';
 import FindingsDetailsPage from '../FindingsDetailsPage';
 import TabVulnerabilityDetails from './TabVulnerabilityDetails';
-import Loader from 'components/Loader';
-import { APIS } from 'utils/systemConsts';
+import { AssetList } from 'layout/list-displays';
 
 const VULNERABILITY_DETAILS_PATHS = {
     VULNERABILITY_DETAILS: "",
@@ -13,25 +11,9 @@ const VULNERABILITY_DETAILS_PATHS = {
 
 const DetailsContent = ({data}) => {
     const {pathname} = useLocation();
-
+    
     const {id} = data;
-
-    const filter = `finding/id eq '${id}'`;
-
-    const [{loading, data: assetFindingData, error}] = useFetch(APIS.ASSET_FINDINGS, {
-        queryParams: {"$filter": filter, "$count": true, "$expand": "asset"}
-    });
-
-    if (error) {
-        return null;
-    }
-
-    if (loading) {
-        return <Loader large />
-    }
-
-    data.assetCount = assetFindingData.count;
-
+    
     return (
         <TabbedPage
             basePath={`${pathname.substring(0, pathname.indexOf(id))}${id}`}

--- a/ui/src/layout/Findings/utils.jsx
+++ b/ui/src/layout/Findings/utils.jsx
@@ -21,8 +21,6 @@ export const FindingsDetailsCommonFields = ({ firstSeen, lastSeen }) => (
     <>
         <TitleValueDisplayRow>
             <TitleValueDisplay title="First seen">{formatDate(firstSeen)}</TitleValueDisplay>
-        </TitleValueDisplayRow>
-        <TitleValueDisplayRow>
             <TitleValueDisplay title="Last seen">{formatDate(lastSeen)}</TitleValueDisplay>
         </TitleValueDisplayRow>
     </>

--- a/ui/src/layout/Scans/Scans/ScansTable.jsx
+++ b/ui/src/layout/Scans/Scans/ScansTable.jsx
@@ -82,20 +82,20 @@ const ScansTable = () => {
             },
             width: 150
         },
-        getVulnerabilitiesColumnConfigItem(TABLE_TITLE),
-        ...getFindingsColumnsConfigList(TABLE_TITLE),
+        getVulnerabilitiesColumnConfigItem({tableTile: TABLE_TITLE}),
+        ...getFindingsColumnsConfigList({tableTitle: TABLE_TITLE}),
         {
             Header: "Scanned assets",
             id: "assets",
             sortIds: ["summary.jobsCompleted"],
             accessor: original => {
                 const {jobsCompleted, jobsLeftToRun} = original.summary || {};
-                
+
                 return `${formatNumber(jobsCompleted)}/${formatNumber(jobsCompleted + jobsLeftToRun)}`;
             }
         }
     ], []);
-    
+
     return (
         <TablePage
             columns={columns}

--- a/ui/src/utils/systemConsts.js
+++ b/ui/src/utils/systemConsts.js
@@ -16,6 +16,7 @@ export const APIS = {
     ASSETS: "assets",
     ASSET_SCANS: "assetScans",
     FINDINGS: "findings",
+    ASSET_FINDINGS: "assetFindings",
     DASHBOARD_RISKIEST_REGIONS: "dashboard/riskiestRegions",
     DASHBOARD_RISKIEST_ASSETS: "dashboard/riskiestAssets",
     DASHBOARD_FINDINGS_TRENDS: "dashboard/findingsTrends",

--- a/ui/src/utils/utils.jsx
+++ b/ui/src/utils/utils.jsx
@@ -13,7 +13,7 @@ export const formatDate = (date) => formatDateBy(date, "MMM Do, YYYY HH:mm:ss");
 export const calculateDuration = (startTime, endTime) => {
     const startMoment = moment(startTime);
     const endMoment = moment(endTime || new Date());
-    
+
     if (!startTime) {
         return null;
     }
@@ -40,7 +40,7 @@ export const getHigestVersionCvssData = (cvssData) => {
     if (isEmpty(cvssData)) {
         return {};
     }
-    
+
     const sortedCvss = orderBy(cvssData || [], ["version"], ["desc"]);
 
     const {vector, metrics, version} = sortedCvss[0];
@@ -67,21 +67,26 @@ export const getHigestVersionCvssData = (cvssData) => {
     }
 }
 
-export const getFindingsColumnsConfigList = (tableTitle) => Object.values(FINDINGS_MAPPING).map(({totalKey, title, icon}) => {
+export const getFindingsColumnsConfigList = (props) => Object.values(FINDINGS_MAPPING).map(({totalKey, title, icon}) => {
+    const {tableTitle, withAssetPrefix=false} = props;
+    const prefix = (withAssetPrefix) ? "asset." : "";
+
     return {
         Header: <IconWithTooltip tooltipId={`table-header-${tableTitle}-${totalKey}`} tooltipText={title} name={icon} />,
         id: totalKey,
-        sortIds: [`summary.${totalKey}`],
+        sortIds: [`${prefix}summary.${totalKey}`],
         accessor: original => {
-            const {summary}  = original;
-            
+            const {summary}  = (withAssetPrefix) ? original.asset : original;
+
             return isEmpty(summary) ? 0 : (formatNumber(summary[totalKey] || 0));
         },
         width: 50
     }
 });
 
-export const getVulnerabilitiesColumnConfigItem = (tableTitle) => {
+export const getVulnerabilitiesColumnConfigItem = (props) => {
+    const { tableTitle, withAssetPrefix=false } = props;
+    const prefix = (withAssetPrefix) ? "asset." : "";
     const {title: vulnerabilitiesTitle, icon: vulnerabilitiesIcon} = VULNERABIITY_FINDINGS_ITEM;
 
     return {
@@ -94,15 +99,15 @@ export const getVulnerabilitiesColumnConfigItem = (tableTitle) => {
         ),
         id: "vulnerabilities",
         sortIds: [
-            "summary.totalVulnerabilities.totalCriticalVulnerabilities",
-            "summary.totalVulnerabilities.totalHighVulnerabilities",
-            "summary.totalVulnerabilities.totalMediumVulnerabilities",
-            "summary.totalVulnerabilities.totalLowVulnerabilities",
-            "summary.totalVulnerabilities.totalNegligibleVulnerabilities"
+            `${prefix}summary.totalVulnerabilities.totalCriticalVulnerabilities`,
+            `${prefix}summary.totalVulnerabilities.totalHighVulnerabilities`,
+            `${prefix}summary.totalVulnerabilities.totalMediumVulnerabilities`,
+            `${prefix}summary.totalVulnerabilities.totalLowVulnerabilities`,
+            `${prefix}summary.totalVulnerabilities.totalNegligibleVulnerabilities`
         ],
         Cell: ({row}) => {
-            const {id, summary} = row.original;
-            
+            const {id, summary} = (withAssetPrefix) ? row.original.asset : row.original;
+
             return (
                 <VulnerabilitiesDisplay minimizedTooltipId={id} counters={summary?.totalVulnerabilities} isMinimized />
             )
@@ -149,7 +154,7 @@ export const scanColumnsFiltersConfig = [
 
 export const getAssetColumnsFiltersConfig = (props) => {
     const {prefix="assetInfo", withType=true, withLabels=true} = props || {};
-    
+
     const ASSET_TYPE_ITEMS = [
         {value: "VMInfo", label: "VMInfo"},
         {value: "ContainerInfo", label: "ContainerInfo"},
@@ -157,7 +162,7 @@ export const getAssetColumnsFiltersConfig = (props) => {
         {value: "PodInfo", label: "PodInfo"},
         {value: "DirInfo", label: "DirInfo"}
     ]
-    
+
     return [
         {value: `${prefix}.instanceID`, label: "Asset name", operators: [
             {...OPERATORS.eq, valueItems: [], creatable: true},


### PR DESCRIPTION
## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

### Context

There was a change recently in #1758 in which the `asset` field was removed from the `finding` object, and a new `assetFinding` structure was introduced in the API spec to make the relationship between assets and findings **n:n**, so the _Asset details_ tab (displaying details of one Asset the finding was found in) from the Finding details page was removed.

### Goal

Put back an _Assets_ tab, but list all assets that the particular finding is related to.

### Screenshots

#### Before

<img width="1488" alt="Screenshot 2024-06-30 at 23 49 51" src="https://github.com/openclarity/vmclarity/assets/39521244/594e5839-53b8-42be-ab86-bf28d0c8f2d6">

#### After

![Screenshot 2024-07-05 at 14 22 17](https://github.com/openclarity/vmclarity/assets/39521244/b4ce63dc-eeb7-4e83-89fd-bbaa4d0bcfb1)

- The `First seen` and `Last seen` sections were put next to each other to gain some vertical space
- An `Asset count` section was added to the bottom of the _General details_ part, displaying the number of currently active assets, followed by the total number of assets in parentheses
- At the top, a new `Assets` tab was added

![Screenshot 2024-07-05 at 14 22 25](https://github.com/openclarity/vmclarity/assets/39521244/8a5213dc-cd36-4264-84c7-73ffca40e9e8)

Default state of the `Assets` tab of a Finding with the table of the related Assets, which was derived from the Assets table (second item from the left menu bar):
- The `Filters` button was removed. Copying the code that enables it resulted in a slow page load time and this error message to the Console I had no time to debug:

```
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
```

- The `Hide terminated` toggle is on, works, and keeps the state (on or off) even after navigating elsewhere, then navigating back.
- The `Show finding counts` toggle is off, works, and keeps the state (on or off) even after navigating elsewhere, then navigating back similar to the previous toggle. I implemented this so this table is not cluttered with information that might not be relevant when navigating from the page of a specific Finding, but suggestions are welcome!
- Clicking on a row navigates to the details page of the clicked Asset

![Screenshot 2024-07-05 at 14 22 29](https://github.com/openclarity/vmclarity/assets/39521244/b7349617-75b8-485c-bdff-a85d73911ecc)

Assets table on a Finding's Assets tab with the `Hide terminated` toggle off

![Screenshot 2024-07-05 at 14 22 33](https://github.com/openclarity/vmclarity/assets/39521244/46faa651-f4d9-4f9c-9f5b-95e40a5e53a5)

Assets table on a Finding's Assets tab with the `Show finding counts` toggle on

Fixes #1766 

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
