### PR TITLE
fix(api): return missing finding data

### DIFF
--- a/api/server/database/gorm/odata.go
+++ b/api/server/database/gorm/odata.go
@@ -999,6 +999,8 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 			"filePath":    odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
 			"startLine":   odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
 			"endLine":     odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
+			"startColumn": odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
+			"endColumn":   odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
 			"fingerprint": odatasql.FieldMeta{FieldType: odatasql.StringFieldType},
 		},
 	},
@@ -1256,7 +1258,7 @@ var schemaMetas = map[string]odatasql.SchemaMeta{
 			},
 			"finding": odatasql.FieldMeta{
 				FieldType:            odatasql.RelationshipFieldType,
-				RelationshipSchema:   "Finding",
+				RelationshipSchema:   findingSchemaName,
 				RelationshipProperty: "id",
 			},
 			"firstSeen":     odatasql.FieldMeta{FieldType: odatasql.DateTimeFieldType},

--- a/orchestrator/processor/assetscan/common.go
+++ b/orchestrator/processor/assetscan/common.go
@@ -47,10 +47,9 @@ func (asp *AssetScanProcessor) createOrUpdateDBFinding(ctx context.Context, info
 		return "", fmt.Errorf("failed to create finding: %w", err)
 	}
 
-	var id string
+	id := *conflictError.ConflictingFinding.Id
 	// Update existing finding if newer
 	if conflictError.ConflictingFinding.LastSeen.Before(completedTime) {
-		id = *conflictError.ConflictingFinding.Id
 		finding := apitypes.Finding{
 			LastSeen: &completedTime,
 			LastSeenBy: &apitypes.AssetScanRelationship{


### PR DESCRIPTION
## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

Due to some changes since v0.7.1 saving specific kinds of finding data to the DB started to fail, so they were not displayed on the UI either. One problem was missing odatasql meta fields from the Secret finding type, the other is a function not returning the finding ID after unsuccessful update, so the next method in the chain could patch it.

Fixes #1897

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
