### PR TITLE
refactor(api): provider status

### DIFF
--- a/api/types/providerstatus.go
+++ b/api/types/providerstatus.go
@@ -1,0 +1,27 @@
+// Copyright © 2024 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "time"
+
+func NewProviderStatus(s ProviderStatusState, r ProviderStatusReason, m *string) *ProviderStatus {
+	return &ProviderStatus{
+		State:              s,
+		Reason:             r,
+		Message:            m,
+		LastTransitionTime: time.Now(),
+	}
+}

--- a/e2e/provider_test.go
+++ b/e2e/provider_test.go
@@ -17,7 +17,6 @@ package e2e
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -36,11 +35,11 @@ var _ = ginkgo.Describe("Posting and getting a provider", func() {
 				ctx,
 				apitypes.Provider{
 					DisplayName: to.Ptr("test-provider"),
-					Status: to.Ptr(apitypes.ProviderStatus{
-						State:              apitypes.ProviderStatusStateHealthy,
-						Reason:             apitypes.HeartbeatReceived,
-						LastTransitionTime: time.Now(),
-					}),
+					Status: apitypes.NewProviderStatus(
+						apitypes.ProviderStatusStateHealthy,
+						apitypes.HeartbeatReceived,
+						nil,
+					),
 				})
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
## Description

This PR creates a function to set the `Status` of a `Provider` object.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
