### PR TITLE
fix(ci): use correct Renovatebot manager for Python

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
     "gomod",
     "helm-values",
     "helmv3",
-    "python"
+    "pip_setup"
   ],
   "forkProcessing": "disabled",
   "labels": [


### PR DESCRIPTION
## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

Quick fix for the Renovatebot config to use the correct name for the manager to update Python dependencies.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
