### PR TITLE
fix(scanner): add missing append for exploits

### DIFF
--- a/scanner/config.go
+++ b/scanner/config.go
@@ -103,8 +103,7 @@ func (c *Config) AddInputs(inputType common.InputType, inputs []string) {
 				StripPathFromResult: to.Ptr(true),
 				Input:               mountDir,
 				InputType:           inputType,
-			},
-			)
+			})
 		}
 
 		if c.InfoFinder.Enabled {
@@ -112,8 +111,7 @@ func (c *Config) AddInputs(inputType common.InputType, inputs []string) {
 				StripPathFromResult: to.Ptr(true),
 				Input:               mountDir,
 				InputType:           inputType,
-			},
-			)
+			})
 		}
 
 		if c.Malware.Enabled {

--- a/scanner/config.go
+++ b/scanner/config.go
@@ -90,6 +90,32 @@ func (c *Config) AddInputs(inputType common.InputType, inputs []string) {
 			})
 		}
 
+		if c.Exploits.Enabled {
+			c.Exploits.Inputs = append(c.Exploits.Inputs, common.ScanInput{
+				StripPathFromResult: to.Ptr(true),
+				Input:               mountDir,
+				InputType:           inputType,
+			})
+		}
+
+		if c.Misconfiguration.Enabled {
+			c.Misconfiguration.Inputs = append(c.Misconfiguration.Inputs, common.ScanInput{
+				StripPathFromResult: to.Ptr(true),
+				Input:               mountDir,
+				InputType:           inputType,
+			},
+			)
+		}
+
+		if c.InfoFinder.Enabled {
+			c.InfoFinder.Inputs = append(c.InfoFinder.Inputs, common.ScanInput{
+				StripPathFromResult: to.Ptr(true),
+				Input:               mountDir,
+				InputType:           inputType,
+			},
+			)
+		}
+
 		if c.Malware.Enabled {
 			c.Malware.Inputs = append(c.Malware.Inputs, common.ScanInput{
 				StripPathFromResult: to.Ptr(true),
@@ -104,28 +130,6 @@ func (c *Config) AddInputs(inputType common.InputType, inputs []string) {
 				Input:               mountDir,
 				InputType:           inputType,
 			})
-		}
-
-		if c.Misconfiguration.Enabled {
-			c.Misconfiguration.Inputs = append(
-				c.Misconfiguration.Inputs,
-				common.ScanInput{
-					StripPathFromResult: to.Ptr(true),
-					Input:               mountDir,
-					InputType:           inputType,
-				},
-			)
-		}
-
-		if c.InfoFinder.Enabled {
-			c.InfoFinder.Inputs = append(
-				c.InfoFinder.Inputs,
-				common.ScanInput{
-					StripPathFromResult: to.Ptr(true),
-					Input:               mountDir,
-					InputType:           inputType,
-				},
-			)
 		}
 
 		if c.Plugins.Enabled {


### PR DESCRIPTION
## Description

- Adding inputs for exploits was missing, added it.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
