### PR TITLE
feat(ci): extend renovate-fix make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ BICEP_DIR := $(INSTALLATION_DIR)/azure
 CFN_DIR := $(INSTALLATION_DIR)/aws
 DOCKER_COMPOSE_DIR := $(INSTALLATION_DIR)/docker
 GCP_DM_DIR := $(INSTALLATION_DIR)/gcp/dm
+API_DIR := $(ROOT_DIR)/api
+UI_DIR := $(ROOT_DIR)/ui
 
 ####
 ## Load additional makefiles
@@ -586,6 +588,8 @@ multimod-prerelease: bin/multimod
 
 ##@ Renovate
 
+.PHONY: renovate-fix
+renovate-fix: renovate-fix-gomod renovate-fix-helm-docs renovate-fix-bicep renovate-fix-api renovate-fix-format ## Fix all Renovate issues, recommended to run it with the "-i" flag
 
 .PHONY: renovate-fix-gomod
 renovate-fix-gomod: gomod-tidy ## Fix go.mod files after bumping Go dependency versions
@@ -597,10 +601,23 @@ renovate-fix-gomod: gomod-tidy ## Fix go.mod files after bumping Go dependency v
 renovate-fix-helm-docs: gen-helm-docs ## Fix Helm Chart documentation after version update
 	$(info --- Fix Helm Chart documentation after version update)
 	git add ':$(subst $(ROOT_DIR),,$(HELM_CHART_DIR))' \
-	&& git commit -m "docs: update helm docs"
+	&& git commit -m "docs: update Helm docs"
 
 .PHONY: renovate-fix-bicep
 renovate-fix-bicep: gen-bicep ## Fix Azure Bicep files after version update
 	$(info --- Fix Azure Bicep files after version update)
 	git add ':$(subst $(ROOT_DIR),,$(BICEP_DIR))' \
-	&& git commit -m "fix: generate bicep template"
+	&& git commit -m "fix: generate Bicep template"
+
+.PHONY: renovate-fix-api
+renovate-fix-api: gen-api-go gen-api-js ## Fix generated API code after version update
+	$(info --- Generate API code after version update)
+	git add ':$(subst $(ROOT_DIR),,$(API_DIR))' \
+	git add ':$(subst $(ROOT_DIR),,$(UI_DIR))' \
+	&& git commit -m "fix: generate API code"
+
+.PHONY: renovate-fix-format
+renovate-fix-format: format ## Format files after version update
+	$(info --- Run formatters after version update)
+	git add ':$(subst $(ROOT_DIR),,$(UI_DIR))' \
+	&& git commit -m "style: format code"


### PR DESCRIPTION
## Description

<!-- Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all. -->

Added renovate fix targets for generating API and format UI code automatically just in case, also a high-level `renovate-fix` target that runs all the individual renovate fix targets to make dealing with renovatebot PRs easier. The only caveat is that it is recommended to be run with the "-i" flag like `make -i renovate-fix` so it won't return with a git error at the first step in which there is nothing to be committed.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](https://github.com/openclarity/vmclarity/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
